### PR TITLE
protect import of external dependencies

### DIFF
--- a/base_location_geonames_import/wizard/geonames_import.py
+++ b/base_location_geonames_import/wizard/geonames_import.py
@@ -27,10 +27,14 @@ from openerp.exceptions import Warning
 import requests
 import tempfile
 import StringIO
-import unicodecsv
 import zipfile
 import os
 import logging
+
+try:
+    import unicodecsv
+except ImportError:
+    unicodecsv = None
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Odoo won't install an addon if the external dependencies are not met.
However, the python modules of the addons are imported at startup, and the
lack of an external dependency for an external addon will cause a crash,
therefore the import needs to be in a try..except block.

closes #100
