### PR TITLE
[10.0][FIX] Prevent flake8 error for non-critical bare except.

### DIFF
--- a/base_location_nuts/wizard/nuts_import.py
+++ b/base_location_nuts/wizard/nuts_import.py
@@ -97,7 +97,10 @@ class NutsImport(models.TransientModel):
                 if field_type == 'integer':
                     try:
                         value = int(value)
-                    except:  # flake8: noqa
+                    except (ValueError, TypeError):
+                        logger.warn(
+                            "Value %s for field %s replaced by 0" %
+                            (value, k))
                         value = 0
             else:
                 logger.debug("xpath = '%s', not found" % field_xpath)

--- a/base_location_nuts/wizard/nuts_import.py
+++ b/base_location_nuts/wizard/nuts_import.py
@@ -97,7 +97,7 @@ class NutsImport(models.TransientModel):
                 if field_type == 'integer':
                     try:
                         value = int(value)
-                    except:
+                    except:  # flake8: noqa
                         value = 0
             else:
                 logger.debug("xpath = '%s', not found" % field_xpath)


### PR DESCRIPTION
I am getting Travis errors on flake8 because of a bare except in the base_location_nuts module. The bare except in this particulare case should not be any problem. Added just a #noqa comment to ignore it.