### PR TITLE
[8.0] fix partner_relations addit'l fields

### DIFF
--- a/partner_relations/__openerp__.py
+++ b/partner_relations/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Partner relations",
-    "version": "8.0.1.1.1",
+    "version": "8.0.1.1.2",
     "author": "Therp BV,Camptocamp,Odoo Community Association (OCA)",
     "complexity": "normal",
     "category": "Customer Relationship Management",

--- a/partner_relations/models/res_partner_relation_all.py
+++ b/partner_relations/models/res_partner_relation_all.py
@@ -28,20 +28,6 @@ class ResPartnerRelationAll(models.AbstractModel):
 
     _overlays = 'res.partner.relation'
 
-    _additional_view_fields = []
-    """append to this list if you added fields to res_partner_relation that
-    you need in this model and related fields are not adequate (ie for sorting)
-    You must use the same name as in res_partner_relation.
-    Don't overwrite this list in your declaration but append in _auto_init:
-
-    def _auto_init(self, cr, context=None):
-        self._additional_view_fields.append('my_field')
-        return super(ResPartnerRelationAll, self)._auto_init(
-            cr, context=context)
-
-    my_field = fields...
-    """
-
     this_partner_id = fields.Many2one(
         comodel_name='res.partner',
         string='One Partner',
@@ -80,9 +66,23 @@ class ResPartnerRelationAll(models.AbstractModel):
         search='_search_any_partner_id'
     )
 
+    def _get_additional_view_fields(self):
+        """
+        append to this list if you added fields to res_partner_relation that
+        you need in this model and related fields are not adequate
+        (ie for sorting)
+        You must use the same name as in res_partner_relation.
+
+        def _get_additional_view_fields(self):
+            res = super(
+                ResPartnerRelationAll, self)._get_additional_view_fields()
+            return res + ['my_field1', 'my_field2']
+        """
+        return []
+
     def _auto_init(self, cr, context=None):
         drop_view_if_exists(cr, self._table)
-        additional_view_fields = ','.join(self._additional_view_fields)
+        additional_view_fields = ','.join(self._get_additional_view_fields())
         additional_view_fields = (',' + additional_view_fields)\
             if additional_view_fields else ''
         cr.execute(


### PR DESCRIPTION
The use of the _additional_view_fields private attribute for adding new fields fails in the following scenario:

- odoo 8.0 running without workers
- db1 with 'partner_relations' module installed
- db1 has also a 'custom_partner_relations' module adding fields as documented in the docstring (via the autoinit)

As soon as we create a second database db2 on this odoo server and we try to install the partner_relations module (NOT the 'custom_partner_relations' module, the module install fails since  the _additional_view_fields added in the 'custom_partner_relations' module are added to the postgres view creation of db2, but since those fields are not defined the module install fails.

By changing from a private attribute to a method (cf. diff infra) this issue is solved.