### PR TITLE
[8.0] fix partner merge

### DIFF
--- a/base_partner_merge/base_partner_merge.py
+++ b/base_partner_merge/base_partner_merge.py
@@ -295,7 +295,8 @@ class MergePartnerAutomatic(TransientModel):
             legacy = proxy_model._columns.get(record.name)
             field_spec = proxy_model._fields.get(record.name)
 
-            if isinstance(legacy, fields.function) or field_spec.compute:
+            if not legacy or isinstance(legacy, fields.function) \
+                    or field_spec.compute:
                 continue
 
             for partner in src_partners:


### PR DESCRIPTION
partner merge  fails on migrated databases.
If a field no longer exists in  the python code but still in ir_model_fields, than the partner merge fails.