### PR TITLE
[ADD] add partner_maiden_name module: It allows to add the maiden name field to the partner

### DIFF
--- a/partner_birth_name/__init__.py
+++ b/partner_birth_name/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import res_partner

--- a/partner_birth_name/__openerp__.py
+++ b/partner_birth_name/__openerp__.py
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Partner Birth Name',
+    'version': '1.0',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'category': 'Customer Relationship Management',
+    'description': """
+Partner Birth Name
+==================
+
+This module allows you to specify a birth name on a partner
+
+Contributors
+------------
+* El Hadji Dem (elhadji.dem@savoirfairelinux.com)
+* Sandy Carter (sandy.carter@savoirfairelinux.com)
+""",
+    'data': [
+        'res_partner_view.xml',
+    ],
+    'installable': True,
+}

--- a/partner_birth_name/i18n/fr.po
+++ b/partner_birth_name/i18n/fr.po
@@ -1,0 +1,28 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* partner_birth_name
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-30 18:38+0000\n"
+"PO-Revision-Date: 2014-10-30 14:40-0500\n"
+"Last-Translator: Sandy Carter <sandy.carter@savoirfairelinux.com>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.6.10\n"
+
+#. module: partner_birth_name
+#: model:ir.model,name:partner_birth_name.model_res_partner
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: partner_birth_name
+#: view:res.partner:0 field:res.partner,birth_name:0
+msgid "Birth Name"
+msgstr "Nom de jeune fille"

--- a/partner_birth_name/i18n/partner_birth_name.pot
+++ b/partner_birth_name/i18n/partner_birth_name.pot
@@ -1,0 +1,27 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* partner_birth_name
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-30 18:38+0000\n"
+"PO-Revision-Date: 2014-10-30 18:38+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: partner_birth_name
+#: model:ir.model,name:partner_birth_name.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: partner_birth_name
+#: view:res.partner:0
+#: field:res.partner,birth_name:0
+msgid "Birth Name"
+msgstr ""

--- a/partner_birth_name/res_partner.py
+++ b/partner_birth_name/res_partner.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class res_partner(orm.Model):
+    _inherit = 'res.partner'
+    _columns = {
+        'birth_name': fields.char('Birth Name'),
+    }

--- a/partner_birth_name/res_partner_view.xml
+++ b/partner_birth_name/res_partner_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="view_partner_form" model="ir.ui.view">
+      <field name="model">res.partner</field>
+      <field name="inherit_id" ref="base.view_partner_form"/>
+      <field name="arch" type="xml">
+
+        <xpath expr="//field[@name='name']/.." position="after">
+           <field name="birth_name"
+                  attrs="{'invisible': [('is_company','=', True)]}"
+                  placeholder="Birth Name"/>
+        </xpath>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
Port of https://code.launchpad.net/~savoirfairelinux-openerp/partner-contact-management/partner-contact-management-base_contact_add_partner_maiden_name/+merge/204023
# Previous Review:

@yvaucher: 

> Sorry indeed something is missing
> 
> Thanks for the reminder
> 
> Correct me if I'm wrong but Maiden name is sexist and not accurate nor generic nowadays.
> 
> You should find enough altenatives with:
> Maiden name -> birth name, surname at birth, original name, former name
