### PR TITLE
[9.0][IMP] partner_sector: allow to search for Main sector and children.

### DIFF
--- a/partner_sector/README.rst
+++ b/partner_sector/README.rst
@@ -55,6 +55,7 @@ Contributors
 * Javier Iniesta <javieria@antiun.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Lois Rilo <lois.rilo@eficent.com>
 
 Maintainer
 ----------

--- a/partner_sector/__openerp__.py
+++ b/partner_sector/__openerp__.py
@@ -6,7 +6,7 @@
 {
     "name": "Partner Sector",
     "summary": "Add partner sectors",
-    "version": "9.0.1.1.2",
+    "version": "9.0.1.2.0",
     "category": "Customer Relationship Management",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/partner_sector/models/res_partner.py
+++ b/partner_sector/models/res_partner.py
@@ -9,12 +9,19 @@ from openerp import models, fields, api, exceptions, _
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    sector_id = fields.Many2one(comodel_name='res.partner.sector',
-                                string='Main Sector')
-
+    sector_id = fields.Many2one(
+        comodel_name='res.partner.sector',
+        string='Main Sector',
+    )
+    sector_complete_name = fields.Char(
+        string="Main Sector Complete Name",
+        related="sector_id.complete_name",
+        readonly=True,
+    )
     secondary_sector_ids = fields.Many2many(
         comodel_name='res.partner.sector', string="Secondary Sectors",
-        domain="[('id', '!=', sector_id)]")
+        domain="[('id', '!=', sector_id)]",
+    )
 
     @api.constrains('sector_id', 'secondary_sector_ids')
     def _check_sectors(self):

--- a/partner_sector/models/res_partner_sector.py
+++ b/partner_sector/models/res_partner_sector.py
@@ -23,6 +23,17 @@ class ResPartnerSector(models.Model):
                                 string="Children")
     parent_left = fields.Integer('Parent Left', select=True)
     parent_right = fields.Integer('Parent Right', select=True)
+    complete_name = fields.Char(
+        string="Complete Name",
+        compute='_compute_complete_name',
+        store=True,
+    )
+
+    @api.multi
+    @api.depends("name", "parent_id", "parent_id.name")
+    def _compute_complete_name(self):
+        for rec in self:
+            rec.complete_name = rec.display_name
 
     @api.multi
     def name_get(self):
@@ -30,7 +41,7 @@ class ResPartnerSector(models.Model):
             """ Return the list [cat.name, cat.parent_id.name, ...] """
             res = []
             while cat:
-                res.append(cat.name)
+                res.append(cat.name or '/')
                 cat = cat.parent_id
             return res
 

--- a/partner_sector/views/res_partner_sector_view.xml
+++ b/partner_sector/views/res_partner_sector_view.xml
@@ -16,6 +16,7 @@
         <field name="arch" type="xml">
             <tree string="Sectors" editable="top">
                 <field name="name"/>
+                <field name="complete_name"/>
                 <field name="parent_id"/>
             </tree>
         </field>

--- a/partner_sector/views/res_partner_view.xml
+++ b/partner_sector/views/res_partner_view.xml
@@ -36,6 +36,7 @@
         <field name="inherit_id" ref="base.view_res_partner_filter"/>
         <field name="arch" type="xml">
             <field name="category_id" position="after">
+                <field name="sector_complete_name"/>
                 <field name="sector_id"
                        string="Sector"
                        filter_domain="['|',('sector_id','ilike',self),


### PR DESCRIPTION
Field added:
* `sector_complete_name` on res.partner.sector: Provides a way to consider children sectors when searching. ex: if you search by sector_complete_name ilike "Engineering" you will get all customer for "Engineering" and "Engineering / Aerospacial".

It is stored in order to have them available to filter on BI reports.