### PR TITLE
Keep partner's lastname if it has one

### DIFF
--- a/partner_firstname/res_user.py
+++ b/partner_firstname/res_user.py
@@ -42,8 +42,7 @@ class ResUsers(orm.Model):
             res_partner = self.pool.get('res.partner')
             partner = res_partner.browse(cr, user, vals2['partner_id'],
                                          context)
-            if partner.lastname:
-                vals2['lastname'] = partner.lastname
+            vals2['lastname'] = partner.lastname
         elif 'login' in vals and 'lastname' not in vals:
             vals2['lastname'] = vals2['login']
         return super(ResUsers, self).create(cr, user, vals2, context=context)

--- a/partner_firstname/res_user.py
+++ b/partner_firstname/res_user.py
@@ -36,13 +36,14 @@ class ResUsers(orm.Model):
         """
         vals2 = vals.copy()
 
-        res_partner = self.pool.get('res.partner')
-        partner = res_partner.browse(cr, user, vals2['partner_id'], context)
-
         if 'name' in vals:
             vals2['lastname'] = vals2['name']
-        elif partner.lastname and 'lastname' not in vals:
-            vals2['lastname'] = partner.lastname
+        elif 'lastname' not in vals and 'partner_id' in vals:
+            res_partner = self.pool.get('res.partner')
+            partner = res_partner.browse(cr, user, vals2['partner_id'], 
+                                         context)
+            if partner.lastname:
+                vals2['lastname'] = partner.lastname
         elif 'login' in vals and 'lastname' not in vals:
             vals2['lastname'] = vals2['login']
         return super(ResUsers, self).create(cr, user, vals2, context=context)

--- a/partner_firstname/res_user.py
+++ b/partner_firstname/res_user.py
@@ -40,7 +40,7 @@ class ResUsers(orm.Model):
             vals2['lastname'] = vals2['name']
         elif 'lastname' not in vals and 'partner_id' in vals:
             res_partner = self.pool.get('res.partner')
-            partner = res_partner.browse(cr, user, vals2['partner_id'], 
+            partner = res_partner.browse(cr, user, vals2['partner_id'],
                                          context)
             if partner.lastname:
                 vals2['lastname'] = partner.lastname

--- a/partner_firstname/res_user.py
+++ b/partner_firstname/res_user.py
@@ -35,8 +35,14 @@ class ResUsers(orm.Model):
         installed
         """
         vals2 = vals.copy()
+
+        res_partner = self.pool.get('res.partner')
+        partner = res_partner.browse(cr, user, vals2['partner_id'], context)
+
         if 'name' in vals:
             vals2['lastname'] = vals2['name']
+        elif partner.lastname:
+            vals2['lastname'] = partner.lastname
         elif 'login' in vals and 'lastname' not in vals:
             vals2['lastname'] = vals2['login']
         return super(ResUsers, self).create(cr, user, vals2, context=context)

--- a/partner_firstname/res_user.py
+++ b/partner_firstname/res_user.py
@@ -41,7 +41,7 @@ class ResUsers(orm.Model):
 
         if 'name' in vals:
             vals2['lastname'] = vals2['name']
-        elif partner.lastname:
+        elif partner.lastname and 'lastname' not in vals:
             vals2['lastname'] = partner.lastname
         elif 'login' in vals and 'lastname' not in vals:
             vals2['lastname'] = vals2['login']


### PR DESCRIPTION
On creation of a user, keep the partner's lastname if it has already been set to not have the email instead
