### PR TITLE
[10.0] base_location: improve res.partner form view

### DIFF
--- a/base_location/__manifest__.py
+++ b/base_location/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Location management (aka Better ZIP)',
-    'version': '10.0.1.0.2',
+    'version': '10.0.1.0.3',
     'depends': [
         'base',
     ],

--- a/base_location/__manifest__.py
+++ b/base_location/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Location management (aka Better ZIP)',
-    'version': '10.0.1.0.3',
+    'version': '10.0.1.0.4',
     'depends': [
         'base',
     ],

--- a/base_location/views/partner_view.xml
+++ b/base_location/views/partner_view.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <field name="city" position="before">
                 <field name="zip_id"
+                    attrs="{'readonly': [('type', '=', 'contact'), ('parent_id', '!=', False)]}"
                     options="{'create_name_field': 'city', 'no_open': True, 'no_create': True}"
                     placeholder="City completion"
                     class="oe_edit_only" />


### PR DESCRIPTION
zip_id readonly when the partner is a contact of a parent partner like the other address fields, cf https://github.com/odoo/odoo/blob/10.0/odoo/addons/base/res/res_partner_view.xml#L169