### PR TITLE
Remove the `type` field as is deprecated in the `ir.ui.view` model.

### DIFF
--- a/base_contact/base_contact_view.xml
+++ b/base_contact/base_contact_view.xml
@@ -34,7 +34,6 @@
         <field name="name">res.partner.form.contact</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <field name="is_company" position="after">
                 <field name="contact_type" invisible="1"/>

--- a/passport/res_passport_view.xml
+++ b/passport/res_passport_view.xml
@@ -5,7 +5,6 @@
     <record model="ir.ui.view" id="passport_tree_view">
       <field name="name">Passport Tree View</field>
       <field name="model">res.passport</field>
-      <field name="type">tree</field>
       <field name="arch" type="xml">
         <tree string="PassportTree" version="7.0">
            <field name="country_id"/>
@@ -20,7 +19,6 @@
     <record model="ir.ui.view" id="passport_form_view">
       <field name="name">Passport Form View</field>
       <field name="model">res.passport</field>
-      <field name="type">form</field>
       <field name="arch" type="xml">
         <form string="PassportForm" version="7.0" >
            <group col="4">


### PR DESCRIPTION
Removes the following warnings:

```
2014-09-03 13:57:12,695 28876 WARNING oif openerp.addons.base.ir.ir_ui_view: Setting the `type` field is deprecated in the `ir.ui.view` model.
2014-09-03 13:57:12,702 28876 WARNING oif openerp.addons.base.ir.ir_ui_view: Setting the `type` field is deprecated in the `ir.ui.view` model.
```
