### PR TITLE
[ADD] partner_default_sale_discount

### DIFF
--- a/partner_default_sale_discount/README.rst
+++ b/partner_default_sale_discount/README.rst
@@ -1,0 +1,85 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================
+Default sales discount per partner
+==================================
+
+This module allows to define at partner level a default discount to be applied
+on sales orders as the default one. As the field is a company dependent one,
+you can configure a different value for the partner for each of your companies.
+
+Configuration
+=============
+
+Enabling the use of discounts in Odoo:
+
+#. Go to *Sales > Configuration > Settings*
+#. On the group "Quotations & Sales", select the option "Allow discounts on
+   sales order lines" for the "Discount" section.
+
+Setting a default sales discount:
+
+#. Then, go to *Sales > Customers*.
+#. Create or modify a customer.
+#. Go to "Sales & Purchases" page.
+#. In the "Sale" section, there's a field called "Default sales discount (%)"
+   where you can fill the default discount percentage.
+#. This value can only be filled at company partners, not for contacts.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to *Sales > Quotations*.
+#. Create a new quotation.
+#. Select a partner with a default discount applied.
+#. Create an order line, and you will see this discount as default in the line.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/134/9.0
+
+Known issues / Roadmap
+======================
+
+* This module doesn't work with *product_visible_discount*, as it overwrites
+  the discount field with its own value.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/partner-contact/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/partner_default_sale_discount/__init__.py
+++ b/partner_default_sale_discount/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/partner_default_sale_discount/__openerp__.py
+++ b/partner_default_sale_discount/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Default sales discount per partner',
+    'version': '9.0.1.0.0',
+    'category': 'Partner Management',
+    'license': 'AGPL-3',
+    'author': 'Tecnativa,'
+              'Odoo Community Association (OCA)',
+    'website': 'https://www.tecnativa.com',
+    'depends': [
+        'sale',
+    ],
+    'data': [
+        'views/res_partner_view.xml',
+        'views/sale_order_view.xml',
+    ],
+    'installable': True,
+}

--- a/partner_default_sale_discount/i18n/es.po
+++ b/partner_default_sale_discount/i18n/es.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* partner_default_sale_discount
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-01 16:13+0000\n"
+"PO-Revision-Date: 2016-11-01 17:13+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: es\n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#. module: partner_default_sale_discount
+#: model:ir.model.fields,field_description:partner_default_sale_discount.field_res_partner_default_sale_discount
+#: model:ir.model.fields,field_description:partner_default_sale_discount.field_sale_order_default_sale_discount
+msgid "Default sales discount (%)"
+msgstr "Descuento ventas por defecto (%)"
+
+#. module: partner_default_sale_discount
+#: model:ir.model,name:partner_default_sale_discount.model_res_partner
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: partner_default_sale_discount
+#: model:ir.model,name:partner_default_sale_discount.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"

--- a/partner_default_sale_discount/models/__init__.py
+++ b/partner_default_sale_discount/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import res_partner
+from . import sale_order

--- a/partner_default_sale_discount/models/res_partner.py
+++ b/partner_default_sale_discount/models/res_partner.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    default_sale_discount = fields.Float(
+        string="Default sales discount (%)", company_dependent=True,
+    )

--- a/partner_default_sale_discount/models/sale_order.py
+++ b/partner_default_sale_discount/models/sale_order.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+from lxml import etree
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    default_sale_discount = fields.Float(
+        related="partner_id.commercial_partner_id.default_sale_discount",
+        string="Default sales discount (%)",
+    )
+
+    @api.model
+    def fields_view_get(self, view_id=None, view_type='form', toolbar=False,
+                        submenu=False):
+        """Inject the default in the context of the line this way for
+        making it inheritable.
+        """
+        res = super(SaleOrder, self).fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar,
+            submenu=submenu
+        )
+        if view_type != 'form':  # pragma: no cover
+            return res
+        eview = etree.fromstring(res['arch'])
+        xml_order_line = eview.xpath("//field[@name='order_line']")
+        xml_discount = eview.xpath("//field[@name='default_sale_discount']")
+        if xml_order_line and xml_discount:
+            # This should be handled in "string" mode
+            context = xml_order_line[0].get('context', '{}')
+            index = context.find('{')
+            context = (
+                context[:index + 1] +
+                "'default_discount': default_sale_discount, " +
+                context[index + 1:]
+            )
+            xml_order_line[0].set('context', context)
+            res['arch'] = etree.tostring(eview)
+        return res

--- a/partner_default_sale_discount/models/sale_order.py
+++ b/partner_default_sale_discount/models/sale_order.py
@@ -30,7 +30,9 @@ class SaleOrder(models.Model):
         xml_order_line = eview.xpath("//field[@name='order_line']")
         xml_discount = eview.xpath("//field[@name='default_sale_discount']")
         if xml_order_line and xml_discount:
-            # This should be handled in "string" mode
+            # This should be handled in "string" mode, as the context can
+            # contain a expression that can only be evaled on execution time
+            # on the JS web client
             context = xml_order_line[0].get('context', '{}').replace(
                 "{", "{'default_discount': default_sale_discount, ", 1
             )

--- a/partner_default_sale_discount/models/sale_order.py
+++ b/partner_default_sale_discount/models/sale_order.py
@@ -31,12 +31,8 @@ class SaleOrder(models.Model):
         xml_discount = eview.xpath("//field[@name='default_sale_discount']")
         if xml_order_line and xml_discount:
             # This should be handled in "string" mode
-            context = xml_order_line[0].get('context', '{}')
-            index = context.find('{')
-            context = (
-                context[:index + 1] +
-                "'default_discount': default_sale_discount, " +
-                context[index + 1:]
+            context = xml_order_line[0].get('context', '{}').replace(
+                "{", "{'default_discount': default_sale_discount, ", 1
             )
             xml_order_line[0].set('context', context)
             res['arch'] = etree.tostring(eview)

--- a/partner_default_sale_discount/tests/__init__.py
+++ b/partner_default_sale_discount/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_partner_default_sale_discount

--- a/partner_default_sale_discount/tests/test_partner_default_sale_discount.py
+++ b/partner_default_sale_discount/tests/test_partner_default_sale_discount.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests import common
+from lxml import etree
+
+
+class TestPartnerDefaultSaleDiscount(common.SavepointCase):
+    def test_fields_view_get(self):
+        res = self.env['sale.order'].fields_view_get(
+            view_id=self.env.ref('sale.view_order_form').id, view_type='form')
+        eview = etree.fromstring(res['arch'])
+        xml_order_line = eview.xpath("//field[@name='order_line']")
+        self.assertTrue(xml_order_line)
+        self.assertIn(
+            "'default_discount': default_sale_discount,",
+            xml_order_line[0].get('context', '{}'))

--- a/partner_default_sale_discount/views/res_partner_view.xml
+++ b/partner_default_sale_discount/views/res_partner_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field
+                        name="default_sale_discount"
+                        attrs="{'invisible': ['|', ('customer', '=', False), ('parent_id', '!=', False)]}"
+                        groups="sale.group_discount_per_so_line"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/partner_default_sale_discount/views/sale_order_view.xml
+++ b/partner_default_sale_discount/views/sale_order_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="view_order_form">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <field name="date_order" position="after">
+                <field name="default_sale_discount" invisible="1"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Default sales discount per partner
==================================

This module allows to define at partner level a default discount to be applied
on sales orders as the default one. As the field is a company dependent one,
you can configure a different value for the partner for each of your companies.

Configuration
=============

Enabling the use of discounts in Odoo:

* Go to *Sales > Configuration > Settings*
* On the group "Quotations & Sales", select the option "Allow discounts on
  sales order lines" for the "Discount" section.

Setting a default sales discount:

* Then, go to *Sales > Customers*.
* Create or modify a customer.
* Go to "Sales & Purchases" page.
* In the "Sale" section, there's a field called "Default sales discount (%)"
  where you can fill the default discount percentage.
* This value can only be filled at company partners, not for contacts.

Usage
=====

To use this module, you need to:

* Go to *Sales > Quotations*.
* Create a new quotation.
* Select a partner with a default discount applied.
* Create an order line, and you will see this discount as default in the line.

Known issues / Roadmap
======================

* This module doesn't work with *product_visible_discount*, as it overwrites
  the discount field with its own value.