### PR TITLE
Add user rights to limit access to certain users (and give all rights to others)

### DIFF
--- a/base_partner_merge/__openerp__.py
+++ b/base_partner_merge/__openerp__.py
@@ -10,7 +10,7 @@ backport module, to be removed when we switch to saas2 on the private servers
         'base',
     ],
     'data': [
-        'security/ir.model.access.csv',
+        'security/security.xml',
         'base_partner_merge_view.xml',
     ],
     'installable': True,

--- a/base_partner_merge/base_partner_merge.py
+++ b/base_partner_merge/base_partner_merge.py
@@ -346,7 +346,7 @@ class MergePartnerAutomatic(orm.TransientModel):
         ):
             raise orm.except_orm(
                 _('Error'),
-                _("You do not belong in the 'Partner Merge' group. "
+                _("You do not belong to the 'Partner Merge' group. "
                   "Please contact the Administrator to get access to "
                   "the partner merge functionality."))
 

--- a/base_partner_merge/base_partner_merge_view.xml
+++ b/base_partner_merge/base_partner_merge_view.xml
@@ -2,7 +2,7 @@
 <openerp>
     <data>
         <!-- the sequence of the configuration sub menu is 30 -->
-        <menuitem id='root_menu' name='Tools' parent='base.menu_base_partner' sequence="25"/>
+        <menuitem id='root_menu' name='Tools' parent='base.menu_base_partner' sequence="25" groups='group_partner_merge'/>
 
         <record model="ir.actions.act_window" id="base_partner_merge_automatic_act">
             <field name="name">Deduplicate Contacts</field>
@@ -15,7 +15,7 @@
 
         <menuitem id='partner_merge_automatic_menu'
             action='base_partner_merge_automatic_act'
-            groups='base.group_system'
+            groups='group_partner_merge'
             parent='root_menu' />
 
         <record model='ir.ui.view' id='base_partner_merge_automatic_wizard_form'>
@@ -116,7 +116,7 @@
         </record>
         
         <act_window id="action_partner_merge" res_model="base.partner.merge.automatic.wizard" src_model="res.partner"
-            target="new" multi="True" key2="client_action_multi" view_mode="form" name="Automatic Merge"/>
+            target="new" multi="True" key2="client_action_multi" view_mode="form" name="Automatic Merge" groups="group_partner_merge"/>
 
     </data>
 

--- a/base_partner_merge/security/security.xml
+++ b/base_partner_merge/security/security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="res.groups" id="group_partner_merge">
+            <field name="name">Partner Merge</field>
+        </record>
+        <record model="res.groups" id="base.group_system">
+            <field name="implied_ids" eval="[(4, ref('group_partner_merge'))]"/>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
The goal is, rather than give access to all users to the merge and refuse most cases if they're not the administrator (which is irrelevant later as SUPERUSER_ID is used), to give to a certain group 'Partner Merge' merging rights as if they were the administrator, and hide/deny merges otherwise.
