### PR TITLE
E123 closing bracket indentation fix X 2

### DIFF
--- a/partner_street_number/__openerp__.py
+++ b/partner_street_number/__openerp__.py
@@ -41,9 +41,9 @@ This module is compatible with OpenERP 7.0.
 """,
     "depends": [
         'base'
-        ],
+    ],
     "data": [
         'view/res_partner.xml',
-        ],
+    ],
     'installable': True,
 }


### PR DESCRIPTION
<pre>
./partner_street_number/__openerp__.py:44:9: E123 closing bracket does not match indentation of opening bracket's line
./partner_street_number/__openerp__.py:47:9: E123 closing bracket does not match indentation of opening bracket's line
</pre>
