### PR TITLE
[FIX] Allow migration from another similar addon

### DIFF
--- a/partner_second_lastname/models.py
+++ b/partner_second_lastname/models.py
@@ -11,7 +11,7 @@ class ResPartner(models.Model):
 
     _inherit = "res.partner"
 
-    lastname2 = fields.Char("Second last name")
+    lastname2 = fields.Char("Second last name", oldname="lastname_second")
 
     @api.model
     def _get_computed_name(self, lastname, firstname, lastname2=None):


### PR DESCRIPTION
This is a collateral effect that we (Antiun) have in some customers. We made a second lastname addon in parallel to @Yajo. Well, he came firsts and we accepted his addon here: https://github.com/OCA/partner-contact/pull/141#issuecomment-132516706. Now we search first if there's already an addon with the features we need, also in PRs, in order to work better together and avoid this situation in future.

But our addon was already in some customer in production environment. Now we need to migrate them to OCA implementation in order to share this repo updated.

With this little and harmless fix we can migrate with no problem. I hope you understand our situation and thanks in advance.
