### PR TITLE
[FIX] Unintended trigger of 'street' inverse write function

### DIFF
--- a/partner_street_number/__openerp__.py
+++ b/partner_street_number/__openerp__.py
@@ -21,7 +21,7 @@
 {
     "name": "Street name and number",
     "summary": "Introduces separate fields for street name and street number.",
-    "version": "8.0.0.1.0",
+    "version": "8.0.1.0.0",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "website": "https://github.com/oca/partner-contact",
     "category": 'Tools',

--- a/partner_street_number/views/res_partner.xml
+++ b/partner_street_number/views/res_partner.xml
@@ -24,6 +24,7 @@
                <xpath expr="/form/sheet//div/field[@name='street']"
                        position="attributes">
                     <attribute name="invisible">1</attribute>
+                    <attribute name="readonly">1</attribute>
                 </xpath>
 
                 <xpath expr="//form[@string='Contact']/sheet/group/div/field[@name='street']"
@@ -40,6 +41,7 @@
                 <xpath expr="//form[@string='Contact']/sheet/group/div/field[@name='street']"
                        position="attributes">
                     <attribute name="invisible">1</attribute>
+                    <attribute name="readonly">1</attribute>
                 </xpath>
 
                 <xpath expr="//field[@name='child_ids']" position="attributes">


### PR DESCRIPTION
Regression of https://github.com/OCA/partner-contact/pull/135. The street field is now present on the partner form (if invisible). When the street name or street number is modified by the user, the street field is updated in realtime because of the @api.depends. Because the field was not readonly, this triggered a write in the ORM when the record was saved. The fallback inverse method was triggered, overwriting the street name and street number fields.

When entering a combination that could not be parsed by this method (for instance street name = 'Street', street number = 'a1'), street_name would contain 'Street a1' and street_number would be empty after saving.

Setting the field to readonly prevents the updated value to be sent to the server in the write() call.