### PR TITLE
[8.0][partner_relations - FIX] Allow to search on non-stored field "any_partner_id" by adding …

### DIFF
--- a/partner_relations/model/res_partner_relation.py
+++ b/partner_relations/model/res_partner_relation.py
@@ -41,6 +41,13 @@ class ResPartnerRelation(models.Model):
     _description = 'Partner relation'
     _order = 'active desc, date_start desc, date_end desc'
 
+    def _search_any_partner_id(self, operator, value):
+        return [
+            '|',
+            ('left_partner_id', operator, value),
+            ('right_partner_id', operator, value),
+        ]
+
     def _get_computed_fields(
             self, cr, uid, ids, field_names, arg, context=None):
         '''Return a dictionary of dictionaries, with for every partner for
@@ -101,6 +108,7 @@ class ResPartnerRelation(models.Model):
         'res.partner',
         string='Partner',
         compute='_get_partner_type_any',
+        search='_search_any_partner_id'
     )
 
     left_partner_id = fields.Many2one(

--- a/partner_relations/view/res_partner_relation.xml
+++ b/partner_relations/view/res_partner_relation.xml
@@ -46,7 +46,7 @@
             <field name="model">res.partner.relation</field>
             <field name="arch" type="xml">
                 <search string="Search Relations">
-                    <field name="any_partner_id"/>
+                    <field name="any_partner_id" widget="many2one"/>
                     <field name="left_partner_id"/>
                     <field name="right_partner_id"/>
                     <field name="type_id"/>


### PR DESCRIPTION
…a search method into the fields' declaration

This PR add a search method on `res.partner.relation.any_partner_id` in order to avoid log error 
![selection_004](https://cloud.githubusercontent.com/assets/7601731/10047451/8ae3e266-620e-11e5-89f1-55476db83571.png)

-jne
