### PR TITLE
Coc filter working

### DIFF
--- a/partner_coc/models/res_partner.py
+++ b/partner_coc/models/res_partner.py
@@ -13,7 +13,6 @@ class ResPartner(models.Model):
             'coc_registration_number', 'coc',
         ),
         search=lambda s, *a: s._search_identification(
-            #'coc_registration_number', 'coc', *a  #note: *a accepts an operator and searc_value
             'coc', *a
         ),
     )

--- a/partner_coc/models/res_partner.py
+++ b/partner_coc/models/res_partner.py
@@ -13,6 +13,7 @@ class ResPartner(models.Model):
             'coc_registration_number', 'coc',
         ),
         search=lambda s, *a: s._search_identification(
-            'coc_registration_number', 'coc', *a
+            #'coc_registration_number', 'coc', *a  #note: *a accepts an operator and searc_value
+            'coc', *a
         ),
     )


### PR DESCRIPTION
In Sales/Customer using custom filter on CoC registration number gives a dump 
because *a propagates 2 arguments (operator and value) resulting in total of 5 while the 
definition in partner-identification res.partner.py is:
_search_identification(self, category_code, operator, value)
Hence the 'coc_registration_number' is superfluous.