### PR TITLE
Update vat number in test not listed on VIES.

### DIFF
--- a/partner_create_by_vat/tests/test_partner_create_by_vat.py
+++ b/partner_create_by_vat/tests/test_partner_create_by_vat.py
@@ -64,7 +64,7 @@ class TestPartnerCreatebyVAT(TransactionCase):
     def test_create_from_vat2(self):
         # Create an partner from VAT number field
         self.partner2_id = self.partner_model.create({'name': '1',
-                                                      'vat': 'ro16507426',
+                                                      'vat': 'ro4400972',
                                                       'is_company': True})
 
         # Check VAT number not listed on VIES


### PR DESCRIPTION
Update vat number in partner_create_by_vat, from 1st of January all vat_subjected partners are listed to VIES.