### PR TITLE
Spanish translation for Base Partner Merge for branch 7.0 and a fix

### DIFF
--- a/base_partner_merge/i18n/base_partner_merge.pot
+++ b/base_partner_merge/i18n/base_partner_merge.pot
@@ -1,0 +1,269 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* base_partner_merge
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0-20130824-231042\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-15 14:40+0000\n"
+"PO-Revision-Date: 2015-06-15 14:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Partners"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Exclude contacts having"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Deduplicate the other Contacts"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,partner_ids:0
+msgid "Contacts"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,number_group:0
+msgid "Group of Contacts"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.line,wizard_id:0
+msgid "Wizard"
+msgstr ""
+
+#. module: base_partner_merge
+#: model:ir.model,name:base_partner_merge.model_base_partner_merge_automatic_wizard
+msgid "base.partner.merge.automatic.wizard"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Automatic Merge Wizard"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,state:0
+msgid "State"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Skip these contacts"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge the following contacts"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_email:0
+msgid "Email"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,current_line_id:0
+msgid "Current Line"
+msgstr ""
+
+#. module: base_partner_merge
+#: selection:base.partner.merge.automatic.wizard,state:0
+msgid "Option"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,dst_partner_id:0
+msgid "Destination Contact"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Are you sure to execute the automatic merge of your contacts ?"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Are you sure to execute the list of automatic merges of your contacts ?"
+msgstr ""
+
+#. module: base_partner_merge
+#: selection:base.partner.merge.automatic.wizard,state:0
+msgid "Finished"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_vat:0
+msgid "VAT"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge Automatically all process"
+msgstr ""
+
+#. module: base_partner_merge
+#: model:ir.model,name:base_partner_merge.model_base_partner_merge_line
+msgid "base.partner.merge.line"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Select the list of fields used to search for\n"
+"                            duplicated records. If you select several fields,\n"
+"                            OpenERP will propose you to merge only those having\n"
+"                            all these fields in common. (not one of the fields)."
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_is_company:0
+msgid "Is Company"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,maximum_group:0
+msgid "Maximum of Group of Contacts"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Search duplicates based on duplicated data in"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_name:0
+msgid "Name"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge Automatically"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,line_ids:0
+msgid "Lines"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.line,aggr_ids:0
+msgid "Ids"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.line,min_id:0
+msgid "MinID"
+msgstr ""
+
+#. module: base_partner_merge
+#: selection:base.partner.merge.automatic.wizard,state:0
+msgid "Selection"
+msgstr ""
+
+#. module: base_partner_merge
+#: model:ir.model,name:base_partner_merge.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "There is no more contacts to merge for this request..."
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,exclude_journal_item:0
+msgid "Journal Items associated to the contact"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Options"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "The selected contacts will be merged together. All\n"
+"                                documents linking to one of these contacts will be\n"
+"                                redirected to the aggregated contact. You can remove\n"
+"                                contacts from this list to avoid merging them."
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge Selection"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_parent_id:0
+msgid "Parent Company"
+msgstr ""
+
+#. module: base_partner_merge
+#: model:res.groups,name:base_partner_merge.group_partner_merge
+msgid "Partner Merge"
+msgstr ""
+
+#. module: base_partner_merge
+#: model:ir.actions.act_window,name:base_partner_merge.action_partner_merge
+msgid "Automatic Merge"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "or"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:res.partner,create_date:0
+msgid "Create Date"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge with Manual Check"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Cancel"
+msgstr ""
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Close"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,exclude_contact:0
+msgid "A user associated to the contact"
+msgstr ""
+
+#. module: base_partner_merge
+#: model:ir.ui.menu,name:base_partner_merge.root_menu
+msgid "Tools"
+msgstr ""
+
+#. module: base_partner_merge
+#: field:res.partner,id:0
+msgid "Id"
+msgstr ""
+
+#. module: base_partner_merge
+#: model:ir.actions.act_window,name:base_partner_merge.base_partner_merge_automatic_act
+#: model:ir.ui.menu,name:base_partner_merge.partner_merge_automatic_menu
+msgid "Deduplicate Contacts"
+msgstr ""
+

--- a/base_partner_merge/i18n/es.po
+++ b/base_partner_merge/i18n/es.po
@@ -1,0 +1,279 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* base_partner_merge
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0-20130824-231042\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-15 14:51+0000\n"
+"PO-Revision-Date: 2015-06-15 14:56-0500\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: es\n"
+"X-Generator: Poedit 1.7.5\n"
+"X-Poedit-Bookmarks: -1,-1,15,-1,-1,-1,-1,-1,-1,-1\n"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Partners"
+msgstr "Socios"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Exclude contacts having"
+msgstr "Excluir contactos que tengan"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Deduplicate the other Contacts"
+msgstr "Desduplicar los otros contactos"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,partner_ids:0
+msgid "Contacts"
+msgstr "Contactos"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,number_group:0
+msgid "Group of Contacts"
+msgstr "Grupo de Contactos"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.line,wizard_id:0
+msgid "Wizard"
+msgstr "Asistente"
+
+#. module: base_partner_merge
+#: model:ir.model,name:base_partner_merge.model_base_partner_merge_automatic_wizard
+msgid "base.partner.merge.automatic.wizard"
+msgstr "base.partner.merge.automatic.wizard"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Automatic Merge Wizard"
+msgstr "Asistente para Combinar Automáticamente"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,state:0
+msgid "State"
+msgstr "Estado"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Skip these contacts"
+msgstr "Saltar estos contactos"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge the following contacts"
+msgstr "Combinar los siguientes contactos"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_email:0
+msgid "Email"
+msgstr "Correo"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,current_line_id:0
+msgid "Current Line"
+msgstr "Current Line"
+
+#. module: base_partner_merge
+#: selection:base.partner.merge.automatic.wizard,state:0
+msgid "Option"
+msgstr "Opción"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,dst_partner_id:0
+msgid "Destination Contact"
+msgstr "Contacto Destino"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Are you sure to execute the automatic merge of your contacts ?"
+msgstr "¿Está seguro de ejecutar combinación automática en sus contactos?"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Are you sure to execute the list of automatic merges of your contacts ?"
+msgstr "¿Está seguro de ejecutar la lista de combinación  automática de sus contactos?"
+
+#. module: base_partner_merge
+#: selection:base.partner.merge.automatic.wizard,state:0
+msgid "Finished"
+msgstr "Finalizado"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_vat:0
+msgid "VAT"
+msgstr "CIF/NIF"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge Automatically all process"
+msgstr "Combinar Automáticamente todos los procesos"
+
+#. module: base_partner_merge
+#: model:ir.model,name:base_partner_merge.model_base_partner_merge_line
+msgid "base.partner.merge.line"
+msgstr "base.partner.merge.line"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid ""
+"Select the list of fields used to search for\n"
+"                            duplicated records. If you select several fields,\n"
+"                            OpenERP will propose you to merge only those having\n"
+"                            all these fields in common. (not one of the fields)."
+msgstr ""
+"Seleccione la lista de campos utilizados para buscar registros duplicados.\n"
+"Si selecciona varios campos, OpenERP le propondrá fusionar sólo aquellos\n"
+"que tienen en común todos los campos seleccionados (no uno de los campos)."
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_is_company:0
+msgid "Is Company"
+msgstr "Es Empresa"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,maximum_group:0
+msgid "Maximum of Group of Contacts"
+msgstr "Máximo Grupo de Contactos"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Search duplicates based on duplicated data in"
+msgstr "Buscar duplicados basado en datos duplicados en"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_name:0
+msgid "Name"
+msgstr "Nombre"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge Automatically"
+msgstr "Combinar Automáticamente"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,line_ids:0
+msgid "Lines"
+msgstr "Líneas"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.line,aggr_ids:0
+msgid "Ids"
+msgstr "Ids"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.line,min_id:0
+msgid "MinID"
+msgstr "MinID"
+
+#. module: base_partner_merge
+#: selection:base.partner.merge.automatic.wizard,state:0
+msgid "Selection"
+msgstr "Selección"
+
+#. module: base_partner_merge
+#: model:ir.model,name:base_partner_merge.model_res_partner
+msgid "Partner"
+msgstr "Socio"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "There is no more contacts to merge for this request..."
+msgstr "No hay mas contactos a combinar para esta solicitud..."
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,exclude_journal_item:0
+msgid "Journal Items associated to the contact"
+msgstr "Artículos  asociados al contacto"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Options"
+msgstr "Opciones"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid ""
+"The selected contacts will be merged together. All\n"
+"                                documents linking to one of these contacts will be\n"
+"                                redirected to the aggregated contact. You can remove\n"
+"                                contacts from this list to avoid merging them."
+msgstr ""
+"Los contactos seleccionados serán conmibinados.\n"
+"Todos los documentos enlazados a uno de estos contactos serán redireccionados al contacto agregado.\n"
+"Puede eliminar contactos de esta lista para evitar que sean combinados."
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge Selection"
+msgstr "Combinar Selección"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,group_by_parent_id:0
+msgid "Parent Company"
+msgstr "Empresa Matriz"
+
+#. module: base_partner_merge
+#: model:res.groups,name:base_partner_merge.group_partner_merge
+msgid "Partner Merge"
+msgstr "Combinar Socio"
+
+#. module: base_partner_merge
+#: model:ir.actions.act_window,name:base_partner_merge.action_partner_merge
+msgid "Automatic Merge"
+msgstr "Combinar Automáticamente"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "or"
+msgstr "o"
+
+#. module: base_partner_merge
+#: field:res.partner,create_date:0
+msgid "Create Date"
+msgstr "Fecha de Creación"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Merge with Manual Check"
+msgstr "Combinar mediante Chequeo Manual"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: base_partner_merge
+#: view:base.partner.merge.automatic.wizard:0
+msgid "Close"
+msgstr "Cerrar"
+
+#. module: base_partner_merge
+#: field:base.partner.merge.automatic.wizard,exclude_contact:0
+msgid "A user associated to the contact"
+msgstr "Un usuario asociado al contacto"
+
+#. module: base_partner_merge
+#: model:ir.ui.menu,name:base_partner_merge.root_menu
+msgid "Tools"
+msgstr "Herramientas"
+
+#. module: base_partner_merge
+#: field:res.partner,id:0
+msgid "Id"
+msgstr "Id"
+
+#. module: base_partner_merge
+#: model:ir.actions.act_window,name:base_partner_merge.base_partner_merge_automatic_act
+#: model:ir.ui.menu,name:base_partner_merge.partner_merge_automatic_menu
+msgid "Deduplicate Contacts"
+msgstr "Desduplicar Contactos"


### PR DESCRIPTION
Added `i18n/base_partner_merge.pot` and `i18n/es.po` files in module `base_partner_merge` with all strings translated to spanish.

**UPDATE**

Added new commit with a fix in base_partner_merge.

Problem: When an admin user try to merge contacts with different emails got a wrong message:

> All contacts must have the same email. Only the Administrator can merge contacts with different emails.

Since the logged in user is an admin it shouldn't display this error.

In branch 8.0 there is a condition asking for superuser, but in branch 7.0 don't, so I just added the condition to the branch 7.0 and now it works. The condition has been removed from this file in commit e0a359f431bc781017122f29fad3b63f122dd40f
