### PR TITLE
add missing dependency on mail base addon

### DIFF
--- a/base_partner_merge/__openerp__.py
+++ b/base_partner_merge/__openerp__.py
@@ -8,6 +8,7 @@ backport module, to be removed when we switch to saas2 on the private servers
 """,
     'depends': [
         'base',
+        'mail'
     ],
     'data': [
         'security/ir.model.access.csv',


### PR DESCRIPTION
base_partner_merge makes use of message_post(), which is defined in the mail
addon.
