### PR TITLE
[IMP] partner_affiliate - Changes to avoid some data being changed when swapping the parent from the Affiliate. 

### DIFF
--- a/partner_affiliate/README.rst
+++ b/partner_affiliate/README.rst
@@ -42,6 +42,7 @@ Contributors
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
 * Raul Martin <raul.martin@braintec-group.com>
+* Miguel Ángel Gómez <miguel.gomez@braintec-group.com>
 * Dave Lasley <dave@laslabs.com>
 
 Maintainer

--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -3,12 +3,14 @@
 # Copyright 2018 brain-tec AG - Raul Martin
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class ResPartner(models.Model):
     """Add relation affiliate_ids."""
     _inherit = "res.partner"
+
+    type = fields.Selection(selection_add=[('affiliate', 'Affiliate')])
 
     # force "active_test" domain to bypass _search() override
     child_ids = fields.One2many('res.partner', 'parent_id',

--- a/partner_affiliate/tests/__init__.py
+++ b/partner_affiliate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_partner_affiliate

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -7,83 +7,89 @@ class TestPartnerAffiliate(common.TransactionCase):
         super(TestPartnerAffiliate, self).setUp()
         self.partner_obj = self.env['res.partner']
 
-        self.first_parent = self.partner_obj.create({
-            'name': 'MyFirstParentForTheAffiliate',
+        self.first_company = self.partner_obj.create({
+            'name': 'MyFirstCompanyForTheAffiliate',
             'type': 'contact',
             'is_company': True,
-            'street': 'first parent street',
-            'street2': 'number 99',
-            'zip': 123,
-            'city': 'Test City',
+            'street': 'first company street',
         })
 
-        self.second_parent = self.partner_obj.create({
-            'name': 'MySecondParentForTheAffiliate',
+        self.second_company = self.partner_obj.create({
+            'name': 'MySecondCompanyForTheAffiliate',
             'type': 'contact',
             'is_company': True,
-            'street': 'second parent street',
-            'street2': 'number 44',
-            'zip': 999,
-            'city': 'Test City',
+            'street': 'second company street',
         })
 
     # Check data integrity of the objects when an affiliate is given a new
     # parent. So both objects keeps their data.
     def test_change_parent_from_a_new_affiliate(self):
-        new_affiliate = self.partner_obj.create({
-            'name': 'MyTestAffiliate',
+        my_affiliate = self.partner_obj.create({
+            'name': 'MyAffiliate',
             'is_company': True,
-            'parent_id': self.first_parent.id,
+            'parent_id': self.first_company.id,
             'type': 'affiliate',
             'street': 'affiliate street',
-            'street2': 'number 11',
-            'zip': 567,
-            'city': 'Test City',
-            'email': 'myAffiliate@test.com',
         })
 
         # Checks for data integrity in affiliate and his parent.
-        self.assertTrue(new_affiliate, "The new affiliate have been created.")
+        self.assertTrue(my_affiliate, "The new affiliate have been created.")
 
-        self.assertEquals(new_affiliate.type, 'affiliate',
+        self.assertEquals(my_affiliate.type, 'affiliate',
                           "Check type must be 'affiliate'")
-        self.assertEquals(new_affiliate.parent_id.id, self.first_parent.id,
+        self.assertEquals(my_affiliate.parent_id.id, self.first_company.id,
                           "Must be child of the parent defined in the setup")
-        self.assertEquals(new_affiliate.street, "affiliate street",
+        self.assertEquals(my_affiliate.street, "affiliate street",
                           "The street have been correctly set.")
-        self.assertEquals(self.first_parent.street, "first parent street",
+        self.assertEquals(self.first_company.street, "first company street",
                           "The parent continues with his original street")
 
         # Change the parent of the affiliate for the second one in the set-up.
-        new_affiliate.parent_id = self.second_parent.id
-        new_affiliate.onchange_parent_id()
+        my_affiliate.parent_id = self.second_company.id
+        my_affiliate.onchange_parent_id()
 
         # The parent have been changed. And is not the first one.
-        self.assertEquals(new_affiliate.parent_id.id, self.second_parent.id)
+        self.assertEquals(my_affiliate.parent_id.id, self.second_company.id)
 
-        # The affiliate keeps its data for the street. Not modified.
-        self.assertEquals(new_affiliate.street, "affiliate street",
+        # The affiliate keeps its data for the street (address). Not modified.
+        self.assertEquals(my_affiliate.street, "affiliate street",
                           "keeps the same street")
         # The data for the street of the first parent have not been changed.
-        self.assertEquals(self.first_parent.street, "first parent street",
+        self.assertEquals(self.first_company.street, "first company street",
                           "keeps the same street")
-
 
     # Check that the default value for 'type' defined by default in the view
     # is set correctly when a new affiliate is created.
     def test_new_affiliate_is_created_with_type_affiliate_by_default(self):
         new_affiliate = self.partner_obj.with_context(
-            {'default_parent_id': self.first_parent.id,
+            {'default_parent_id': self.first_company.id,
              'default_is_company': True,
              'default_type': 'affiliate'
              }
         ).create({
             'name': 'MyTestAffiliate',
             'street': 'affiliate street',
-            'street2': 'number 11',
-            'zip': 567,
-            'city': 'Test City',
-            'email': 'myAffiliate@test.com',
         })
 
         self.assertEquals(new_affiliate.type, 'affiliate')
+
+    # Check that when changing the parent from an individual, it changes also
+    # the address keeping the expected behaviour.
+    def test_individual_changes_address_when_changing_parent_id(self):
+        my_individual = self.partner_obj.create({
+            'name': 'MyIndividual',
+            'parent_id': self.first_company.id,
+            'type': 'contact',
+            'is_company': False,
+            'street': 'individual street',
+        })
+
+        my_individual.parent_id = self.second_company.id
+        my_individual.onchange_parent_id()
+
+        # The parent have been changed.
+        self.assertEquals(my_individual.parent_id.id, self.second_company.id)
+
+        # The affiliate gets the address from the new parent.
+        self.assertEquals(my_individual.street, "second company street",
+                          "keeps the same street")

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -1,0 +1,89 @@
+from odoo.tests import common
+
+
+class TestPartnerAffiliate(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPartnerAffiliate, self).setUp()
+        self.partner_obj = self.env['res.partner']
+
+        self.first_parent = self.partner_obj.create({
+            'name': 'MyFirstParentForTheAffiliate',
+            'type': 'contact',
+            'is_company': True,
+            'street': 'first parent street',
+            'street2': 'number 99',
+            'zip': 123,
+            'city': 'Test City',
+        })
+
+        self.second_parent = self.partner_obj.create({
+            'name': 'MySecondParentForTheAffiliate',
+            'type': 'contact',
+            'is_company': True,
+            'street': 'second parent street',
+            'street2': 'number 44',
+            'zip': 999,
+            'city': 'Test City',
+        })
+
+    # Check data integrity of the objects when an affiliate is given a new
+    # parent. So both objects keeps their data.
+    def test_change_parent_from_a_new_affiliate(self):
+        new_affiliate = self.partner_obj.create({
+            'name': 'MyTestAffiliate',
+            'is_company': True,
+            'parent_id': self.first_parent.id,
+            'type': 'affiliate',
+            'street': 'affiliate street',
+            'street2': 'number 11',
+            'zip': 567,
+            'city': 'Test City',
+            'email': 'myAffiliate@test.com',
+        })
+
+        # Checks for data integrity in affiliate and his parent.
+        self.assertTrue(new_affiliate, "The new affiliate have been created.")
+
+        self.assertEquals(new_affiliate.type, 'affiliate',
+                          "Check type must be 'affiliate'")
+        self.assertEquals(new_affiliate.parent_id.id, self.first_parent.id,
+                          "Must be child of the parent defined in the setup")
+        self.assertEquals(new_affiliate.street, "affiliate street",
+                          "The street have been correctly set.")
+        self.assertEquals(self.first_parent.street, "first parent street",
+                          "The parent continues with his original street")
+
+        # Change the parent of the affiliate for the second one in the set-up.
+        new_affiliate.parent_id = self.second_parent.id
+        new_affiliate.onchange_parent_id()
+
+        # The parent have been changed. And is not the first one.
+        self.assertEquals(new_affiliate.parent_id.id, self.second_parent.id)
+
+        # The affiliate keeps its data for the street. Not modified.
+        self.assertEquals(new_affiliate.street, "affiliate street",
+                          "keeps the same street")
+        # The data for the street of the first parent have not been changed.
+        self.assertEquals(self.first_parent.street, "first parent street",
+                          "keeps the same street")
+
+
+    # Check that the default value for 'type' defined by default in the view
+    # is set correctly when a new affiliate is created.
+    def test_new_affiliate_is_created_with_type_affiliate_by_default(self):
+        new_affiliate = self.partner_obj.with_context(
+            {'default_parent_id': self.first_parent.id,
+             'default_is_company': True,
+             'default_type': 'affiliate'
+             }
+        ).create({
+            'name': 'MyTestAffiliate',
+            'street': 'affiliate street',
+            'street2': 'number 11',
+            'zip': 567,
+            'city': 'Test City',
+            'email': 'myAffiliate@test.com',
+        })
+
+        self.assertEquals(new_affiliate.type, 'affiliate')

--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -14,7 +14,7 @@
             <xpath expr='//page[@name="internal_notes"]' position="before">
                 <page string="Affiliates" attrs="{'invisible': [('is_company','=',False)]}">
                     <field name="affiliate_ids"
-                           context="{'default_parent_id': active_id, 'default_is_company': True, 'default_type':'other'}" mode="kanban">
+                           context="{'default_parent_id': active_id, 'default_is_company': True, 'default_type':'affiliate'}" mode="kanban">
                         <kanban>
                             <field name="color"/>
                             <field name="name"/>

--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -14,7 +14,7 @@
             <xpath expr='//page[@name="internal_notes"]' position="before">
                 <page string="Affiliates" attrs="{'invisible': [('is_company','=',False)]}">
                     <field name="affiliate_ids"
-                           context="{'default_parent_id': active_id, 'default_is_company': True, 'default_type':'affiliate'}" mode="kanban">
+                           context="{'default_parent_id': active_id, 'default_is_company': True}" mode="kanban">
                         <kanban>
                             <field name="color"/>
                             <field name="name"/>


### PR DESCRIPTION
Created new Affiliate type and set it as default when creating a new affiliate.
Fixing functionality not to change address of existing company when assigning a parent