### PR TITLE
[9.0] Improve view of company field in partner form

### DIFF
--- a/partner_firstname/views/res_partner.xml
+++ b/partner_firstname/views/res_partner.xml
@@ -43,7 +43,7 @@
                 }</attribute>
             </xpath>
 
-            <xpath expr="//h1//field[@name='name']/.." position="after">
+            <xpath expr="//field[@name='parent_id']/.." position="after">
                 <div class="oe_edit_only">
                   <group attrs="{'invisible': [('is_company', '=', True)]}">
                       <field name="lastname" attrs=


### PR DESCRIPTION
Before fix, in edit mode of partner :
![firstname_before](https://cloud.githubusercontent.com/assets/8435180/26154506/035f9e16-3b10-11e7-84b2-c0056b3e0b26.PNG)

After fix :
![firstname_after](https://cloud.githubusercontent.com/assets/8435180/26154515/0acf8058-3b10-11e7-8fc0-ec27195d9188.PNG)
