### PR TITLE
8.0 Add module base_vat_sanitized

### DIFF
--- a/base_vat_sanitized/README.rst
+++ b/base_vat_sanitized/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================
+Base VAT Sanitized
+==================
+
+This module that adds a technical field *vat_sanitized* on partners that stores the VAT number without spaces and with letters in uppercase. It is usefull for other modules that need to match partners on VAT number, such as the *account_invoice_import* module for example.
+
+Configuration
+=============
+
+No configuration is needed.
+
+Usage
+=====
+
+This module doesn't bring any visible feature for the users.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/134/8.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/partner-contact/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+partner-contact/issues/new?body=module:%20
+base_vat_sanitized%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/base_vat_sanitized/README.rst
+++ b/base_vat_sanitized/README.rst
@@ -6,7 +6,7 @@
 Base VAT Sanitized
 ==================
 
-This module that adds a technical field *sanitized_vat* on partners that stores the VAT number without spaces and with letters in uppercase. It is usefull for other modules that need to match partners on VAT number, such as the *account_invoice_import* module for example.
+This module adds a technical field *sanitized_vat* on partners that stores the VAT number without spaces and with letters in uppercase. It is useful for other modules that need to match partners on VAT number, such as the *account_invoice_import* module for example.
 
 Configuration
 =============

--- a/base_vat_sanitized/README.rst
+++ b/base_vat_sanitized/README.rst
@@ -6,7 +6,7 @@
 Base VAT Sanitized
 ==================
 
-This module that adds a technical field *vat_sanitized* on partners that stores the VAT number without spaces and with letters in uppercase. It is usefull for other modules that need to match partners on VAT number, such as the *account_invoice_import* module for example.
+This module that adds a technical field *sanitized_vat* on partners that stores the VAT number without spaces and with letters in uppercase. It is usefull for other modules that need to match partners on VAT number, such as the *account_invoice_import* module for example.
 
 Configuration
 =============

--- a/base_vat_sanitized/__init__.py
+++ b/base_vat_sanitized/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/base_vat_sanitized/__openerp__.py
+++ b/base_vat_sanitized/__openerp__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# © 2016 Akretion (http://www.akretion.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# @author Alexis de Lattre <alexis.delattre@akretion.com>
+
+{
+    'name': 'Base VAT Sanitized',
+    'version': '8.0.1.0.0',
+    'category': 'Hidden/Dependency',
+    'license': 'AGPL-3',
+    'summary': 'Adds field sanitized_vat on partners',
+    'author': 'Akretion,Odoo Community Association (OCA)',
+    'website': 'http://www.akretion.com',
+    'depends': ['base_vat'],
+    'installable': True,
+}

--- a/base_vat_sanitized/models/__init__.py
+++ b/base_vat_sanitized/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import res_partner

--- a/base_vat_sanitized/models/res_partner.py
+++ b/base_vat_sanitized/models/res_partner.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © 2016 Akretion (http://www.akretion.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# @author Alexis de Lattre <alexis.delattre@akretion.com>
+
+from openerp import models, fields, api
+import re
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    sanitized_vat = fields.Char(
+        compute='compute_sanitized_vat', string='Sanitized TIN',
+        store=True, readonly=True,
+        help='TIN in uppercase without spaces nor special caracters.')
+
+    def _sanitize_vat(self, vat):
+        return vat and re.sub(r'\W+', '', vat).upper() or False
+
+    @api.multi
+    @api.depends('vat')
+    def compute_sanitized_vat(self):
+        for partner in self:
+            partner.sanitized_vat = self._sanitize_vat(partner.vat)

--- a/base_vat_sanitized/tests/__init__.py
+++ b/base_vat_sanitized/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_vat

--- a/base_vat_sanitized/tests/test_vat.py
+++ b/base_vat_sanitized/tests/test_vat.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2016 Akretion (http://www.akretion.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# @author Alexis de Lattre <alexis.delattre@akretion.com>
+
+from openerp.tests.common import TransactionCase
+
+
+class TestVatSanitized(TransactionCase):
+
+    def test_vat_sanitized(self):
+        ldlc = self.env['res.partner'].create({
+            'name': 'LDLC',
+            'is_company': True,
+            'vat': 'fr 26 403 554 181'
+            })
+        self.assertEqual(ldlc.sanitized_vat, 'FR26403554181')
+        # Also test invalidation
+        ldlc.vat = False
+        self.assertEqual(ldlc.sanitized_vat, False)


### PR DESCRIPTION
This module adds a field vat_sanitized on res.partner.

It is used by the modules:
- account_invoice_import https://github.com/OCA/account-invoicing/pull/122
- ovh_supplier_invoice https://github.com/akretion/ovh-supplier-invoice/tree/8.0/ovh_supplier_invoice

It is usefull for all modules that need to match a partner by VAT number.
