### PR TITLE
partner_firstname Fix tests with stock

### DIFF
--- a/partner_firstname/res_user.py
+++ b/partner_firstname/res_user.py
@@ -25,6 +25,22 @@ class ResUsers(orm.Model):
 
     _inherit = 'res.users'
 
+    def create(self, cr, user, vals, context=None):
+        """To support data backward compatibility we have to keep this
+        overwrite even if we use fnct_inv: otherwise we can't create
+        entry because lastname is mandatory and module will not install
+        if there is demo data
+
+        This fixes the unittests in stock when partner_firstname is
+        installed
+        """
+        vals2 = vals.copy()
+        if 'name' in vals:
+            vals2['lastname'] = vals2['name']
+        elif 'login' in vals and 'lastname' not in vals:
+            vals2['lastname'] = vals2['login']
+        return super(ResUsers, self).create(cr, user, vals2, context=context)
+
     def copy_data(self, cr, uid, _id, default=None, context=None):
         """Avoid to replicate the firstname into the name when
          duplicating a user

--- a/partner_firstname/tests/test_partner_firstname.py
+++ b/partner_firstname/tests/test_partner_firstname.py
@@ -195,3 +195,16 @@ class test_partner_firstname(common.TransactionCase):
             vals['firstname'],
             'Update of the user firstname failed with wrong firstname'
         )
+
+    def test_create_user_login_only(self):
+        """Test creation of a user with only the login supplied"""
+        cr, uid, context = self.cr, self.uid, self.context
+        # create a user
+        res_id = self.user_model.create(
+            cr, uid, {'login': 'test_login_only'}, context=context
+        )
+        # get the related partner id and add it a firstname
+        user = self.user_model.browse(cr, uid, res_id, context=context)
+        self.assertEqual(user.login, user.name)
+        self.assertEqual(user.login, user.lastname)
+        self.assertEqual(user.login, user.partner_id.lastname)


### PR DESCRIPTION
There is an edge case where partner_firstname fails to work:

When creating a user, there can be a non-null constraint issue.

The most common error is when running odoo tests, there are some tests in stock which fail.
