### PR TITLE
[REM] Unused pip dependency

### DIFF
--- a/partner_create_by_vat/__openerp__.py
+++ b/partner_create_by_vat/__openerp__.py
@@ -15,7 +15,7 @@
     'application': False,
     'installable': True,
     'external_dependencies': {
-        'python': ['stdnum', 'suds'],
+        'python': ['stdnum'],
     },
     'depends': ['base_vat'],
     'data': ['views/res_partner_view.xml'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 python-stdnum==1.1
-suds
 requests
 unicodecsv


### PR DESCRIPTION
The dependency `suds` is used nowhere in this repo (on branch 8.0), so should be removed.