### PR TITLE
Rename correct python dependency

### DIFF
--- a/partner_create_by_vat/__manifest__.py
+++ b/partner_create_by_vat/__manifest__.py
@@ -15,7 +15,7 @@
     'application': False,
     'installable': True,
     'external_dependencies': {
-        'python': ['stdnum', 'suds'],
+        'python': ['python-stdnum', 'suds'],
     },
     'depends': ['base_vat'],
     'data': ['views/res_partner_view.xml'],


### PR DESCRIPTION
The correct python dependency is python-stdnum not stdnum: https://pypi.org/project/python-stdnum/