### PR TITLE
[FIX] _get_inverse_name in case of space in name

### DIFF
--- a/partner_firstname/models.py
+++ b/partner_firstname/models.py
@@ -90,7 +90,7 @@ class ResPartner(models.Model):
             parts = [name or False, False]
         # Guess name splitting
         else:
-            parts = name.split(" ", 1)
+            parts = name.strip().split(" ", 1)
             while len(parts) < 2:
                 parts.append(False)
         return parts


### PR DESCRIPTION
## issue

in case of installation of the module with existing data.

if name == `' my_name'` then firstname is `u' '` and lastname is `'my_name'`

but value of self.lastname is lost in def _check_name() and EmptyNamesError is raised
## workaround

This PR
Avoid side effects to firstname and lastname in _check_name.

EDIT(@yvaucher) add backquote for readability
