### PR TITLE
[FIX] fix name constrains

### DIFF
--- a/partner_firstname/exceptions.py
+++ b/partner_firstname/exceptions.py
@@ -8,5 +8,7 @@ class EmptyNamesError(exceptions.ValidationError):
     def __init__(self, record, value=_("No name is set.")):
         self.record = record
         self._value = value
-        self.name = _("Error(s) with partner %d's name.") % record.id
+        self.name = _(
+            "Error(s): at least one name (name, firstname or "
+            "lastname)  is mandatory for partner (id : %d).") % record.id
         self.args = (self.name, value)

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -203,10 +203,9 @@ class ResPartner(models.Model):
     def _check_name(self):
         """Ensure at least one name is set."""
         for record in self:
-            if all((
-                record.type == 'contact' or record.is_company,
-                not (record.firstname or record.lastname)
-            )):
+            if (
+                not (record.firstname or record.lastname or record.name)
+            ):
                 raise exceptions.EmptyNamesError(record)
 
     @api.onchange("firstname", "lastname")


### PR DESCRIPTION
If we create contact from company partner, the type is 'contact'. But if we create a partner directly from customer menu this type is "false" and constraint doesn't work.
Otherwise, in my case I have a strange bug where First-name and last-name are not required (in form view) but only for 1 partner. This partner was created by an user (without any name and I get error on bank reconciliation). I can't reproduce this issue and don't know what way was used to create it. (when I change partner First-name and last name become required again !!)
![image](https://user-images.githubusercontent.com/15939329/41157561-752117b8-6b26-11e8-9686-36b0244d8909.png)
