### PR TITLE
[FIX] Make sure we create a new partner on import.

### DIFF
--- a/base_contact_function_partner_firstname/res_partner.py
+++ b/base_contact_function_partner_firstname/res_partner.py
@@ -57,9 +57,6 @@ class res_partner(orm.Model):
             vals['firstname'] = contact_info.firstname
             vals['title'] = contact_info.title.id or ''
 
-        if ('contact_id'in vals and ('reset_password' in context or
-                                     'install_mode' in context)):
-            return vals['contact_id']
         res = super(res_partner, self).create(cr, user, vals, context=context)
         return res
 


### PR DESCRIPTION
When we try to import a funtion partner with a cantact_id field pointing to an existing contact, the create method will just return the existing contact id instead of creating a new entry in the database but the import will think that the importation went ok since no exception is triggered.

This PR removes the code that causes this behaviour.
