### PR TITLE
[FIX] partner contact street, unintentional trigger of street inverse write method

### DIFF
--- a/partner_street_number/views/res_partner.xml
+++ b/partner_street_number/views/res_partner.xml
@@ -24,6 +24,7 @@
                <xpath expr="/form/sheet//div/field[@name='street']"
                        position="attributes">
                     <attribute name="invisible">1</attribute>
+                    <attribute name="readonly">1</attribute>
                 </xpath>
 
                 <xpath expr="//form[@string='Contact']/sheet/group/div/field[@name='street']"
@@ -40,6 +41,7 @@
                 <xpath expr="//form[@string='Contact']/sheet/group/div/field[@name='street']"
                        position="attributes">
                     <attribute name="invisible">1</attribute>
+                    <attribute name="readonly">1</attribute>
                 </xpath>
 
                 <xpath expr="//field[@name='child_ids']" position="attributes">


### PR DESCRIPTION
Regression of https://github.com/OCA/partner-contact/pull/135. Now that the street field is present on the partner form (but invisible) it is updated in realtime when the user enters a street name or street number. The modified value is then sent to the server, which triggers the inverse write method of the street field.

When entering street name 'Street' and street number 'a1', the value of the street field is updated dynamically to 'Street a1'. This value is not segmented properly by the fallback write method of the street computed field, and the result is that the street name is now 'Street a1' and the street number is empty.

By setting the field to readonly, the dynamic update of the field is not passed back to the server as a write() value.