### PR TITLE
partner_firstname: Write in one step

### DIFF
--- a/partner_firstname/models.py
+++ b/partner_firstname/models.py
@@ -155,7 +155,12 @@ class ResPartner(models.Model):
     def _inverse_name(self):
         """Try to revert the effect of :meth:`._compute_name`."""
         parts = self._get_inverse_name(self.name, self.is_company)
-        self.lastname, self.firstname = parts["lastname"], parts["firstname"]
+        values = {
+            "lastname": parts["lastname"],
+            "firstname": parts["firstname"]
+        }
+        self.write(values)
+        self.update(values)
 
     @api.one
     @api.constrains("firstname", "lastname")


### PR DESCRIPTION
Both fields should be written in one go. An inline write like this
causes validations to be called two times and fail at times where
lastname becomes False and firstname is written only in following write.

Use Case:
When the intention is to change the order of firstname and lastname, the
user is guided to override the _get_inverse_name.  One of the simpler
approaches is to switch the fields of the result returned by this
function. However, this will fail for companies.

At the moment lastname and firstname attributes are written, lastname
will be written first (if the order is changed it will be False) leaving
the record temporarily with both lastname and firstname False which
raises an exception in _check_name function.
