### PR TITLE
[8.0] base_contact: Show warning without install it

### DIFF
--- a/base_contact/__init__.py
+++ b/base_contact/__init__.py
@@ -19,14 +19,3 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
-import logging
-import os
-
-
-_logger = logging.getLogger(__name__ + ".deprecated")
-
-# Skip warnings on runbots
-_method = _logger.info if "OCA_RUNBOT" in os.environ else _logger.warning
-_method("This module is DEPRECATED. See %s/README.rst.",
-        os.path.dirname(__file__))

--- a/base_contact/__openerp__.py
+++ b/base_contact/__openerp__.py
@@ -31,4 +31,5 @@
         'partner_contact_in_several_companies',
         'partner_contact_nationality',
     ],
+    'installable': False,
 }


### PR DESCRIPTION
I have next warning in my instance without install the module: `base_contact`

``` bash
2015-09-21 18:52:38,338 174 WARNING openerp_template openerp.addons.base_contact.deprecated: 
This module is DEPRECATED. See /root/partner-contact/base_contact/README.rst.
```

IMHO a warning message of a module that is not installed is a bad idea.
