### PR TITLE
[9.0] partner_firstname: fix user creation

### DIFF
--- a/partner_firstname/views/res_user.xml
+++ b/partner_firstname/views/res_user.xml
@@ -10,6 +10,7 @@
         <data>
             <xpath expr="//field[@name='name']" position="attributes">
                 <attribute name="readonly">True</attribute>
+                <attribute name="required">False</attribute>
             </xpath>
 
             <xpath expr="//field[@name='email']" position="after">


### PR DESCRIPTION
User name field is required what is stooping to create a new user.

Please check below screenshot:
![user_add_error_odoo9](https://cloud.githubusercontent.com/assets/213811/14013153/5ac198c8-f1b3-11e5-9dd3-a5e98bbf829b.png)
