### PR TITLE
[10.0] partner_changeset - Fix condition on test_enable

### DIFF
--- a/partner_changeset/models/res_partner.py
+++ b/partner_changeset/models/res_partner.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.tools import config
 
 
 class ResPartner(models.Model):
@@ -28,7 +29,7 @@ class ResPartner(models.Model):
     @api.multi
     def write(self, values):
         if (self.env.context.get('__no_changeset') or
-                self.env.context.get('test_enable') and
+                config['test_enable'] and
                 not self.env.context.get('test_partner_changeset')):
             return super(ResPartner, self).write(values)
         else:

--- a/partner_changeset/tests/test_changeset_field_type.py
+++ b/partner_changeset/tests/test_changeset_field_type.py
@@ -44,7 +44,7 @@ class TestChangesetFieldType(ChangesetMixin, common.TransactionCase):
         self.partner = self.env['res.partner'].create({
             'name': 'Original Name',
             'street': 'Original Street',
-        })
+        }).with_context(test_partner_changeset=True)
 
     def test_new_changeset_char(self):
         """ Add a new changeset on a Char field """

--- a/partner_changeset/tests/test_changeset_flow.py
+++ b/partner_changeset/tests/test_changeset_flow.py
@@ -51,7 +51,7 @@ class TestChangesetFlow(ChangesetMixin, common.TransactionCase):
             'name': 'X',
             'street': 'street X',
             'street2': 'street2 X',
-        })
+        }).with_context(test_partner_changeset=True)
 
     def test_new_changeset(self):
         """ Add a new changeset on a partner


### PR DESCRIPTION
Context key `test_enable` will always be empty.

Thus previous patch had no effect.
Still this might speed the tests of other modules as we will only trigger changeset methods in thoses tests.