### PR TITLE
[8.0] partner_firstname: Recursive @onchange misbehavior

### DIFF
--- a/partner_firstname/models.py
+++ b/partner_firstname/models.py
@@ -78,8 +78,8 @@ class ResPartner(models.Model):
         trimmed whitespace.
         """
         # Company name goes to the lastname
-        if self.is_company or self.name is False:
-            parts = [self.name, False]
+        if self.is_company or not self.name:
+            parts = [self.name or False, False]
 
         # Guess name splitting
         else:

--- a/partner_firstname/tests/__init__.py
+++ b/partner_firstname/tests/__init__.py
@@ -28,4 +28,4 @@
 #
 ##############################################################################
 
-from . import test_name, test_empty
+from . import test_empty, test_name, test_onchange

--- a/partner_firstname/tests/base.py
+++ b/partner_firstname/tests/base.py
@@ -29,7 +29,15 @@ from openerp.tests.common import TransactionCase
 from .. import exceptions as ex
 
 
-class BaseCase(TransactionCase):
+class MailInstalled():
+    def mail_installed(self):
+        """Check if ``mail`` module is installed.``"""
+        return (self.env["ir.module.module"]
+                .search([("name", "=", "mail")])
+                .state == "installed")
+
+
+class BaseCase(TransactionCase, MailInstalled):
     def setUp(self):
         super(BaseCase, self).setUp()
         self.check_fields = True

--- a/partner_firstname/tests/base.py
+++ b/partner_firstname/tests/base.py
@@ -76,3 +76,13 @@ class BaseCase(TransactionCase):
         self.check_fields = False
         with self.assertRaises(ex.EmptyNamesError):
             self.original.firstname = self.original.lastname = False
+
+
+class OnChangeCase(TransactionCase):
+    is_company = False
+
+    def new_partner(self):
+        """Create an empty partner. Ensure it is (or not) a company."""
+        new = self.env["res.partner"].new()
+        new.is_company = self.is_company
+        return new

--- a/partner_firstname/tests/test_empty.py
+++ b/partner_firstname/tests/test_empty.py
@@ -16,7 +16,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""Test situations where names are empty.
+
+To have more accurate results, remove the ``mail`` module before testing.
+"""
+
 from openerp.tests.common import TransactionCase
+from .base import MailInstalled
 from .. import exceptions as ex
 
 
@@ -47,7 +53,16 @@ class PersonCase(CompanyCase):
     context = {"default_is_company": False}
 
 
-class UserCase(CompanyCase):
+class UserCase(CompanyCase, MailInstalled):
     """Test ``res.users``."""
     model = "res.users"
     context = {"default_login": "user@example.com"}
+
+    def tearDown(self):
+        # Cannot create users if ``mail`` is installed
+        if self.mail_installed():
+            # Skip tests
+            super(CompanyCase, self).tearDown()
+        else:
+            # Run tests
+            super(UserCase, self).tearDown()

--- a/partner_firstname/tests/test_name.py
+++ b/partner_firstname/tests/test_name.py
@@ -27,8 +27,7 @@
 
 """Test naming logic.
 
-Please have in mind that some tests will fail if the ``mail`` module is
-installed.
+To have more accurate results, remove the ``mail`` module before testing.
 """
 
 from .base import BaseCase
@@ -60,6 +59,7 @@ class PartnerCompanyCase(BaseCase):
         self.original.is_company = True
 
     def test_copy(self):
+        """Copy the partner and compare the result."""
         super(PartnerCompanyCase, self).test_copy()
         self.expect(self.name, False, self.name)
 
@@ -72,6 +72,19 @@ class PartnerCompanyCase(BaseCase):
 
 class UserCase(PartnerContactCase):
     def create_original(self):
-        self.original = self.env["res.users"].create({
-            "name": u"%s %s" % (self.lastname, self.firstname),
-            "login": "firstnametest@example.com"})
+        name = u"%s %s" % (self.lastname, self.firstname)
+
+        # Cannot create users if ``mail`` is installed
+        if self.mail_installed():
+            self.original = self.env.ref("base.user_demo")
+            self.original.name = name
+        else:
+            self.original = self.env["res.users"].create({
+                "name": name,
+                "login": "firstnametest@example.com"})
+
+    def test_copy(self):
+        """Copy the partner and compare the result."""
+        # Skip if ``mail`` is installed
+        if not self.mail_installed():
+            super(UserCase, self).test_copy()

--- a/partner_firstname/tests/test_name.py
+++ b/partner_firstname/tests/test_name.py
@@ -25,6 +25,12 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
+"""Test naming logic.
+
+Please have in mind that some tests will fail if the ``mail`` module is
+installed.
+"""
+
 from .base import BaseCase
 
 

--- a/partner_firstname/tests/test_onchange.py
+++ b/partner_firstname/tests/test_onchange.py
@@ -1,23 +1,21 @@
 # -*- coding: utf-8 -*-
 """These tests try to mimic the behavior of the UI form.
 
-The form operates in onchange mode, and has only some limitations that must be
-met.
+The form operates in onchange mode, with its limitations.
 """
 
-from openerp.tests.common import TransactionCase
+from .base import OnChangeCase
 
 
-class PartnerCompanyCase(TransactionCase):
+class PartnerCompanyCase(OnChangeCase):
+    is_company = True
+
     def test_create_from_form(self):
         """A user creates a company from the form."""
         name = u"Sôme company"
         with self.env.do_in_onchange():
             # User presses ``new``
-            partner = self.env["res.partner"].create({})
-
-            # User ensures it is a company
-            partner.is_company = True
+            partner = self.new_partner()
 
             # User sets a name, which triggers onchanges
             partner.name = name
@@ -34,10 +32,7 @@ class PartnerCompanyCase(TransactionCase):
         """
         with self.env.do_in_onchange():
             # User presses ``new``
-            partner = self.env["res.partner"].create({})
-
-            # User ensures it is a company
-            partner.is_company = True
+            partner = self.new_partner()
 
             # User sets a name, which triggers onchanges
             partner.name = u"Foó"
@@ -51,16 +46,13 @@ class PartnerCompanyCase(TransactionCase):
             self.assertEqual(partner.lastname, False)
 
 
-class PartnerContactCase(TransactionCase):
+class PartnerContactCase(OnChangeCase):
     def test_create_from_form_only_firstname(self):
         """A user creates a contact with only the firstname from the form."""
         firstname = u"Fïrst"
         with self.env.do_in_onchange():
             # User presses ``new``
-            partner = self.env["res.partner"].create({})
-
-            # User ensures it is not a company
-            partner.is_company = False
+            partner = self.new_partner()
 
             # Changes firstname, which triggers onchanges
             partner.firstname = firstname
@@ -76,10 +68,7 @@ class PartnerContactCase(TransactionCase):
         lastname = u"Läst"
         with self.env.do_in_onchange():
             # User presses ``new``
-            partner = self.env["res.partner"].create({})
-
-            # User ensures it is not a company
-            partner.is_company = False
+            partner = self.new_partner()
 
             # Changes lastname, which triggers onchanges
             partner.lastname = lastname
@@ -96,10 +85,7 @@ class PartnerContactCase(TransactionCase):
         lastname = u"Läst"
         with self.env.do_in_onchange():
             # User presses ``new``
-            partner = self.env["res.partner"].create({})
-
-            # User ensures it is not a company
-            partner.is_company = False
+            partner = self.new_partner()
 
             # Changes firstname, which triggers onchanges
             partner.firstname = firstname

--- a/partner_firstname/tests/test_onchange.py
+++ b/partner_firstname/tests/test_onchange.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+"""These tests try to mimic the behavior of the UI form.
+
+The form operates in onchange mode, and has only some limitations that must be
+met.
+"""
 
 from openerp.tests.common import TransactionCase
 

--- a/partner_firstname/tests/test_onchange.py
+++ b/partner_firstname/tests/test_onchange.py
@@ -19,7 +19,7 @@ class PartnerCompanyCase(TransactionCase):
             # User ensures it is a company
             partner.is_company = True
 
-            # User sets a name, that triggers ``_onchange_name()``
+            # User sets a name, which triggers onchanges
             partner.name = name
             partner._onchange_name()
 
@@ -39,8 +39,9 @@ class PartnerContactCase(TransactionCase):
             # User ensures it is not a company
             partner.is_company = False
 
-            # Changes firstname, which triggers _onchange_name()
+            # Changes firstname, which triggers onchanges
             partner.firstname = firstname
+            partner._onchange_subnames()
             partner._onchange_name()
 
             self.assertEqual(partner.lastname, False)
@@ -57,8 +58,9 @@ class PartnerContactCase(TransactionCase):
             # User ensures it is not a company
             partner.is_company = False
 
-            # Changes lastname, which triggers _onchange_name()
+            # Changes lastname, which triggers onchanges
             partner.lastname = lastname
+            partner._onchange_subnames()
             partner._onchange_name()
 
             self.assertEqual(partner.firstname, False)
@@ -76,14 +78,16 @@ class PartnerContactCase(TransactionCase):
             # User ensures it is not a company
             partner.is_company = False
 
-            # Changes firstname, which triggers _onchange_name()
+            # Changes firstname, which triggers onchanges
             partner.firstname = firstname
+            partner._onchange_subnames()
             partner._onchange_name()
 
-            # Changes lastname, which triggers _onchange_name()
+            # Changes lastname, which triggers onchanges
             partner.lastname = lastname
+            partner._onchange_subnames()
             partner._onchange_name()
 
             self.assertEqual(partner.lastname, lastname)
             self.assertEqual(partner.firstname, firstname)
-            self.assertEqual(partner.name, u" ".join(lastname, firstname))
+            self.assertEqual(partner.name, u" ".join((lastname, firstname)))

--- a/partner_firstname/tests/test_onchange.py
+++ b/partner_firstname/tests/test_onchange.py
@@ -27,6 +27,29 @@ class PartnerCompanyCase(TransactionCase):
             self.assertEqual(partner.firstname, False)
             self.assertEqual(partner.lastname, name)
 
+    def test_empty_name_and_subnames(self):
+        """If the user empties ``name``, subnames must be ``False``.
+
+        Otherwise, the ``required`` attr will not work as expected.
+        """
+        with self.env.do_in_onchange():
+            # User presses ``new``
+            partner = self.env["res.partner"].create({})
+
+            # User ensures it is a company
+            partner.is_company = True
+
+            # User sets a name, which triggers onchanges
+            partner.name = u"Foó"
+            partner._onchange_name()
+
+            # User unsets name, which triggers onchanges
+            partner.name = u""
+            partner._onchange_name()
+
+            self.assertEqual(partner.firstname, False)
+            self.assertEqual(partner.lastname, False)
+
 
 class PartnerContactCase(TransactionCase):
     def test_create_from_form_only_firstname(self):

--- a/partner_firstname/tests/test_onchange.py
+++ b/partner_firstname/tests/test_onchange.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+from openerp.tests.common import TransactionCase
+
+
+class PartnerCompanyCase(TransactionCase):
+    def test_create_from_form(self):
+        """A user creates a company from the form."""
+        name = u"Sôme company"
+        with self.env.do_in_onchange():
+            # User presses ``new``
+            partner = self.env["res.partner"].create({})
+
+            # User ensures it is a company
+            partner.is_company = True
+
+            # User sets a name, that triggers ``_onchange_name()``
+            partner.name = name
+            partner._onchange_name()
+
+            self.assertEqual(partner.name, name)
+            self.assertEqual(partner.firstname, False)
+            self.assertEqual(partner.lastname, name)
+
+
+class PartnerContactCase(TransactionCase):
+    def test_create_from_form_only_firstname(self):
+        """A user creates a contact with only the firstname from the form."""
+        firstname = u"Fïrst"
+        with self.env.do_in_onchange():
+            # User presses ``new``
+            partner = self.env["res.partner"].create({})
+
+            # User ensures it is not a company
+            partner.is_company = False
+
+            # Changes firstname, which triggers _onchange_name()
+            partner.firstname = firstname
+            partner._onchange_name()
+
+            self.assertEqual(partner.lastname, False)
+            self.assertEqual(partner.firstname, firstname)
+            self.assertEqual(partner.name, firstname)
+
+    def test_create_from_form_only_lastname(self):
+        """A user creates a contact with only the lastname from the form."""
+        lastname = u"Läst"
+        with self.env.do_in_onchange():
+            # User presses ``new``
+            partner = self.env["res.partner"].create({})
+
+            # User ensures it is not a company
+            partner.is_company = False
+
+            # Changes lastname, which triggers _onchange_name()
+            partner.lastname = lastname
+            partner._onchange_name()
+
+            self.assertEqual(partner.firstname, False)
+            self.assertEqual(partner.lastname, lastname)
+            self.assertEqual(partner.name, lastname)
+
+    def test_create_from_form_all(self):
+        """A user creates a contact with all names from the form."""
+        firstname = u"Fïrst"
+        lastname = u"Läst"
+        with self.env.do_in_onchange():
+            # User presses ``new``
+            partner = self.env["res.partner"].create({})
+
+            # User ensures it is not a company
+            partner.is_company = False
+
+            # Changes firstname, which triggers _onchange_name()
+            partner.firstname = firstname
+            partner._onchange_name()
+
+            # Changes lastname, which triggers _onchange_name()
+            partner.lastname = lastname
+            partner._onchange_name()
+
+            self.assertEqual(partner.lastname, lastname)
+            self.assertEqual(partner.firstname, firstname)
+            self.assertEqual(partner.name, u" ".join(lastname, firstname))


### PR DESCRIPTION
@pedrobaeza This is the bug that I discovered from https://github.com/OCA/partner-contact/pull/104.

The problem is that I don't know how to fix it, but at least I'm sending the tests to get some help.

Current failure:
- User creates a new partner.
- User unchecks `is_company`.
- User sets `firstname` to "John".
  - This triggers `_compute_name()`.
    - This updates `name`.
      - This triggers `_onchange_name()`.
        - This inverts name.
          - This sets `lastname` to "John" and `firstname` to False.

The result is that the user writes in `firstname`, and that ends up in `lastname` after triggering all the onchanges.

**1st idea** tried: Remove `_onchange_name()` function, and let `_inverse_name_after_cleaning_whitespace()` be called only on save, but then:
- User creates a new partner.
- User checks `is_company`.
- User writes in `name`.
- User saves.
  - Odoo sends the correct `name` value, but also sends `lastname = firstname = False` because hidden fields are sent always too.
    - This triggers `_compute_name()`.
      - This sets `name = False`
        - This makes `_check_name()` fail.

**2nd idea** was to disable `_onchange_name()` when called from `_compute_name()`, so the code was:

```
@api.one
@api.depends("firstname", "lastname")
def _compute_name(self):
    """Write the 'name' field according to splitted data."""
    self.with_context(skip_invert=True).name = u" ".join(
        filter(None, (self.lastname, self.firstname)))

[...]

@api.one
@api.onchange("name")
def _onchange_name(self):
    """Ensure :attr:`~.name` is inverted in the UI."""
    if not self.env.context.get("skip_invert"):
        self._inverse_name_after_cleaning_whitespace()
```

But seems like the _onchange magic_ does not work when switching the context. `_compute_name()` never changes anything. For some reason if you don't set new values directly to `self`, no record is updated.

In fact, that does not even let you install the module, since `_compute_name()` is called from `_install_partner_firstname()`.

**3rd idea** was same as 2nd but returning the modified record, but I ended up with same result as for the 2nd:

```
@api.one
@api.depends("firstname", "lastname")
def _compute_name(self):
    """Write the 'name' field according to splitted data."""
    other = self.with_context(skip_invert=True)
    other.name = u" ".join(
        filter(None, (self.lastname, self.firstname)))
    return other
```

So **4th idea** was to leave `_compute_name()` uncahnged and add `context="{'skip_invert': True}"` to firstname and lastname `<field/>` in views, but [seems like the `context` attribute is only used in relational fields](https://www.odoo.com/documentation/8.0/reference/views.html#semantic-components). That context was ignored.

So, right now I'm on a dead end. I'd appreciate any suggestions.
