### PR TITLE
[MIG] Migrate partner_firstname to v10

### DIFF
--- a/partner_firstname/__manifest__.py
+++ b/partner_firstname/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Partner first name and last name',
     'summary': "Split first name and last name for non company partners",
-    'version': '9.0.1.0.0',
+    'version': '10.0.1.0.0',
     'author': "Camptocamp, "
               "Grupo ESOC Ingeniería de Servicios, "
               "Odoo Community Association (OCA)",
@@ -22,9 +22,6 @@
         'views/res_user.xml',
         'data/res_partner.yml',
     ],
-    'demo': [],
-    'test': [],
     'auto_install': False,
-    'installable': False,
-    'images': []
+    'installable': True,
 }

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -4,7 +4,7 @@
 # © 2015 Grupo ESOC (<http://www.grupoesoc.es>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import logging
-from openerp import api, fields, models
+from odoo import api, fields, models
 from .. import exceptions
 
 
@@ -150,7 +150,6 @@ class ResPartner(models.Model):
                 not (self.firstname or self.lastname)):
             raise exceptions.EmptyNamesError(self)
 
-    @api.one
     @api.onchange("firstname", "lastname")
     def _onchange_subnames(self):
         """Avoid recursion when the user changes one of these fields.
@@ -162,7 +161,6 @@ class ResPartner(models.Model):
         # See https://github.com/odoo/odoo/issues/7472#issuecomment-119503916.
         self.env.context = self.with_context(skip_onchange=True).env.context
 
-    @api.one
     @api.onchange("name")
     def _onchange_name(self):
         """Ensure :attr:`~.name` is inverted in the UI."""

--- a/partner_firstname/models/res_user.py
+++ b/partner_firstname/models/res_user.py
@@ -4,7 +4,7 @@
 # © 2015 Grupo ESOC (<http://www.grupoesoc.es>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import logging
-from openerp import api, models
+from odoo import api, models
 
 
 _logger = logging.getLogger(__name__)

--- a/partner_firstname/tests/base.py
+++ b/partner_firstname/tests/base.py
@@ -2,7 +2,7 @@
 # © 2014 Nemry Jonathan (Acsone SA/NV) (http://www.acsone.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 from .. import exceptions as ex
 
 

--- a/partner_firstname/tests/test_create.py
+++ b/partner_firstname/tests/test_create.py
@@ -4,7 +4,7 @@
 
 """Test default values for models."""
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 from .base import MailInstalled
 
 

--- a/partner_firstname/tests/test_defaults.py
+++ b/partner_firstname/tests/test_defaults.py
@@ -4,7 +4,7 @@
 
 """Test default values for models."""
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 from .base import MailInstalled
 
 

--- a/partner_firstname/tests/test_delete.py
+++ b/partner_firstname/tests/test_delete.py
@@ -2,7 +2,7 @@
 # © 2015 Grupo ESOC
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 from .base import MailInstalled
 
 

--- a/partner_firstname/tests/test_empty.py
+++ b/partner_firstname/tests/test_empty.py
@@ -6,7 +6,7 @@
 
 To have more accurate results, remove the ``mail`` module before testing.
 """
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 from .base import MailInstalled
 from .. import exceptions as ex
 

--- a/partner_firstname/tests/test_user_onchange.py
+++ b/partner_firstname/tests/test_user_onchange.py
@@ -2,7 +2,7 @@
 # © 2016 Yannick Vaucher (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 
 
 class UserOnchangeCase(TransactionCase):

--- a/partner_firstname/views/res_partner.xml
+++ b/partner_firstname/views/res_partner.xml
@@ -1,86 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-<data>
+<odoo>
+    <record id="view_partner_simple_form_firstname" model="ir.ui.view">
+        <field name="name">Add firstname and lastname</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_simple_form"/>
+        <field name="arch" type="xml">
+            <data>
+                <xpath expr="//field[@name='name']" position="attributes">
+                    <attribute name="attrs">{
+                        'readonly': [('is_company', '=', False)],
+                        'required': [('is_company', '=', True)]
+                        }</attribute>
+                </xpath>
 
-<record id="view_partner_simple_form_firstname" model="ir.ui.view">
-    <field name="name">Add firstname and lastname</field>
-    <field name="model">res.partner</field>
-    <field name="inherit_id" ref="base.view_partner_simple_form"/>
-    <field name="arch" type="xml">
-        <data>
-            <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="attrs">{
-                    'readonly': [('is_company', '=', False)],
-                    'required': [('is_company', '=', True)]
-                }</attribute>
-            </xpath>
+                <xpath expr="//h1//field[@name='name']/.." position="before">
+                    <group attrs="{'invisible': [('is_company', '=', True)]}">
+                        <field name="lastname" attrs=
+                            "{'required': [('firstname', '=', False),
+                            ('is_company', '=', False)]}"/>
+                        <field name="firstname" attrs=
+                            "{'required': [('lastname', '=', False),
+                            ('is_company', '=', False)]}"/>
+                    </group>
+                </xpath>
+            </data>
+        </field>
+    </record>
 
-            <xpath expr="//h1//field[@name='name']/.." position="before">
-                <group attrs="{'invisible': [('is_company', '=', True)]}">
-                    <field name="lastname" attrs=
-                        "{'required': [('firstname', '=', False),
-                                       ('is_company', '=', False)]}"/>
-                    <field name="firstname" attrs=
-                        "{'required': [('lastname', '=', False),
-                                       ('is_company', '=', False)]}"/>
-                </group>
-            </xpath>
-        </data>
-    </field>
-</record>
+    <record id="view_partner_form_firstname" model="ir.ui.view">
+        <field name="name">Add firstname and surnames</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <data>
+                <xpath expr="//field[@name='name']" position="attributes">
+                    <attribute name="attrs">{
+                        'readonly': [('is_company', '=', False)],
+                        'required': [('is_company', '=', True)]
+                        }</attribute>
+                </xpath>
 
-<record id="view_partner_form_firstname" model="ir.ui.view">
-    <field name="name">Add firstname and surnames</field>
-    <field name="model">res.partner</field>
-    <field name="inherit_id" ref="base.view_partner_form"/>
-    <field name="arch" type="xml">
-        <data>
-            <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="attrs">{
-                    'readonly': [('is_company', '=', False)],
-                    'required': [('is_company', '=', True)]
-                }</attribute>
-            </xpath>
+                <xpath expr="//h1//field[@name='name']/.." position="after">
+                    <div class="oe_edit_only">
+                        <group attrs="{'invisible': [('is_company', '=', True)]}">
+                            <field name="lastname" attrs=
+                                "{'required': [('firstname', '=', False),
+                                ('is_company', '=', False)]}"/>
+                            <field name="firstname" attrs=
+                                "{'required': [('lastname', '=', False),
+                                ('is_company', '=', False)]}"/>
+                        </group>
+                    </div>
+                </xpath>
 
-            <xpath expr="//h1//field[@name='name']/.." position="after">
-                <div class="oe_edit_only">
-                  <group attrs="{'invisible': [('is_company', '=', True)]}">
-                      <field name="lastname" attrs=
-                          "{'required': [('firstname', '=', False),
-                                         ('is_company', '=', False)]}"/>
-                      <field name="firstname" attrs=
-                          "{'required': [('lastname', '=', False),
-                                         ('is_company', '=', False)]}"/>
-                  </group>
-                </div>
-            </xpath>
+                <!-- Modify inner contact form of child_ids -->
+                <xpath expr="//field[@name='child_ids']/form//field[@name='name']"
+                    position="attributes">
+                    <attribute name="attrs">{
+                        'readonly': [('is_company', '=', False)],
+                        'required': [('is_company', '=', True)]
+                        }</attribute>
+                </xpath>
 
-            <!-- Modify inner contact form of child_ids -->
-            <xpath expr="//field[@name='child_ids']/form//field[@name='name']"
-                   position="attributes">
-                <attribute name="attrs">{
-                    'readonly': [('is_company', '=', False)],
-                    'required': [('is_company', '=', True)]
-                }</attribute>
-            </xpath>
-
-            <xpath expr="//field[@name='child_ids']/form//field[@name='name']"
-                   position="after">
-                <div class="oe_edit_only" colspan="2">
-                  <field name="is_company" invisible="True"/>
-                  <group attrs="{'invisible': [('is_company', '=', True)]}">
-                      <field name="lastname" attrs=
-                          "{'required': [('firstname', '=', False),
-                                         ('is_company', '=', False)]}"/>
-                      <field name="firstname" attrs=
-                          "{'required': [('lastname', '=', False),
-                                         ('is_company', '=', False)]}"/>
-                  </group>
-                </div>
-            </xpath>
-        </data>
-  </field>
-</record>
-
-</data>
-</openerp>
+                <xpath expr="//field[@name='child_ids']/form//field[@name='name']"
+                    position="after">
+                    <div class="oe_edit_only" colspan="2">
+                        <field name="is_company" invisible="True"/>
+                        <group attrs="{'invisible': [('is_company', '=', True)]}">
+                            <field name="lastname" attrs=
+                                "{'required': [('firstname', '=', False),
+                                ('is_company', '=', False)]}"/>
+                            <field name="firstname" attrs=
+                                "{'required': [('lastname', '=', False),
+                                ('is_company', '=', False)]}"/>
+                        </group>
+                    </div>
+                </xpath>
+            </data>
+        </field>
+    </record>
+</odoo>

--- a/partner_firstname/views/res_user.xml
+++ b/partner_firstname/views/res_user.xml
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-<data>
+<odoo>
+    <record id="view_users_form" model="ir.ui.view">
+        <field name="name">Add firstname and surnames</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <data>
+                <xpath expr="//field[@name='name']" position="attributes">
+                    <attribute name="readonly">True</attribute>
+                    <attribute name="required">False</attribute>
+                </xpath>
 
-<record id="view_users_form" model="ir.ui.view">
-    <field name="name">Add firstname and surnames</field>
-    <field name="model">res.users</field>
-    <field name="inherit_id" ref="base.view_users_form"/>
-    <field name="arch" type="xml">
-        <data>
-            <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="readonly">True</attribute>
-                <attribute name="required">False</attribute>
-            </xpath>
-
-            <xpath expr="//field[@name='email']" position="after">
-                <group>
-                    <field name="lastname"
-                           attrs="{'required': [('firstname', '=', False)]}"/>
-                    <field name="firstname"
-                           attrs="{'required': [('lastname', '=', False)]}"/>
-                </group>
-            </xpath>
-        </data>
-  </field>
-</record>
-
-</data>
-</openerp>
+                <xpath expr="//field[@name='email']" position="after">
+                    <group>
+                        <field name="lastname"
+                            attrs="{'required': [('firstname', '=', False)]}"/>
+                        <field name="firstname"
+                            attrs="{'required': [('lastname', '=', False)]}"/>
+                    </group>
+                </xpath>
+            </data>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In addition to regular renames ("import openerp" > "import odoo" in python and "openerp/data" > "odoo" in XML files), I had to remove @api.one decorators on onchanges.

With @api.one, it returned [None], and the onchange result reader expected to have something empty, or a dictionnary. Otherwise, the module worked fine without any other modification.
