### PR TITLE
Credit creators, using same name across modules to avoid split statistics

### DIFF
--- a/partner_contact_gender/__openerp__.py
+++ b/partner_contact_gender/__openerp__.py
@@ -20,9 +20,10 @@
     "name": "Contact gender",
     "version": "8.0.1.0.0",
     "category": "Customer Relationship Management",
-    "author": "Odoo Community Association (OCA), Grupo ESOC",
+    "website": "https://grupoesoc.es",
+    "author": "Grupo ESOC Ingeniería de Servicios, "
+              "Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "website": "https://odoo-community.org/",
     "installable": True,
     "application": False,
     "summary": "Add gender field to contacts",

--- a/partner_firstname/__openerp__.py
+++ b/partner_firstname/__openerp__.py
@@ -22,7 +22,9 @@
     'name': 'Partner first name and last name',
     'summary': "Split first name and last name for non company partners",
     'version': '8.0.2.1.0',
-    'author': "Camptocamp, Grupo ESOC, Odoo Community Association (OCA)",
+    "author": "Camptocamp, "
+              "Grupo ESOC Ingeniería de Servicios, "
+              "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     'maintainer': 'Camptocamp, Acsone',
     'category': 'Extra Tools',

--- a/partner_second_lastname/__openerp__.py
+++ b/partner_second_lastname/__openerp__.py
@@ -4,12 +4,14 @@
 
 {
     "name": "Partner second last name",
+    "summary": "Have split first and second lastnames",
     "version": "8.0.4.0.0",
-    "author": "Grupo ESOC, Odoo Community Association (OCA)",
     "license": "AGPL-3",
+    "website": "https://grupoesoc.es",
+    "author": "Grupo ESOC Ingeniería de Servicios, "
+              "Odoo Community Association (OCA)",
     "maintainer": "Odoo Community Association (OCA)",
     "category": "Extra Tools",
-    "website": "http://www.grupoesoc.es",
     "depends": [
         "partner_firstname"
     ],


### PR DESCRIPTION
I'm trying to unify Grupo ESOC work into one single name. Could you merge this please?
