### PR TITLE
Fix base location Spanish translation and drop better zip

### DIFF
--- a/base_location/better_zip.py
+++ b/base_location/better_zip.py
@@ -24,7 +24,7 @@ from openerp.osv import orm, fields
 
 class BetterZip(orm.Model):
 
-    " City/locations completion object"
+    "City/locations completion object"
 
     _name = "res.better.zip"
     _description = __doc__

--- a/base_location/better_zip.py
+++ b/base_location/better_zip.py
@@ -30,8 +30,7 @@ class BetterZip(orm.Model):
     _description = __doc__
     _order = "priority"
 
-    _columns = {'priority': fields.integer('Priority', deprecated=True),
-                'name': fields.char('ZIP'),
+    _columns = {'name': fields.char('ZIP'),
                 'city': fields.char('City', required=True),
                 'state_id': fields.many2one('res.country.state', 'State'),
                 'country_id': fields.many2one('res.country', 'Country'),

--- a/base_location/i18n/base_location.pot
+++ b/base_location/i18n/base_location.pot
@@ -1,13 +1,13 @@
-# Translation of OpenERP Server.
+# Translation of Odoo Server.
 # This file contains the translation of the following modules:
 #	* base_location
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenERP Server 7.0\n"
+"Project-Id-Version: Odoo Server 8.0-536d00d\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-12-12 22:33+0000\n"
-"PO-Revision-Date: 2013-12-12 22:33+0000\n"
+"POT-Creation-Date: 2014-12-04 09:59+0000\n"
+"PO-Revision-Date: 2014-12-04 09:59+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,85 +16,13 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: base_location
-#: model:ir.actions.act_window,name:base_location.action_zip_tree
-msgid "Cites/locations Management"
-msgstr ""
-
-#. module: base_location
-#: field:res.better.zip,city:0
-msgid "City"
-msgstr ""
-
-#. module: base_location
-#: view:res.better.zip:0
-#: field:res.better.zip,name:0
-msgid "ZIP"
-msgstr ""
-
-#. module: base_location
-#: field:res.better.zip,state_id:0
-msgid "State"
-msgstr ""
-
-#. module: base_location
-#: field:res.better.zip,country_id:0
-msgid "Country"
-msgstr ""
-
-#. module: base_location
-#: field:res.better.zip,priority:0
-msgid "Priority"
-msgstr ""
-
-#. module: base_location
-#: model:ir.model,name:base_location.model_res_company
-msgid "Companies"
-msgstr ""
-
-#. module: base_location
-#: field:res.better.zip,code:0
-msgid "City Code"
-msgstr ""
-
-#. module: base_location
 #: model:ir.model,name:base_location.model_res_better_zip
 msgid " City/locations completion object"
 msgstr ""
 
 #. module: base_location
-#: help:res.company,better_zip_id:0
-msgid "Use the city name or the zip code to search the location"
-msgstr ""
-
-#. module: base_location
-#: field:res.partner,zip_id:0
-msgid "City/Location"
-msgstr ""
-
-#. module: base_location
-#: view:res.better.zip:0
-msgid "Search city"
-msgstr ""
-
-#. module: base_location
-#: field:res.company,better_zip_id:0
-msgid "Location"
-msgstr ""
-
-#. module: base_location
-#: model:ir.ui.menu,name:base_location.zip_base
-msgid "Cities/Locations Management"
-msgstr ""
-
-#. module: base_location
-#: model:ir.model,name:base_location.model_res_partner
-msgid "Partner"
-msgstr ""
-
-#. module: base_location
-#: view:res.company:0
-#: view:res.partner:0
-msgid "City completion"
+#: model:ir.actions.act_window,name:base_location.action_zip_tree
+msgid "Cites/locations Management"
 msgstr ""
 
 #. module: base_location
@@ -103,8 +31,94 @@ msgid "Cities"
 msgstr ""
 
 #. module: base_location
+#: model:ir.ui.menu,name:base_location.zip_base
+msgid "Cities/Locations Management"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,city:0
+msgid "City"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,code:0
+msgid "City Code"
+msgstr ""
+
+#. module: base_location
+#: view:res.company:base_location.view_company_form_city
+#: view:res.partner:base_location.view_partner_form
+msgid "City completion"
+msgstr ""
+
+#. module: base_location
+#: field:res.partner,zip_id:0
+msgid "City/Location"
+msgstr ""
+
+#. module: base_location
+#: model:ir.model,name:base_location.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,country_id:0
+msgid "Country"
+msgstr ""
+
+#. module: base_location
 #: model:ir.model,name:base_location.model_res_country_state
 msgid "Country state"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,id:0
+msgid "ID"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: base_location
+#: field:res.company,better_zip_id:0
+msgid "Location"
+msgstr ""
+
+#. module: base_location
+#: model:ir.model,name:base_location.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,priority:0
+msgid "Priority"
+msgstr ""
+
+#. module: base_location
+#: view:res.better.zip:base_location.view_better_zip_filter
+msgid "Search city"
+msgstr ""
+
+#. module: base_location
+#: field:res.better.zip,state_id:0
+msgid "State"
 msgstr ""
 
 #. module: base_location
@@ -112,3 +126,14 @@ msgstr ""
 msgid "The official code for the city"
 msgstr ""
 
+#. module: base_location
+#: help:res.company,better_zip_id:0
+msgid "Use the city name or the zip code to search the location"
+msgstr ""
+
+#. module: base_location
+#: view:res.better.zip:base_location.better_zip_form
+#: view:res.better.zip:base_location.better_zip_tree
+#: field:res.better.zip,name:0
+msgid "ZIP"
+msgstr ""

--- a/base_location/i18n/es.po
+++ b/base_location/i18n/es.po
@@ -1,101 +1,30 @@
 # Translation of OpenERP Server.
 # This file contains the translation of the following modules:
-#	* base_location
+# 	* base_location
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-12-12 22:34+0000\n"
-"PO-Revision-Date: 2013-12-12 23:34+0100\n"
-"Last-Translator: Pedro Manuel Baeza <pedro.baeza@serviciosbaeza.com>\n"
+"POT-Creation-Date: 2014-12-04 09:59+0000\n"
+"PO-Revision-Date: 2014-12-04 11:38+0100\n"
+"Last-Translator: Jairo Llopis <j.llopis@grupoesoc.es>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: \n"
-
-#. module: base_location
-#: model:ir.actions.act_window,name:base_location.action_zip_tree
-msgid "Cites/locations Management"
-msgstr "Gestión de ciudades/ubicaciones"
-
-#. module: base_location
-#: field:res.better.zip,city:0
-msgid "City"
-msgstr "Ciudad"
-
-#. module: base_location
-#: view:res.better.zip:0
-#: field:res.better.zip,name:0
-msgid "ZIP"
-msgstr "C.P."
-
-#. module: base_location
-#: field:res.better.zip,state_id:0
-msgid "State"
-msgstr "Provincia"
-
-#. module: base_location
-#: field:res.better.zip,country_id:0
-msgid "Country"
-msgstr "País"
-
-#. module: base_location
-#: field:res.better.zip,priority:0
-msgid "Priority"
-msgstr "Prioridad"
-
-#. module: base_location
-#: model:ir.model,name:base_location.model_res_company
-msgid "Companies"
-msgstr "Compañías"
-
-#. module: base_location
-#: field:res.better.zip,code:0
-msgid "City Code"
-msgstr "Código de ciudad"
+"X-Generator: Poedit 1.5.4\n"
+"Language: es_ES\n"
 
 #. module: base_location
 #: model:ir.model,name:base_location.model_res_better_zip
 msgid " City/locations completion object"
-msgstr " Objeto de completado de ciudad/ubicación"
+msgstr "Objeto de completado de ciudad/ubicación"
 
 #. module: base_location
-#: help:res.company,better_zip_id:0
-msgid "Use the city name or the zip code to search the location"
-msgstr "Utilice el nombre de ciudad o el código postal para buscar la ubicación"
-
-#. module: base_location
-#: field:res.partner,zip_id:0
-msgid "City/Location"
-msgstr "Ciudad/Ubicación"
-
-#. module: base_location
-#: view:res.better.zip:0
-msgid "Search city"
-msgstr "Buscar ciudad"
-
-#. module: base_location
-#: field:res.company,better_zip_id:0
-msgid "Location"
-msgstr "Ubicación"
-
-#. module: base_location
-#: model:ir.ui.menu,name:base_location.zip_base
-msgid "Cities/Locations Management"
-msgstr "Ciudad/Ubicaciones"
-
-#. module: base_location
-#: model:ir.model,name:base_location.model_res_partner
-msgid "Partner"
-msgstr "Empresa"
-
-#. module: base_location
-#: view:res.company:0
-#: view:res.partner:0
-msgid "City completion"
-msgstr "Autocompletado a partir de la ciudad"
+#: model:ir.actions.act_window,name:base_location.action_zip_tree
+msgid "Cites/locations Management"
+msgstr "Gestión de ciudades/localidades"
 
 #. module: base_location
 #: field:res.country.state,better_zip_ids:0
@@ -103,8 +32,94 @@ msgid "Cities"
 msgstr "Ciudades"
 
 #. module: base_location
+#: model:ir.ui.menu,name:base_location.zip_base
+msgid "Cities/Locations Management"
+msgstr "Gestión de ciudades/localidades"
+
+#. module: base_location
+#: field:res.better.zip,city:0
+msgid "City"
+msgstr "Ciudad"
+
+#. module: base_location
+#: field:res.better.zip,code:0
+msgid "City Code"
+msgstr "Código de ciudad"
+
+#. module: base_location
+#: view:res.company:base_location.view_company_form_city
+#: view:res.partner:base_location.view_partner_form
+msgid "City completion"
+msgstr "Autocompletar a partir de la ciudad"
+
+#. module: base_location
+#: field:res.partner,zip_id:0
+msgid "City/Location"
+msgstr "Ciudad/Localidad"
+
+#. module: base_location
+#: model:ir.model,name:base_location.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: base_location
+#: field:res.better.zip,country_id:0
+msgid "Country"
+msgstr "País"
+
+#. module: base_location
 #: model:ir.model,name:base_location.model_res_country_state
 msgid "Country state"
+msgstr "Provincia"
+
+#. module: base_location
+#: field:res.better.zip,create_uid:0
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: base_location
+#: field:res.better.zip,create_date:0
+msgid "Created on"
+msgstr "Fecha de creación"
+
+#. module: base_location
+#: field:res.better.zip,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: base_location
+#: field:res.better.zip,write_uid:0
+msgid "Last Updated by"
+msgstr "Actualizado la última vez por"
+
+#. module: base_location
+#: field:res.better.zip,write_date:0
+msgid "Last Updated on"
+msgstr "Fecha de última actualización"
+
+#. module: base_location
+#: field:res.company,better_zip_id:0
+msgid "Location"
+msgstr "Localidad"
+
+#. module: base_location
+#: model:ir.model,name:base_location.model_res_partner
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: base_location
+#: field:res.better.zip,priority:0
+msgid "Priority"
+msgstr "Prioridad"
+
+#. module: base_location
+#: view:res.better.zip:base_location.view_better_zip_filter
+msgid "Search city"
+msgstr "Buscar ciudad"
+
+#. module: base_location
+#: field:res.better.zip,state_id:0
+msgid "State"
 msgstr "Provincia"
 
 #. module: base_location
@@ -112,3 +127,15 @@ msgstr "Provincia"
 msgid "The official code for the city"
 msgstr "El código oficial para la ciudad"
 
+#. module: base_location
+#: help:res.company,better_zip_id:0
+msgid "Use the city name or the zip code to search the location"
+msgstr ""
+"Utilice el nombre de ciudad o el código postal para buscar la localidad"
+
+#. module: base_location
+#: view:res.better.zip:base_location.better_zip_form
+#: view:res.better.zip:base_location.better_zip_tree
+#: field:res.better.zip,name:0
+msgid "ZIP"
+msgstr "C.P."

--- a/better_zip
+++ b/better_zip
@@ -1,1 +1,0 @@
-base_location


### PR DESCRIPTION
Module `base_location` and `better_zip` were conflicting, and translations are outdated. This fixes the Spanish one and drops the long deprecated `better_zip`.
