### PR TITLE
[9.0][FIX] partner_sector: fixing invalid filter_domain

### DIFF
--- a/partner_sector/__openerp__.py
+++ b/partner_sector/__openerp__.py
@@ -6,7 +6,7 @@
 {
     "name": "Partner Sector",
     "summary": "Add partner sectors",
-    "version": "9.0.1.0.2",
+    "version": "9.0.1.1.2",
     "category": "Customer Relationship Management",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/partner_sector/views/res_partner_view.xml
+++ b/partner_sector/views/res_partner_view.xml
@@ -39,7 +39,7 @@
                 <field name="sector_id"
                        string="Sector"
                        filter_domain="['|',('sector_id','ilike',self),
-                                           ('secondary_sector_ids','ilike',self)]"/>
+                                           ('secondary_sector_ids.name','ilike',self)]"/>
             </field>
             <filter name="salesperson" position="after">
                 <filter name="sector"


### PR DESCRIPTION
Fixes error when filtering using "Sector" filter.

```   
raise ValueError("Invalid leaf %s" % str(self.leaf))
ValueError: Invalid leaf [
```