### PR TITLE
[FIX] partner_identification: Infinite loop in search

### DIFF
--- a/partner_identification/__manifest__.py
+++ b/partner_identification/__manifest__.py
@@ -11,7 +11,7 @@
 {
     'name': 'Partner Identification Numbers',
     'category': 'Customer Relationship Management',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'depends': [
         'sales_team',
     ],

--- a/partner_identification/models/res_partner.py
+++ b/partner_identification/models/res_partner.py
@@ -44,7 +44,7 @@ class ResPartner(models.Model):
                     'social_security', 'SSN',
                 ),
                 search=lambda s, *a: s._search_identification(
-                    'social_security', 'SSN', *a
+                    'SSN', *a
                 ),
             )
 
@@ -86,7 +86,7 @@ class ResPartner(models.Model):
                     'social_security', 'SSN',
                 ),
                 search=lambda s, *a: s._search_identification(
-                    'social_security', 'SSN', *a
+                    'SSN', *a
                 ),
             )
 
@@ -136,8 +136,7 @@ class ResPartner(models.Model):
                 ))
 
     @api.model
-    def _search_identification(self, field_name, category_code,
-                               operator, value):
+    def _search_identification(self, category_code, operator, value):
         """ Search method for an identification field.
 
         Example:
@@ -152,7 +151,7 @@ class ResPartner(models.Model):
                     'social_security', 'SSN',
                 ),
                 search=lambda s, *a: s._search_identification(
-                    'social_security', 'SSN', *a
+                    'SSN', *a
                 ),
             )
 
@@ -163,8 +162,10 @@ class ResPartner(models.Model):
         Returns:
             list: Domain to search with.
         """
-
-        return [
-            (field_name, operator, value),
+        id_numbers = self.env['res.partner.id_number'].search([
+            ('name', operator, value),
             ('category_id.code', '=', category_code),
+        ])
+        return [
+            ('id_numbers.id', 'in', id_numbers.ids),
         ]

--- a/partner_identification/models/res_partner.py
+++ b/partner_identification/models/res_partner.py
@@ -156,8 +156,9 @@ class ResPartner(models.Model):
             )
 
         Args:
-            field_name (str): Name of field to set.
             category_code (str): Category code of the Identification type.
+            operator (str): Operator of domain.
+            value (str): Value to search for.
 
         Returns:
             list: Domain to search with.

--- a/partner_identification/tests/test_res_partner.py
+++ b/partner_identification/tests/test_res_partner.py
@@ -18,7 +18,7 @@ class ResPartner(models.Model):
             'social_security', 'SSN',
         ),
         search=lambda s, *a: s._search_identification(
-            'social_security', 'SSN', *a
+            'SSN', *a
         ),
     )
 


### PR DESCRIPTION
This PR reimplements the partner_identification search method to fix #434 