### PR TITLE
[FIX] don't override defaults from context

### DIFF
--- a/partner_firstname/__manifest__.py
+++ b/partner_firstname/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Partner first name and last name',
     'summary': "Split first name and last name for non company partners",
-    'version': '10.0.2.1.0',
+    'version': '10.0.2.1.1',
     'author': "Camptocamp, "
               "Grupo ESOC Ingeniería de Servicios, "
               "Tecnativa, "

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -68,13 +68,16 @@ class ResPartner(models.Model):
         """Invert name when getting default values."""
         result = super(ResPartner, self).default_get(fields_list)
 
+        if not result.get('name'):
+            return result
+
         inverted = self._get_inverse_name(
-            self._get_whitespace_cleaned_name(result.get("name", "")),
+            self._get_whitespace_cleaned_name(result["name"]),
             result.get("is_company", False))
 
-        for field in inverted.keys():
-            if field in fields_list:
-                result[field] = inverted.get(field)
+        for field in inverted:
+            if field in fields_list and field not in result:
+                result[field] = inverted[field]
 
         return result
 


### PR DESCRIPTION
the current implementation makes it impossible to set default values for first and last name.

To me this function looks a bit botched anyways, I think it only makes sense to do anything here if `result.get('name')` is truthy. Can anyone remember why it's unconditional?