### PR TITLE
[UPD] partner_firstname: fix website url in manifest

### DIFF
--- a/partner_firstname/__manifest__.py
+++ b/partner_firstname/__manifest__.py
@@ -16,9 +16,7 @@
     'license': "AGPL-3",
     'maintainer': 'Camptocamp, Acsone',
     'category': 'Extra Tools',
-    'website': 'http://www.camptocamp.com, '
-               'http://www.acsone.eu, '
-               'http://grupoesoc.es',
+    'website': 'https://odoo-community.org/',
     'depends': ['base_setup'],
     'data': [
         'views/base_config_view.xml',

--- a/partner_firstname/__manifest__.py
+++ b/partner_firstname/__manifest__.py
@@ -12,6 +12,7 @@
               "Grupo ESOC Ingeniería de Servicios, "
               "Tecnativa, "
               "LasLabs, "
+              "ACSONE SA/NV, "
               "Odoo Community Association (OCA)",
     'license': "AGPL-3",
     'maintainer': 'Camptocamp, Acsone',


### PR DESCRIPTION
The website url must be a valid uri for pypi.

Given the long history and large number of contributors I propose to use https://odoo-community.org/ as website url for this module.