### PR TITLE
[FIX] disable create position on contact

### DIFF
--- a/partner_contact_in_several_companies/README.rst
+++ b/partner_contact_in_several_companies/README.rst
@@ -37,7 +37,12 @@ For further information, please visit:
 Known issues / Roadmap
 ======================
 
-* No known issues.
+* You can not add position directly from individual partner, you can just see other positions and update them
+
+Improve:
+
+* Add an wizard / form to clean create new position from individual partner form.
+  In this cas you will have to select an existing company (or create one on the fly)
 
 Bug Tracker
 ===========

--- a/partner_contact_in_several_companies/views/res_partner.xml
+++ b/partner_contact_in_several_companies/views/res_partner.xml
@@ -51,7 +51,7 @@
         <page name='internal_notes' position="before">
             <page string="Other Positions" attrs="{'invisible': ['|',('is_company','=',True),('contact_id','!=',False)]}">
                 <field name="other_contact_ids" context="{'default_contact_id': active_id, 'default_name': name, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_supplier': supplier}" mode="kanban">
-                    <kanban>
+                    <kanban create="false">
                         <field name="color"/>
                         <field name="name"/>
                         <field name="title"/>


### PR DESCRIPTION
- This is just to see all positions
- If we want to add position go to one company and add contact linked to this partner

Issues:

- fixes #573 