### PR TITLE
[FIX][8.0][base_partner_merge] correctly handle new style reference fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - secure: "R3Tr39zWkjHWyKxBuOoxtvkIZNipt+HbPccuh9+fLi5irikIN3y1+YofBbK/H/wqzg6Vv6mnmwlHfXixiDmZRzQ1GidZ3nFqZYhGREp4vuEjBEf+rUb5/Ijrn6Zspgl+CCDR7ET9E3wOLMRV4A39poPgIll0vALzrAdIbdRbDqc="
 
   matrix:
-  - LINT_CHECK="1"
+  - LINT_CHECK="1" PYLINT_EXPECTED_ERRORS="2"  # base_partner_merge uses openerp.osv
   - TRANSIFEX="1"
   - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="portal_partner_merge"
   - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="portal_partner_merge"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - secure: "R3Tr39zWkjHWyKxBuOoxtvkIZNipt+HbPccuh9+fLi5irikIN3y1+YofBbK/H/wqzg6Vv6mnmwlHfXixiDmZRzQ1GidZ3nFqZYhGREp4vuEjBEf+rUb5/Ijrn6Zspgl+CCDR7ET9E3wOLMRV4A39poPgIll0vALzrAdIbdRbDqc="
 
   matrix:
-  - LINT_CHECK="1" PYLINT_EXPECTED_ERRORS="2"  # base_partner_merge uses openerp.osv
+  - LINT_CHECK="1"
   - TRANSIFEX="1"
   - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="portal_partner_merge"
   - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="portal_partner_merge"

--- a/base_partner_merge/base_partner_merge.py
+++ b/base_partner_merge/base_partner_merge.py
@@ -274,9 +274,10 @@ class MergePartnerAutomatic(orm.TransientModel):
             if record.model == 'ir.property':
                 continue
 
+            legacy = proxy_model._columns.get(record.name)
             field_spec = proxy_model._fields.get(record.name)
 
-            if field_spec.compute:
+            if isinstance(legacy, fields.function) or field_spec.compute:
                 continue
 
             for partner in src_partners:

--- a/base_partner_merge/base_partner_merge.py
+++ b/base_partner_merge/base_partner_merge.py
@@ -274,9 +274,9 @@ class MergePartnerAutomatic(orm.TransientModel):
             if record.model == 'ir.property':
                 continue
 
-            field_type = proxy_model._columns.get(record.name).__class__._type
+            field_spec = proxy_model._fields.get(record.name)
 
-            if field_type == 'function':
+            if field_spec.compute:
                 continue
 
             for partner in src_partners:


### PR DESCRIPTION
new style reference fields are not listed in _columns, use _fields instead
replace the test for functional fields with a check on the compute attribute of the field spec.
