### PR TITLE
Add res_bank_account module

### DIFF
--- a/res_bank_account/__init__.py
+++ b/res_bank_account/__init__.py
@@ -21,5 +21,3 @@
 ##############################################################################
 
 from . import res_bank
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/res_bank_account/__init__.py
+++ b/res_bank_account/__init__.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import res_bank
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/res_bank_account/__openerp__.py
+++ b/res_bank_account/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Bank Account',
+    'version': '0.1',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'category': 'MISC',
+    'description': """
+Bank Account
+============
+
+
+Contributors
+------------
+* El Hadji Dem (elhadji.dem@savoirfairelinux.com)
+""",
+    'depends': [
+        'account',
+    ],
+    'external_dependencies': {},
+    'data': [
+        'res_bank_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'active': False,
+}
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/res_bank_account/__openerp__.py
+++ b/res_bank_account/__openerp__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2013 Savoir-faire Linux
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
 #    (<http://www.savoirfairelinux.com>).
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -26,10 +26,15 @@
     'author': 'Savoir-faire Linux',
     'maintainer': 'Savoir-faire Linux',
     'website': 'http://www.savoirfairelinux.com',
-    'category': 'MISC',
+    'category': 'Customer Relationship Management',
     'description': """
 Bank Account
 ============
+
+This module allows to manage multiple bank accounts for a specific contact.
+
+It adds a bank account object linked to a bank with a name for the account, a
+description and wheter it is active or not.
 
 
 Contributors
@@ -46,7 +51,4 @@ Contributors
     'demo': [],
     'test': [],
     'installable': True,
-    'active': False,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/res_bank_account/i18n/fr.po
+++ b/res_bank_account/i18n/fr.po
@@ -44,7 +44,7 @@ msgstr "Intitulé du compte bancaire"
 #. module: res_bank_account
 #: field:res.partner.bank,active:0
 msgid "Active"
-msgstr "Active"
+msgstr "Actif"
 
 #. module: res_bank_account
 #: help:res.partner.bank,title_bank_account:0

--- a/res_bank_account/i18n/fr.po
+++ b/res_bank_account/i18n/fr.po
@@ -1,0 +1,52 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* res_bank_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-01-03 07:26+0000\n"
+"PO-Revision-Date: 2014-01-03 02:26-0500\n"
+"Last-Translator: EL Hadji DEM <elhadji.dem@savoirfairelinux.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: res_bank_account
+#: field:res.partner.bank,observation:0
+msgid "Observation"
+msgstr "Remarque"
+
+#. module: res_bank_account
+#: help:res.partner.bank,active:0
+msgid "Active/Inactive."
+msgstr "Actif/Inactif."
+
+#. module: res_bank_account
+#: model:ir.model,name:res_bank_account.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr "Comptes bancaires"
+
+#. module: res_bank_account
+#: help:res.partner.bank,observation:0
+msgid "Observation."
+msgstr "Remarque."
+
+#. module: res_bank_account
+#: field:res.partner.bank,title_bank_account:0
+msgid "Title bank account"
+msgstr "Intitulé du compte bancaire"
+
+#. module: res_bank_account
+#: field:res.partner.bank,active:0
+msgid "Active"
+msgstr "Active"
+
+#. module: res_bank_account
+#: help:res.partner.bank,title_bank_account:0
+msgid "Title bank account."
+msgstr "Intitulé du compte bancaire."

--- a/res_bank_account/i18n/fr.po
+++ b/res_bank_account/i18n/fr.po
@@ -6,15 +6,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-01-03 07:26+0000\n"
-"PO-Revision-Date: 2014-01-03 02:26-0500\n"
-"Last-Translator: EL Hadji DEM <elhadji.dem@savoirfairelinux.com>\n"
+"POT-Creation-Date: 2014-10-21 18:33+0000\n"
+"PO-Revision-Date: 2014-10-21 14:36-0500\n"
+"Last-Translator: Sandy Carter <sandy.carter@savoirfairelinux.com>\n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 1.6.10\n"
+
+#. module: res_bank_account
+#: view:res.partner:0
+msgid "Bank Details"
+msgstr "Détails banquaires"
 
 #. module: res_bank_account
 #: field:res.partner.bank,observation:0
@@ -22,9 +28,9 @@ msgid "Observation"
 msgstr "Remarque"
 
 #. module: res_bank_account
-#: help:res.partner.bank,active:0
-msgid "Active/Inactive."
-msgstr "Actif/Inactif."
+#: help:res.partner.bank,title_bank_account:0
+msgid "Name for the bank account."
+msgstr "Intitulé du compte bancaire."
 
 #. module: res_bank_account
 #: model:ir.model,name:res_bank_account.model_res_partner_bank
@@ -32,9 +38,9 @@ msgid "Bank Accounts"
 msgstr "Comptes bancaires"
 
 #. module: res_bank_account
-#: help:res.partner.bank,observation:0
-msgid "Observation."
-msgstr "Remarque."
+#: view:res.partner:0
+msgid "Banks"
+msgstr "Banques"
 
 #. module: res_bank_account
 #: field:res.partner.bank,title_bank_account:0
@@ -42,11 +48,22 @@ msgid "Title bank account"
 msgstr "Intitulé du compte bancaire"
 
 #. module: res_bank_account
+#: help:res.partner.bank,observation:0
+msgid "Extra information about the account."
+msgstr "Informations supplémentaires du compte."
+
+#. module: res_bank_account
 #: field:res.partner.bank,active:0
 msgid "Active"
 msgstr "Actif"
 
 #. module: res_bank_account
-#: help:res.partner.bank,title_bank_account:0
-msgid "Title bank account."
-msgstr "Intitulé du compte bancaire."
+#: help:res.partner.bank,active:0
+msgid "Whether the account is still active or not."
+msgstr "Si le compte est actif."
+
+#~ msgid "Active/Inactive."
+#~ msgstr "Actif/Inactif."
+
+#~ msgid "Observation."
+#~ msgstr "Remarque."

--- a/res_bank_account/i18n/res_bank_account.pot
+++ b/res_bank_account/i18n/res_bank_account.pot
@@ -1,20 +1,24 @@
 # Translation of OpenERP Server.
 # This file contains the translation of the following modules:
-# 	* res_bank_account
+#	* res_bank_account
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-01-03 07:25+0000\n"
-"PO-Revision-Date: 2014-01-03 02:25-0500\n"
-"Last-Translator: EL Hadji DEM <elhadji.dem@savoirfairelinux.com>\n"
+"POT-Creation-Date: 2014-10-21 18:33+0000\n"
+"PO-Revision-Date: 2014-10-21 18:33+0000\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 1.5.4\n"
+
+#. module: res_bank_account
+#: view:res.partner:0
+msgid "Bank Details"
+msgstr ""
 
 #. module: res_bank_account
 #: field:res.partner.bank,observation:0
@@ -22,8 +26,8 @@ msgid "Observation"
 msgstr ""
 
 #. module: res_bank_account
-#: help:res.partner.bank,active:0
-msgid "Active/Inactive."
+#: help:res.partner.bank,title_bank_account:0
+msgid "Name for the bank account."
 msgstr ""
 
 #. module: res_bank_account
@@ -32,8 +36,8 @@ msgid "Bank Accounts"
 msgstr ""
 
 #. module: res_bank_account
-#: help:res.partner.bank,observation:0
-msgid "Observation."
+#: view:res.partner:0
+msgid "Banks"
 msgstr ""
 
 #. module: res_bank_account
@@ -42,11 +46,16 @@ msgid "Title bank account"
 msgstr ""
 
 #. module: res_bank_account
+#: help:res.partner.bank,observation:0
+msgid "Extra information about the account."
+msgstr ""
+
+#. module: res_bank_account
 #: field:res.partner.bank,active:0
 msgid "Active"
 msgstr ""
 
 #. module: res_bank_account
-#: help:res.partner.bank,title_bank_account:0
-msgid "Title bank account."
+#: help:res.partner.bank,active:0
+msgid "Whether the account is still active or not."
 msgstr ""

--- a/res_bank_account/i18n/res_bank_account.pot
+++ b/res_bank_account/i18n/res_bank_account.pot
@@ -1,0 +1,52 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* res_bank_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-01-03 07:25+0000\n"
+"PO-Revision-Date: 2014-01-03 02:25-0500\n"
+"Last-Translator: EL Hadji DEM <elhadji.dem@savoirfairelinux.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: res_bank_account
+#: field:res.partner.bank,observation:0
+msgid "Observation"
+msgstr ""
+
+#. module: res_bank_account
+#: help:res.partner.bank,active:0
+msgid "Active/Inactive."
+msgstr ""
+
+#. module: res_bank_account
+#: model:ir.model,name:res_bank_account.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr ""
+
+#. module: res_bank_account
+#: help:res.partner.bank,observation:0
+msgid "Observation."
+msgstr ""
+
+#. module: res_bank_account
+#: field:res.partner.bank,title_bank_account:0
+msgid "Title bank account"
+msgstr ""
+
+#. module: res_bank_account
+#: field:res.partner.bank,active:0
+msgid "Active"
+msgstr ""
+
+#. module: res_bank_account
+#: help:res.partner.bank,title_bank_account:0
+msgid "Title bank account."
+msgstr ""

--- a/res_bank_account/res_bank.py
+++ b/res_bank_account/res_bank.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2013 Savoir-faire Linux
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
 #    (<http://www.savoirfairelinux.com>).
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -24,13 +24,19 @@ from openerp.osv import orm, fields
 
 
 class res_partner_bank(orm.Model):
+    """Bank account"""
     _inherit = 'res.partner.bank'
-
     _columns = {
-        'title_bank_account': fields.char('Title bank account', size=256,
-                                          help="Title bank account."),
-        'observation': fields.text('Observation', help="Observation."),
-        'active': fields.boolean('Active', help="Active/Inactive."),
+        'title_bank_account': fields.char(
+            'Title bank account',
+            help="Name for the bank account.",
+        ),
+        'observation': fields.text(
+            'Observation',
+            help="Extra information about the account.",
+        ),
+        'active': fields.boolean(
+            'Active',
+            help="Whether the account is still active or not."
+        ),
     }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/res_bank_account/res_bank.py
+++ b/res_bank_account/res_bank.py
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class res_partner_bank(orm.Model):
+    _inherit = 'res.partner.bank'
+
+    _columns = {
+        'title_bank_account': fields.char('Title bank account', size=256,
+                                          help="Title bank account."),
+        'observation': fields.text('Observation', help="Observation."),
+        'active': fields.boolean('Active', help="Active/Inactive."),
+    }
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/res_bank_account/res_bank_view.xml
+++ b/res_bank_account/res_bank_view.xml
@@ -43,17 +43,19 @@
       <field name="arch" type="xml">
         <!--redefine bank_ids tree-->
         <field name="bank_ids" position="replace">
-          <field name="bank_ids"
-                 context="{'default_partner_id': active_id, 'form_view_ref': 'base.view_partner_bank_form'}">
-            <tree string="Bank Details">
-              <field name="active"/>
-              <field name="state" invisible="1"/>
-              <field name="sequence" invisible="1"/>
-              <field name="acc_number"/>
-              <field name="bank_name"/>
-              <field name="owner_name"/>
-            </tree>
-          </field>
+          <group string="Banks">
+            <field name="bank_ids"
+                   context="{'default_partner_id': active_id, 'form_view_ref': 'base.view_partner_bank_form'}">
+              <tree string="Bank Details">
+                <field name="active"/>
+                <field name="state" invisible="1"/>
+                <field name="sequence" invisible="1"/>
+                <field name="acc_number"/>
+                <field name="bank_name"/>
+                <field name="owner_name"/>
+              </tree>
+            </field>
+          </group>
         </field>
       </field>
     </record>

--- a/res_bank_account/res_bank_view.xml
+++ b/res_bank_account/res_bank_view.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+      <!-- Adds title_bank_account,observation and active fields in res.bank form view -->
+      <record id="view_partner_bank_inherit_add_form" model="ir.ui.view">
+        <field name="name">res.partner.bank.inherit.add.form</field>
+        <field name="model">res.partner.bank</field>
+        <field name="inherit_id" ref="base.view_partner_bank_form"/>
+        <field name="arch" type="xml">
+          <field name="state" position="before">
+              <field name="title_bank_account"/>
+          </field>
+          <field name="acc_number" position="after">
+              <field name="active"/>
+          </field>
+          <xpath expr="//form[@string='Bank account']/group[2]"
+               position="after">
+           <group>
+              <field name="observation"/>
+           </group>
+        </xpath>
+        </field>
+      </record>
+
+      <!--Add active field in tree view-->
+      <record id="view_partner_bank_inherit_active_tree" model="ir.ui.view">
+        <field name="name">res.partner.bank.inherit.active.tree</field>
+        <field name="model">res.partner.bank</field>
+        <field name="inherit_id" ref="base.view_partner_bank_tree"/>
+        <field name="arch" type="xml">
+          <field name="state" position="before">
+              <field name="active"/>
+          </field>
+        </field>
+      </record>
+
+      <!--redefine bank_ids tree-->
+    <record id="view_partner_property_bank_form" model="ir.ui.view">
+      <field name="name">res.partner.property.bank.inherit.bank.form</field>
+      <field name="model">res.partner</field>
+      <field name="inherit_id" ref="account.view_partner_property_form"/>
+      <field name="arch" type="xml">
+        <!--redefine bank_ids tree-->
+        <field name="bank_ids" position="replace">
+          <field name="bank_ids"
+                 context="{'default_partner_id': active_id, 'form_view_ref': 'base.view_partner_bank_form'}">
+            <tree string="Bank Details">
+              <field name="active"/>
+              <field name="state" invisible="1"/>
+              <field name="sequence" invisible="1"/>
+              <field name="acc_number"/>
+              <field name="bank_name"/>
+              <field name="owner_name"/>
+            </tree>
+          </field>
+        </field>
+      </field>
+    </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Add res_bank_account module: add the title bank account, observation and active boolean fields.It allows to manage several bank accounts for each contact

Port of https://code.launchpad.net/~savoirfairelinux-openerp/partner-contact-management/partner-contact-management-base_contact_add_res_bank_account/+merge/204047
## Previous reviews:

@yvaucher:

> Description seems inaccurate to me, OpenERP already allows to manage multiple bank account per partner.
> 
> What is the plus-value when installing this module?
> I suppose this is to add details on bank accounts to describe for what they should be used.
> Why should I need a title_bank_account and an observation field on my res_partner_bank
> Wouldn't one field be enough?
> If I needed more info on res.partner.bank, I would simply add a 'description' field as on other models
> 
> title_bank_account seems useless to me as it isn't even in tree views.
> 
> Active field already exists on res.partner.bank model. By the way you overide the select=True parameter on it.
> 
> And finally this may be a matter of taste but I would name this module res_partner_bank_imp instead.
> 
> Thus sorry but I'll disaprove this one in that state.

Ana Juaristi Olalde:

@yvaucher

> title_bank_account seems useless to me as it isn't even in tree views.
> 
> This is a subjective opinion. If someone needs 2 fields, he adds 2 fields. That's all :)
> 
> @ehdem
> My oppinion is Need fixing because:
> 1. <field name="bank_ids" position="replace">
>    If you replace bank_ids with something hardcoded on your module view, you will not see new "future" core improvements on that view.
> 2. I agree with @yannick in --> Active field already exists on res.partner.bank model. By the way you overide the select=True parameter on it.

@yvaucher:

> Thanks for the review Ana
> 
> My point about title_bank_account is that most of Models have standard `name` and `description` fields.
> I agree having a second field description is quiet useful to add note on the object when you open it.
> 
> However as res.partner.bank is already a bank account, naming a field xxx_bank_account seams also redundant. Thus I think it is badly named.
> 
> Still, module description doesn't match what the module does. This is more about adding fields for informations than allowing to manage multiple bank accounts. Or am I missing something?
