### PR TITLE
[FIX] README.rst blank line after bullet

### DIFF
--- a/base_partner_merge/README.rst
+++ b/base_partner_merge/README.rst
@@ -47,6 +47,7 @@ Author
 ------
 
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
+
 Based Holger Brunn's idea.
 
 Contributors


### PR DESCRIPTION
It's making runbot builds fail:

```
<string>:50: (WARNING/2) Bullet list ends without a blank line; unexpected unindent.
2018-07-12 14:06:05,509 166 WARNING openerp_test odoo.addons.base.module.module: docutils' system message present: <system_message level="2" line="50" source="<string>" type="WARNING"><paragraph>Bullet list ends without a blank line; unexpected unindent.</paragraph></system_message>
```

cc @Tecnativa