### PR TITLE
Fix error : when creating a new relation between res.partner (type : …

### DIFF
--- a/partner_relations/model/res_partner_relation_all.py
+++ b/partner_relations/model/res_partner_relation_all.py
@@ -188,8 +188,7 @@ class ResPartnerRelationAll(models.AbstractModel):
                 'type_selection_id': [
                     '|',
                     ('contact_type_this', '=', False),
-                    ('contact_type_this', '=',
-                     'c' if self.this_partner_id else 'p'),
+                    ('contact_type_this', '=', get_partner_type(self.this_partner_id)),
                     '|',
                     ('partner_category_this', '=', False),
                     ('partner_category_this', 'in',

--- a/partner_relations/model/res_partner_relation_all.py
+++ b/partner_relations/model/res_partner_relation_all.py
@@ -188,8 +188,8 @@ class ResPartnerRelationAll(models.AbstractModel):
                 'type_selection_id': [
                     '|',
                     ('contact_type_this', '=', False),
-                    ('contact_type_this', '=', 
-					get_partner_type(self.this_partner_id)),
+                    ('contact_type_this', '=',
+                     get_partner_type(self.this_partner_id)),
                     '|',
                     ('partner_category_this', '=', False),
                     ('partner_category_this', 'in',

--- a/partner_relations/model/res_partner_relation_all.py
+++ b/partner_relations/model/res_partner_relation_all.py
@@ -188,7 +188,8 @@ class ResPartnerRelationAll(models.AbstractModel):
                 'type_selection_id': [
                     '|',
                     ('contact_type_this', '=', False),
-                    ('contact_type_this', '=', get_partner_type(self.this_partner_id)),
+                    ('contact_type_this', '=', 
+					get_partner_type(self.this_partner_id)),
                     '|',
                     ('partner_category_this', '=', False),
                     ('partner_category_this', 'in',


### PR DESCRIPTION
…Person), the view filter only relation between company, without checking the partner type, making it impossible to select relation typed for two Person
