### PR TITLE
[FIX] partner_financial_risk: Allow contact creation

### DIFF
--- a/partner_financial_risk/__openerp__.py
+++ b/partner_financial_risk/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Partner Financial Risk',
     'summary': 'Manage partner risk',
-    'version': '9.0.2.0.0',
+    'version': '9.0.2.0.1',
     'category': 'Sales Management',
     'license': 'AGPL-3',
     'author': 'Tecnativa, Odoo Community Association (OCA)',

--- a/partner_financial_risk/models/res_partner.py
+++ b/partner_financial_risk/models/res_partner.py
@@ -107,7 +107,7 @@ class ResPartner(models.Model):
 
     @api.multi
     @api.depends(
-        'invoice_ids', 'invoice_ids.state',
+        'customer', 'invoice_ids', 'invoice_ids.state',
         'invoice_ids.amount_total',
         'child_ids.invoice_ids', 'child_ids.invoice_ids.state',
         'child_ids.invoice_ids.amount_total')
@@ -115,11 +115,13 @@ class ResPartner(models.Model):
         all_partners_and_children = {}
         all_partner_ids = []
         for partner in self.filtered('customer'):
+            if not partner.id:
+                continue
             all_partners_and_children[partner] = self.with_context(
                 active_test=False).search([('id', 'child_of', partner.id)]).ids
             all_partner_ids += all_partners_and_children[partner]
         if not all_partner_ids:
-            return  # pragma: no cover
+            return
         total_group = self.env['account.invoice'].sudo().read_group(
             [('type', 'in', ['out_invoice', 'out_refund']),
              ('state', 'in', ['draft', 'proforma', 'proforma2']),

--- a/partner_financial_risk/tests/test_partner_financial_risk.py
+++ b/partner_financial_risk/tests/test_partner_financial_risk.py
@@ -142,3 +142,8 @@ class TestPartnerFinancialRisk(SavepointCase):
         line.date_maturity = '2017-01-01'
         self.assertAlmostEqual(self.partner.risk_account_amount, 0.0)
         self.assertAlmostEqual(self.partner.risk_account_amount_unpaid, 100.0)
+
+    def test_recompute_newid(self):
+        """Computing risk shouldn't fail if record is a NewId."""
+        new = self.env["res.partner"].new({"customer": True})
+        new._compute_risk_invoice()


### PR DESCRIPTION
Without this patch, when creating a new contact from the partner form, users got this traceback:

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/opt/odoo/custom/src/odoo/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/auto/addons/partner_financial_risk/models/res_partner.py", line 119, in _compute_risk_invoice
    active_test=False).search([('id', 'child_of', partner.id)]).ids
  File "/opt/odoo/custom/src/odoo/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/openerp/api.py", line 490, in new_api
    result = method(self._model, cr, uid, *args, **old_kwargs)
  File "/opt/odoo/custom/src/odoo/openerp/models.py", line 1668, in search
    return self._search(cr, user, args, offset=offset, limit=limit, order=order, context=context, count=count)
  File "/opt/odoo/custom/src/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/openerp/addons/base/res/res_partner.py", line 626, in _search
    count=count, access_rights_uid=access_rights_uid)
  File "/opt/odoo/custom/src/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/openerp/models.py", line 4793, in _search
    query = self._where_calc(cr, user, args, context=context)
  File "/opt/odoo/custom/src/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/openerp/models.py", line 4564, in _where_calc
    e = expression.expression(cr, user, domain, self, context)
  File "/opt/odoo/custom/src/odoo/openerp/osv/expression.py", line 644, in __init__
    self.parse(cr, uid, context=context)
  File "/opt/odoo/custom/src/odoo/openerp/osv/expression.py", line 834, in parse
    ids2 = to_ids(right, model, context)
  File "/opt/odoo/custom/src/odoo/openerp/osv/expression.py", line 708, in to_ids
    return list(value)
TypeError: 'NewId' object is not iterable
```

~~Instead, now to get the partner children, we call its `.ids` attribute, [which filters out falsey ids][1], [such as `NewId` objects][2].~~

Patch includes test and ~~indentation fix. It also includes~~ a recomputation when the partner is or not set as customer, since the field is used in the method.

[1]: https://github.com/odoo/odoo/blob/2deb95b852208a8dbfb9640ac8947533c1ad428b/openerp/models.py#L5415
[2]: https://github.com/odoo/odoo/blob/2deb95b852208a8dbfb9640ac8947533c1ad428b/openerp/models.py#L264

@Tecnativa