### PR TITLE
[ADD] Add partner_supplier_information module: It allows to add some specifics fields just for supplier

### DIFF
--- a/partner_supplier_information/__init__.py
+++ b/partner_supplier_information/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import res_partner

--- a/partner_supplier_information/__openerp__.py
+++ b/partner_supplier_information/__openerp__.py
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Partner Supplier Information',
+    'version': '0.1',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'category': 'Customer Relationship Management',
+    'description': """
+Partner Supplier Informations
+=============================
+
+This module adds some fields for supplier:
+
+* Legal form
+* NGO: If partner is a Non-governmental organization (NGO)
+* Confirmed supplier
+* Registration number
+* Registration date
+* Registration location
+* Matriculation Number
+
+
+Contributors
+------------
+* El Hadji Dem (elhadji.dem@savoirfairelinux.com)
+""",
+    'depends': [
+        'account',
+    ],
+    'data': [
+        'res_partner_view.xml',
+    ],
+    'installable': True,
+}

--- a/partner_supplier_information/i18n/fr.po
+++ b/partner_supplier_information/i18n/fr.po
@@ -1,0 +1,97 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* partner_supplier_information
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-21 18:12+0000\n"
+"PO-Revision-Date: 2014-10-21 14:14-0500\n"
+"Last-Translator: Sandy Carter <sandy.carter@savoirfairelinux.com>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.6.10\n"
+
+#. module: partner_supplier_information
+#: view:res.partner:0
+msgid "Information"
+msgstr "Information"
+
+#. module: partner_supplier_information
+#: field:res.partner,rcs_registration_number:0
+msgid "Registration number"
+msgstr "N° d'enregistrement"
+
+#. module: partner_supplier_information
+#: field:res.partner,acronym:0
+msgid "Acronym"
+msgstr "Acronyme"
+
+#. module: partner_supplier_information
+#: field:res.partner,rcs_registration_location:0
+msgid "Registration location"
+msgstr "Lieu d'enregistrement"
+
+#. module: partner_supplier_information
+#: field:res.partner,ong:0
+msgid "ONG"
+msgstr "ONG"
+
+#. module: partner_supplier_information
+#: view:res.partner:0
+msgid "Supplier Information"
+msgstr "Informations du fournisseur"
+
+#. module: partner_supplier_information
+#: field:res.partner,legal_form:0
+msgid "Legal form"
+msgstr "Forme juridique"
+
+#. module: partner_supplier_information
+#: field:res.partner,confirmed_supplier:0
+msgid "Confirmed supplier"
+msgstr "Fournisseur confirmé"
+
+#. module: partner_supplier_information
+#: model:ir.model,name:partner_supplier_information.model_res_partner
+msgid "Partner"
+msgstr "Organisme"
+
+#. module: partner_supplier_information
+#: field:res.partner,rcs_date:0
+msgid "Registration date"
+msgstr "Date d'enregistrement"
+
+#. module: partner_supplier_information
+#: field:res.partner,matriculation_number:0
+msgid "Matriculation number"
+msgstr "Numéro du passeport"
+
+#~ msgid "ONG."
+#~ msgstr "ONG."
+
+#~ msgid "Acronym."
+#~ msgstr "Acronyme."
+
+#~ msgid "Registration location."
+#~ msgstr "Lieu d'enregistrement."
+
+#~ msgid "Immatriculation number."
+#~ msgstr "Numéro d'immatriculation."
+
+#~ msgid "confirmed supplier."
+#~ msgstr "fournisseur confirmé."
+
+#~ msgid "Legal form."
+#~ msgstr "Forme juridique."
+
+#~ msgid "Registration number."
+#~ msgstr "N° d'enregistrement."
+
+#~ msgid "Registration date."
+#~ msgstr "Date d'enregistrement."

--- a/partner_supplier_information/i18n/partner_supplier_information.pot
+++ b/partner_supplier_information/i18n/partner_supplier_information.pot
@@ -1,0 +1,71 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* partner_supplier_information
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-21 18:12+0000\n"
+"PO-Revision-Date: 2014-10-21 18:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: partner_supplier_information
+#: view:res.partner:0
+msgid "Information"
+msgstr ""
+
+#. module: partner_supplier_information
+#: field:res.partner,rcs_registration_number:0
+msgid "Registration number"
+msgstr ""
+
+#. module: partner_supplier_information
+#: field:res.partner,acronym:0
+msgid "Acronym"
+msgstr ""
+
+#. module: partner_supplier_information
+#: field:res.partner,rcs_registration_location:0
+msgid "Registration location"
+msgstr ""
+
+#. module: partner_supplier_information
+#: field:res.partner,ong:0
+msgid "ONG"
+msgstr ""
+
+#. module: partner_supplier_information
+#: view:res.partner:0
+msgid "Supplier Information"
+msgstr ""
+
+#. module: partner_supplier_information
+#: field:res.partner,legal_form:0
+msgid "Legal form"
+msgstr ""
+
+#. module: partner_supplier_information
+#: field:res.partner,confirmed_supplier:0
+msgid "Confirmed supplier"
+msgstr ""
+
+#. module: partner_supplier_information
+#: model:ir.model,name:partner_supplier_information.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: partner_supplier_information
+#: field:res.partner,rcs_date:0
+msgid "Registration date"
+msgstr ""
+
+#. module: partner_supplier_information
+#: field:res.partner,matriculation_number:0
+msgid "Matriculation number"
+msgstr ""

--- a/partner_supplier_information/res_partner.py
+++ b/partner_supplier_information/res_partner.py
@@ -1,0 +1,53 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class res_partner(orm.Model):
+    _inherit = 'res.partner'
+    _columns = {
+        'legal_form': fields.char(
+            'Legal form',
+        ),
+        'ong': fields.boolean(
+            'ONG',
+        ),
+        'acronym': fields.char(
+            'Acronym',
+        ),
+        'confirmed_supplier': fields.boolean(
+            'Confirmed supplier',
+        ),
+        'rcs_registration_number': fields.char(
+            'Registration number',
+        ),
+        'rcs_date': fields.date(
+            'Registration date',
+        ),
+        'rcs_registration_location': fields.char(
+            'Registration location',
+        ),
+        'matriculation_number': fields.char(
+            'Matriculation number',
+        ),
+    }

--- a/partner_supplier_information/res_partner_view.xml
+++ b/partner_supplier_information/res_partner_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+    <!--Add legal form, ong,acronym,confirmed supplier,
+      rcs number,rcs date, rcs and SIRET number fields in form view-->
+    <record id="view_partner_property_supplier_info_form" model="ir.ui.view">
+      <field name="name">res.partner.property.supplier.info.form.inherit</field>
+      <field name="model">res.partner</field>
+      <field name="inherit_id" ref="account.view_partner_property_form"/>
+      <field name="arch" type="xml">
+        <xpath expr="//page[@string='Accounting']/group[1]/group[2]"
+               position="after">
+         <group string="Supplier Information" col="4" colspan="4"
+                attrs="{'invisible': [('supplier', '=', False)]}">
+            <field name="legal_form"/>
+            <field name="ong"/>
+            <field name="acronym"/>
+            <field name="confirmed_supplier"/>
+         </group>
+         <group string="Information" col="4" colspan="4"
+                attrs="{'invisible': [('confirmed_supplier', '=', False)]}">
+              <field name="rcs_registration_number"/>
+              <field name="rcs_date"/>
+              <field name="rcs_registration_location"/>
+         </group>
+        </xpath>
+
+        <!--add matriculation number in form view-->
+        <field name="last_reconciliation_date"
+               position="after">
+          <field name="matriculation_number"
+                 attrs="{'invisible': [('confirmed_supplier', '=', False)]}"/>
+        </field>
+      </field>
+    </record>
+  </data>
+</openerp>


### PR DESCRIPTION
Port of https://code.launchpad.net/~savoirfairelinux-openerp/partner-contact-management/partner-contact-management-base_contact_add_partner_supplier_information/+merge/204046
## Previous reviews:

Romain Deheele:

> Hello,
> 
> code review : LGTM.
> 
> Would it not be better to place these new fields in a new tab?
> 
> Regards,
> 
> Romain

@yvaucher:

> It seems very specific, I'm unsure this should be part of community modules.
> 
> Who could reuse this module?
