### PR TITLE
[10.0] partner_changeset - Adapt tests to play nicely with other module tests

### DIFF
--- a/partner_changeset/__manifest__.py
+++ b/partner_changeset/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {'name': 'Partner Changesets',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'author': 'Camptocamp, Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'category': 'Sales Management',

--- a/partner_changeset/models/res_partner.py
+++ b/partner_changeset/models/res_partner.py
@@ -27,7 +27,9 @@ class ResPartner(models.Model):
 
     @api.multi
     def write(self, values):
-        if self.env.context.get('__no_changeset'):
+        if (self.env.context.get('__no_changeset') or
+                self.env.context.get('test_enable') and
+                not self.env.context.get('test_partner_changeset')):
             return super(ResPartner, self).write(values)
         else:
             changeset_model = self.env['res.partner.changeset']

--- a/partner_changeset/tests/test_changeset_origin.py
+++ b/partner_changeset/tests/test_changeset_origin.py
@@ -30,6 +30,8 @@ class TestChangesetOrigin(ChangesetMixin, common.TransactionCase):
         self.partner = self.env['res.partner'].create({
             'name': 'X',
         })
+        # Add context for this test for compatibility with other modules' tests
+        self.partner = self.partner.with_context(test_partner_changeset=True)
 
     def test_origin_value_of_change_with_apply(self):
         """ Origin field is read from the parter or 'old' - with apply


### PR DESCRIPTION
This should fix:

``` python
ERROR: test_apply_boolean (odoo.addons.partner_changeset.tests.test_changeset_field_type.TestChangesetFieldType)
` Apply a change on a Boolean field
Traceback (most recent call last):
`   File "/home/travis/build/OCA/partner-contact/partner_changeset/tests/test_changeset_field_type.py", line 205, in test_apply_boolean
`     changeset.change_ids.apply()
`   File "/home/travis/build/OCA/partner-contact/partner_changeset/models/res_partner_changeset.py", line 404, in apply
`     _('This change cannot be applied because a previous '
` UserError: (u'This change cannot be applied because a previous changeset for the same partner is pending.\nApply all the anterior changesets before applying this one.', '')
FAILED
```

Error is raised in case a module create an unexpected changeset in its tests.