### PR TITLE
[10.0][IMP] base_location(geonames): Add Lat/Long

### DIFF
--- a/base_location/README.rst
+++ b/base_location/README.rst
@@ -43,6 +43,7 @@ Contributors
 * Sandy Carter <sandy.carter@savoirfairelinux.com>
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
 * Francesco Apruzzese <f.apruzzese@apuliasoftware.it>
+* Dave Lasley <dave@laslabs.com>
 
 Icon
 ----

--- a/base_location/__manifest__.py
+++ b/base_location/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Location management (aka Better ZIP)',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'depends': [
         'base',
     ],

--- a/base_location/models/better_zip.py
+++ b/base_location/models/better_zip.py
@@ -20,6 +20,8 @@ class BetterZip(models.Model):
     city = fields.Char('City', required=True)
     state_id = fields.Many2one('res.country.state', 'State')
     country_id = fields.Many2one('res.country', 'Country')
+    latitude = fields.Float()
+    longitude = fields.Float()
 
     @api.one
     @api.depends(

--- a/base_location_geonames_import/README.rst
+++ b/base_location_geonames_import/README.rst
@@ -55,6 +55,7 @@ Contributors
 * Alexis de Lattre <alexis.delattre@akretion.com>
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Dave Lasley <dave@laslabs.com>
 
 Icon
 ----

--- a/base_location_geonames_import/__manifest__.py
+++ b/base_location_geonames_import/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Base Location Geonames Import',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Partner Management',
     'license': 'AGPL-3',
     'summary': 'Import better zip entries from Geonames',

--- a/base_location_geonames_import/wizard/geonames_import.py
+++ b/base_location_geonames_import/wizard/geonames_import.py
@@ -59,6 +59,8 @@ class BetterZipGeonamesImport(models.TransientModel):
             'city': self.transform_city_name(row[2], country),
             'state_id': state.id,
             'country_id': country.id,
+            'latitude': row[9],
+            'longitude': row[10],
             }
         return vals
 


### PR DESCRIPTION
This PR contains two modules `base_location` and `base_location_geonames_importer`, but they are minor changes in both and entirely related:

[IMP] base_location: Add lat & long to `better.zip`
* Add latitude and longitude columns to `better.zip`

[IMP] base_location_geonames_import: Add lat/long
* Add support for latitude & longitude to genomes importer

I specifically did not use geoengine so as to not require PostGIS. We can create a glue module pretty easily I think, so we can have the best of both worlds (see https://github.com/OCA/geospatial/issues/136).

I also did not add the lat/long into any views, because I don't really feel they will be useful for humans. Please let me know if you feel otherwise.