### PR TITLE
[8.0][FIX] Travis using mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="portal_partner_merge"
-  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="portal_partner_merge"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="portal_partner_merge,partner_changeset"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="portal_partner_merge,partner_changeset"
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="partner_changeset"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="partner_changeset"
   - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="portal_partner_merge"
   - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="portal_partner_merge"
 


### PR DESCRIPTION
Using mock python module (https://docs.python.org/dev/library/unittest.mock.html) backported to v2.7, we can mock `check_vies` library method in order to not call it and return a sample object.

This avoid test errors in future due to VIES service downtimes or VIES database changes.
