### PR TITLE
[IMP][8.0] partner_firstname order selectable

### DIFF
--- a/partner_firstname/README.rst
+++ b/partner_firstname/README.rst
@@ -39,6 +39,7 @@ Contributors
 * Olivier Laurent <olivier.laurent@acsone.eu>
 * Hans Henrik Gabelgaard <hhg@gabelgaard.org>
 * Jairo Llopis <j.llopis@grupoesoc.es>
+* Antonio Espinosa <antonioea@antiun.com>
 
 Maintainer
 ----------

--- a/partner_firstname/__openerp__.py
+++ b/partner_firstname/__openerp__.py
@@ -30,6 +30,7 @@
     'data': [
         'views/res_partner.xml',
         'views/res_user.xml',
+        'views/res_company.xml',
         'data/res_partner.yml',
     ],
     'demo': [],

--- a/partner_firstname/models.py
+++ b/partner_firstname/models.py
@@ -91,8 +91,8 @@ class ResPartner(models.Model):
                     first = parts[0]
                     last = u" ".join(parts[1:])
                 else:
-                    first = parts[-1]
-                    last = u" ".join(parts[:-1])
+                    last = parts[0]
+                    first = u" ".join(parts[1:])
                 parts = [last, first]
             else:
                 while len(parts) < 2:

--- a/partner_firstname/models.py
+++ b/partner_firstname/models.py
@@ -46,7 +46,7 @@ class ResPartner(models.Model):
         names = (self.lastname, self.firstname)
         if self.company_id.names_order == 'first_last':
             names = (self.firstname, self.lastname)
-        self.name = u" ".join((p for p in names if p))
+        self.name = u" ".join(filter(None, names))
 
     @api.one
     def _inverse_name_after_cleaning_whitespace(self):
@@ -89,10 +89,10 @@ class ResPartner(models.Model):
             if len(parts) > 1:
                 if self.company_id.names_order == 'first_last':
                     first = parts[:1][0]
-                    last = ' '.join(parts[1:])
+                    last = u" ".join(parts[1:])
                 else:
                     first = parts[-1:][0]
-                    last = ' '.join(parts[:-1])
+                    last = u" ".join(parts[:-1])
                 parts = [last, first]
             else:
                 while len(parts) < 2:

--- a/partner_firstname/models.py
+++ b/partner_firstname/models.py
@@ -144,6 +144,6 @@ class ResCompany(models.Model):
             ('company_id', '=', self.id)
         ])
         _logger.info("Recalculating names for %d partners.", len(partners))
-        partners._name_compute()
+        partners._compute_name()
         _logger.info("%d partners updated.", len(partners))
         return True

--- a/partner_firstname/models.py
+++ b/partner_firstname/models.py
@@ -135,10 +135,10 @@ class ResCompany(models.Model):
     names_order = fields.Selection(
         [('first_last', 'Firstname Lastname'),
          ('last_first', 'Lastname Firstname')],
-        string="Names display order", default='last_first',
+        string="Names display order", default='last_first', required=True,
         help="Select order in which names are shown")
 
-    @api.multi
+    @api.one
     def action_recalculate_names(self):
         partners = self.env['res.partner'].search([
             ('company_id', '=', self.id)

--- a/partner_firstname/tests/test_name.py
+++ b/partner_firstname/tests/test_name.py
@@ -48,6 +48,30 @@ class PartnerContactCase(BaseCase):
         self.original.invalidate_cache()
 
 
+class PartnerContactCaseInverse(PartnerContactCase):
+    def test_copy(self):
+        """Copy the partner and compare the result."""
+        self.expect(u"%s (copy)" % self.firstname, self.lastname)
+        self.changed = self.original.with_context(lang="en_US").copy()
+
+    def create_original(self):
+        super(PartnerContactCaseInverse, self).create_original()
+        self.original.company_id.names_order = 'first_last'
+
+    def expect(self, lastname, firstname, name=None):
+        super(PartnerContactCaseInverse, self).expect(
+            lastname, firstname, name)
+        self.name = name or u"%s %s" % (firstname, lastname)
+
+    def test_whitespace_cleanup(self):
+        """Check that whitespace in name gets cleared."""
+        self.expect(u"newlästname", u"newfïrstname")
+        self.original.name = "  newfïrstname  newlästname  "
+
+        # Need this to refresh the ``name`` field
+        self.original.invalidate_cache()
+
+
 class PartnerCompanyCase(BaseCase):
     def create_original(self):
         super(PartnerCompanyCase, self).create_original()

--- a/partner_firstname/views/res_company.xml
+++ b/partner_firstname/views/res_company.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+<record id="view_company_form" model="ir.ui.view">
+    <field name="name">Add name display order setting</field>
+    <field name="model">res.company</field>
+    <field name="inherit_id" ref="base.view_company_form"/>
+    <field name="arch" type="xml">
+        <xpath expr="//group[@name='account_grp']" position="after">
+            <group name="partner_grp" string="Partner">
+                <field name="names_order"/>
+            </group>
+        </xpath>
+    </field>
+</record>
+
+</data>
+</openerp>

--- a/partner_firstname/views/res_company.xml
+++ b/partner_firstname/views/res_company.xml
@@ -10,6 +10,12 @@
         <xpath expr="//group[@name='account_grp']" position="after">
             <group name="partner_grp" string="Partner">
                 <field name="names_order"/>
+                <button name="action_recalculate_names"
+                        string="Recalculate names"
+                        icon="gtk-execute"
+                        class="oe_read_only"
+                        type="object"
+                        help="Recalculate names for all partners. This process could take so much time if there are more than 10,000 active partners in this company"/>
             </group>
         </xpath>
     </field>


### PR DESCRIPTION
This PR improve partner_firstname allowing admin to select how names are ordered to compute `name` and `display_name` fields

There are two possibilities:
- Firstname Lastname
- Lastname Firstname (default, for backward compatibility)

This setting is company dependant
