### PR TITLE
[FIX][8.0] base_partner_merge: correct check for functional fields

### DIFF
--- a/base_partner_merge/base_partner_merge.py
+++ b/base_partner_merge/base_partner_merge.py
@@ -274,9 +274,8 @@ class MergePartnerAutomatic(orm.TransientModel):
             if record.model == 'ir.property':
                 continue
 
-            field_type = proxy_model._columns.get(record.name).__class__._type
-
-            if field_type == 'function':
+            column = proxy_model._columns[record.name]
+            if isinstance(column, fields.function):
                 continue
 
             for partner in src_partners:


### PR DESCRIPTION
Functional fields are not correctly skipped. As a result, any functional field of type reference will be overwritten with value `res.partner,XX` regardless its current value.

This is a disaster for functional fields that implement `fnct_inv`. For example, trying to merge partners will corrupt the target action for ALL menus!
