### PR TITLE
[IMP] partner_identification: Add context override

### DIFF
--- a/partner_identification/README.rst
+++ b/partner_identification/README.rst
@@ -36,7 +36,7 @@ Code:
   Code, abbreviation or acronym of this ID type. For example, 'driver_license'
 Python validation code:
   Optional python code called to validate ID numbers of this ID type. This functionality can be
-  overridden by setting ``__id_no_validate__`` to ``True`` in the context, such as:
+  overridden by setting ``id_no_validate`` to ``True`` in the context, such as:
 
   .. code-block:: python
 

--- a/partner_identification/README.rst
+++ b/partner_identification/README.rst
@@ -40,7 +40,7 @@ Python validation code:
 
   .. code-block:: python
 
-   partner.with_context(__id_no_validate__=True).write({
+   partner.with_context(id_no_validate=True).write({
       'name': 'Bad Value',
       'category_id': self.env.ref('id_category_only_numerics').id,
    })

--- a/partner_identification/README.rst
+++ b/partner_identification/README.rst
@@ -35,8 +35,15 @@ Name:
 Code:
   Code, abbreviation or acronym of this ID type. For example, 'driver_license'
 Python validation code:
-  Optional python code called to validate ID numbers of this ID type.
+  Optional python code called to validate ID numbers of this ID type. This functionality can be
+  overridden by setting ``__id_no_validate__`` to ``True`` in the context, such as:
 
+  .. code-block:: python
+
+   partner.with_context(__id_no_validate__=True).write({
+      'name': 'Bad Value',
+      'category_id': self.env.ref('id_category_only_numerics').id,
+   })
 
 Usage
 =====
@@ -97,6 +104,7 @@ Contributors
 * Gerhard Könighofer <gerhard.koenighofer@swing-system.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Jairo Llopis <jairo.llopis@tecnativa.com>
+* Dave Lasley <dave@laslabs.com>
 
 Maintainer
 ----------

--- a/partner_identification/__manifest__.py
+++ b/partner_identification/__manifest__.py
@@ -11,7 +11,7 @@
 {
     'name': 'Partner Identification Numbers',
     'category': 'Customer Relationship Management',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'depends': [
         'sales_team',
     ],

--- a/partner_identification/models/res_partner_id_category.py
+++ b/partner_identification/models/res_partner_id_category.py
@@ -55,6 +55,8 @@ class ResPartnerIdCategory(models.Model):
         python validation code fails
         """
         self.ensure_one()
+        if self.env.context.get('__id_no_validate__'):
+            return
         eval_context = self._validation_eval_context(id_number)
         try:
             safe_eval(self.validation_code,

--- a/partner_identification/models/res_partner_id_category.py
+++ b/partner_identification/models/res_partner_id_category.py
@@ -55,7 +55,7 @@ class ResPartnerIdCategory(models.Model):
         python validation code fails
         """
         self.ensure_one()
-        if self.env.context.get('__id_no_validate__'):
+        if self.env.context.get('id_no_validate'):
             return
         eval_context = self._validation_eval_context(id_number)
         try:

--- a/partner_identification/tests/test_partner_identification.py
+++ b/partner_identification/tests/test_partner_identification.py
@@ -102,7 +102,7 @@ if id_number.name != '1234' #  missing :
 """
         })
         partner_1 = self.env.ref('base.res_partner_1').with_context(
-            __id_no_validate__=True,
+            id_no_validate=True,
         )
         partner_1.write({'id_numbers': [(0, 0,  {
             'name': '1234',

--- a/partner_identification/tests/test_partner_identification.py
+++ b/partner_identification/tests/test_partner_identification.py
@@ -75,7 +75,7 @@ if id_number.name != '1235':
                 'category_id': partner_id_category2.id
             })
 
-    def test_bad_calidation_code(self):
+    def test_bad_validation_code(self):
         partner_id_category = self.env['res.partner.id_category'].create({
             'code': 'id_code',
             'name': 'id_name',
@@ -90,3 +90,21 @@ if id_number.name != '1234' #  missing :
                 'name': '1234',
                 'category_id': partner_id_category.id
             })]})
+
+    def test_bad_validation_code_override(self):
+        """ It should allow a bad validation code if context overrides. """
+        partner_id_category = self.env['res.partner.id_category'].create({
+            'code': 'id_code',
+            'name': 'id_name',
+            'validation_code': """
+if id_number.name != '1234' #  missing :
+    failed = True
+"""
+        })
+        partner_1 = self.env.ref('base.res_partner_1').with_context(
+            __id_no_validate__=True,
+        )
+        partner_1.write({'id_numbers': [(0, 0,  {
+            'name': '1234',
+            'category_id': partner_id_category.id
+        })]})


### PR DESCRIPTION
* Allow for context override of validations using ``__id_no_validate__``

This was causing me some issues with an importer, where all data may not be good but is still required.