### PR TITLE
base_location: Don't position zip_id after street2, to avoid layout issues with module partner_address_street3

### DIFF
--- a/base_location/partner_view.xml
+++ b/base_location/partner_view.xml
@@ -6,7 +6,7 @@
       <field name="model">res.partner</field>
       <field name="inherit_id" ref="base.view_partner_form"/>
       <field name="arch" type="xml">
-        <field name="street2" position="after">
+        <div class="address_format" position="before">
           <field name="zip_id"
                  options="{'create_name_field': 'city'}"
                  on_change="onchange_zip_id(zip_id)"
@@ -14,8 +14,8 @@
                  attrs="{'invisible': [('use_parent_address','=',True)]}"
                  class="oe_edit_only"
                  />
-        </field>
-        <xpath expr="//field[@name='child_ids']/form//field[@name='street2']" position="after">
+        </div>
+        <xpath expr="//field[@name='child_ids']/form//div[@class='address_format']" position="before">
           <field name="zip_id"
                  options="{'create_name_field': 'city'}"
                  on_change="onchange_zip_id(zip_id)"


### PR DESCRIPTION
Currently, when you install the modules base_location and partner_address_street3, you may have the following layout (from top to bottom):
1) street
2) street2
3) zip_id
4) street3
5) zip + city

We could play with priorities of views, but I prefered to fix this issue by attaching zip_id on "div class="address_format". With this PR, you will always get the following order:
1) street
2) street2
3) street3
4) zip_id
5) zip + city
