### PR TITLE
[FIX] partner_firstname: fix for address 'type'

### DIFF
--- a/partner_firstname/views/res_partner.xml
+++ b/partner_firstname/views/res_partner.xml
@@ -17,10 +17,12 @@
                     <group attrs="{'invisible': [('is_company', '=', True)]}">
                         <field name="lastname" attrs=
                             "{'required': [('firstname', '=', False),
-                            ('is_company', '=', False)]}"/>
+                            ('is_company', '=', False),
+                            ('type', '=', 'contact')]}"/>
                         <field name="firstname" attrs=
                             "{'required': [('lastname', '=', False),
-                            ('is_company', '=', False)]}"/>
+                            ('is_company', '=', False),
+                            ('type', '=', 'contact')]}"/>
                     </group>
                 </xpath>
             </data>
@@ -45,10 +47,12 @@
                         <group attrs="{'invisible': [('is_company', '=', True)]}">
                             <field name="lastname" attrs=
                                 "{'required': [('firstname', '=', False),
-                                ('is_company', '=', False)]}"/>
+                                ('is_company', '=', False),
+                                ('type', '=', 'contact')]}"/>
                             <field name="firstname" attrs=
                                 "{'required': [('lastname', '=', False),
-                                ('is_company', '=', False)]}"/>
+                                ('is_company', '=', False),
+                                ('type', '=', 'contact')]}"/>
                         </group>
                     </div>
                 </xpath>
@@ -69,10 +73,12 @@
                         <group attrs="{'invisible': [('is_company', '=', True)]}">
                             <field name="lastname" attrs=
                                 "{'required': [('firstname', '=', False),
-                                ('is_company', '=', False)]}"/>
+                                ('is_company', '=', False),
+                                ('type', '=', 'contact')]}"/>
                             <field name="firstname" attrs=
                                 "{'required': [('lastname', '=', False),
-                                ('is_company', '=', False)]}"/>
+                                ('is_company', '=', False),
+                                ('type', '=', 'contact')]}"/>
                         </group>
                     </div>
                 </xpath>


### PR DESCRIPTION
[FIX] partner_firstname: name, firstname and lastname are only required if address field 'type' is of type contact.

In many cases addresses don't necessarily have a first- or last-name.
For example in the case of delivery addresses, required fields are not needed.
(A Warehouse doesn’t have a first- and/or lastname )

As https://github.com/OCA/partner-contact/pull/362 but for 10.0 branch.

