### PR TITLE
[9.0] partner_sector: allow to use in individuals

### DIFF
--- a/partner_changeset/README.rst
+++ b/partner_changeset/README.rst
@@ -136,7 +136,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/partner-contact/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed `feedback
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======

--- a/partner_contact_height/README.rst
+++ b/partner_contact_height/README.rst
@@ -21,11 +21,6 @@ To use this module, you need to:
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/134/9.0
 
-Known issues / Roadmap
-======================
-
-* ...
-
 Bug Tracker
 ===========
 

--- a/partner_contact_nutrition/README.rst
+++ b/partner_contact_nutrition/README.rst
@@ -26,11 +26,6 @@ To use this module, you need to:
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/134/9.0
 
-Known issues / Roadmap
-======================
-
-* ...
-
 Bug Tracker
 ===========
 

--- a/partner_contact_weight/README.rst
+++ b/partner_contact_weight/README.rst
@@ -21,11 +21,6 @@ To use this module, you need to:
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/134/9.0
 
-Known issues / Roadmap
-======================
-
-* ...
-
 Bug Tracker
 ===========
 

--- a/partner_identification/README.rst
+++ b/partner_identification/README.rst
@@ -15,7 +15,7 @@ and vary from country to country.
 * Fiscal ID's
 * Membership numbers
 * Driver license
-* ...
+* …
 
 
 Installation

--- a/partner_identification/__openerp__.py
+++ b/partner_identification/__openerp__.py
@@ -19,10 +19,10 @@
         'security/ir.model.access.csv',
     ],
     'author': 'ChriCar Beteiligungs- und Beratungs- GmbH, '
-              'Antiun Ingeniería S.L.',
-              'Camptocamp,'
-              'ACSONE SA/NV,'
-              'Odoo Community Association (OCA)'
+              'Antiun Ingeniería S.L., '
+              'Camptocamp, '
+              'ACSONE SA/NV, '
+              'Odoo Community Association (OCA)',
     'website': 'https://odoo-community.org/',
     'license': 'AGPL-3',
     'installable': True,

--- a/partner_sector/README.rst
+++ b/partner_sector/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
-    :alt: License: AGPL-3
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
 
 ==============
 Partner Sector
@@ -48,12 +48,18 @@ Known issues / Roadmap
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/partner-contact/issues>`_.
-In case of trouble, please check there if your issue has already been reported. If you
-spotted it first, help us smashing it by providing a detailed and welcomed feedback.
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/partner-contact/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
 
 Contributors
 ------------
@@ -78,4 +84,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/partner_sector/README.rst
+++ b/partner_sector/README.rst
@@ -16,6 +16,16 @@ To manage sectors, you need to:
 
 * Go to *Sales > Configuration > Address Book > Sectors*.
 
+By default only companies have sectors. To activate sectors in individuals also,
+you need to activate the following setting:
+
+* Go to *Settings > General Settings > Sector in contacts > Use sector for individuals*
+
+Or, if you have *Sales* or *CRM* modules installed:
+
+* Go to *Sales > Configuration > Settings > Partner Sector > Use sector for individuals*
+
+
 
 Usage
 =====
@@ -23,8 +33,6 @@ Usage
 To use this module, you need to:
 
 * Go to any partner's form.
-
-Only companies have sectors.
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
@@ -55,6 +63,7 @@ Contributors
 * Javier Iniesta <javieria@antiun.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
 
 Maintainer
 ----------

--- a/partner_sector/__openerp__.py
+++ b/partner_sector/__openerp__.py
@@ -14,11 +14,14 @@
     "application": False,
     "installable": True,
     "depends": [
-        "base",
+        "base_setup",
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/partner_sector_security.xml",
         "views/res_partner_sector_view.xml",
         "views/res_partner_view.xml",
+        "views/base_config_settings.xml",
+        "views/sale_config_settings.xml"
     ]
 }

--- a/partner_sector/__openerp__.py
+++ b/partner_sector/__openerp__.py
@@ -6,9 +6,9 @@
 {
     "name": "Partner Sector",
     "summary": "Add partner sectors",
-    "version": "9.0.1.1.2",
+    "version": "9.0.2.0.0",
     "category": "Customer Relationship Management",
-    "website": "http://www.tecnativa.com",
+    "website": "https://github.com/OCA/partner-contact",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,

--- a/partner_sector/models/__init__.py
+++ b/partner_sector/models/__init__.py
@@ -5,3 +5,5 @@
 
 from . import res_partner
 from . import res_partner_sector
+from . import base_config_settings
+from . import sale_config_settings

--- a/partner_sector/models/base_config_settings.py
+++ b/partner_sector/models/base_config_settings.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+
+from openerp import fields, models
+
+
+class BaseConfigSettings(models.TransientModel):
+    _inherit = 'base.config.settings'
+
+    group_use_partner_sector_for_person = fields.Boolean(
+        'Use sector for individuals',
+        help="Set if you want to be able use sectors for "
+             "individuals also.",
+        implied_group='partner_sector.group_use_partner_sector_for_person')

--- a/partner_sector/models/sale_config_settings.py
+++ b/partner_sector/models/sale_config_settings.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+
+from openerp import fields, models
+
+
+class SaleConfigSettings(models.TransientModel):
+    _inherit = 'sale.config.settings'
+
+    group_use_partner_sector_for_person = fields.Boolean(
+        'Use sector for individuals',
+        help="Set if you want to be able to use sectors for "
+             "individuals also.",
+        implied_group='partner_sector.group_use_partner_sector_for_person')

--- a/partner_sector/security/partner_sector_security.xml
+++ b/partner_sector/security/partner_sector_security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    
+    <data noupdate="0">
+
+        <record id="group_use_partner_sector_for_person" model="res.groups">
+            <field name="name">Use sector for individuals</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
+    </data>
+</openerp>

--- a/partner_sector/views/base_config_settings.xml
+++ b/partner_sector/views/base_config_settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_general_configuration" model="ir.ui.view">
+            <field name="name">General Settings</field>
+            <field name="model">base.config.settings</field>
+            <field name="inherit_id" ref="base_setup.view_general_configuration"/>
+            <field name="arch" type="xml">
+                <group name="authentication" position="after">
+                    <group name="partner">
+                        <label for="id" string="Sector for individual"/>
+                        <div name="group_use_partner_sector_for_person">
+                            <field name="group_use_partner_sector_for_person" class="oe_inline"/>
+                            <label for="group_use_partner_sector_for_person"/>
+                        </div>
+                    </group>
+                </group>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/partner_sector/views/res_partner_view.xml
+++ b/partner_sector/views/res_partner_view.xml
@@ -15,6 +15,14 @@
                 <field name="secondary_sector_ids" widget="many2many_tags"
                        attrs="{'invisible': [('is_company', '=', False)]}"/>
             </field>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='title']" position="after">
+                <field name="is_company" invisible="1"/>
+                <field name="sector_id" placeholder="Sector"
+                       options='{"no_open": True}'
+                       attrs="{'invisible': [('is_company', '=', False)]}"/>
+                <field name="secondary_sector_ids" widget="many2many_tags"
+                       attrs="{'invisible': [('is_company', '=', False)]}"/>
+            </xpath>
         </field>
     </record>
 
@@ -46,6 +54,53 @@
                         string="Sector"
                         domain="[('is_company','=', True)]"
                         context="{'group_by': 'sector_id'}"/>
+            </filter>
+        </field>
+    </record>
+
+    <!-- Views activated for group_use_partner_sector_for_person -->
+
+    <record model="ir.ui.view" id="view_partner_form_sector_person">
+        <field name="name">Partner form with sector</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="partner_sector.view_partner_form_sector"/>
+        <field name="groups_id" eval="[(4, ref('partner_sector.group_use_partner_sector_for_person'))]"/>
+        <field name="arch" type="xml">
+            <field name="sector_id" position="attributes">
+                <attribute name="attrs">{'invisible': 0}</attribute>
+            </field>
+            <field name="secondary_sector_ids" position="attributes">
+                <attribute name="attrs">{'invisible': 0}</attribute>
+            </field>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='sector_id']" position="attributes">
+                <attribute name="attrs">{'invisible': 0}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='secondary_sector_ids']" position="attributes">
+                <attribute name="attrs">{'invisible': 0}</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_partner_tree_sector_person">
+        <field name="name">Partner tree with sector</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="partner_sector.view_partner_tree_sector"/>
+        <field name="groups_id" eval="[(4, ref('partner_sector.group_use_partner_sector_for_person'))]"/>
+        <field name="arch" type="xml">
+            <field name="sector_id" position="attributes">
+                <attribute name="attrs">{'invisible': 0}</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_res_partner_filter_sector_person">
+        <field name="name">Partner search with sector</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="partner_sector.view_res_partner_filter_sector"/>
+        <field name="groups_id" eval="[(4, ref('partner_sector.group_use_partner_sector_for_person'))]"/>
+        <field name="arch" type="xml">
+            <filter name="sector" position="attributes">
+                <attribute name="domain"/>
             </filter>
         </field>
     </record>

--- a/partner_sector/views/sale_config_settings.xml
+++ b/partner_sector/views/sale_config_settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_sale_config_settings" model="ir.ui.view">
+            <field name="name">partner sector settings</field>
+            <field name="model">sale.config.settings</field>
+            <field name="inherit_id" ref="base_setup.view_sale_config_settings"/>
+            <field name="arch" type="xml">
+                <div id="main" position="inside">
+                    <group name="partner_sector" string="Partner Sector">
+                        <label for="id" string="Sector for individuals"/>
+                        <div name="group_use_partner_sector_for_person">
+                            <field name="group_use_partner_sector_for_person" class="oe_inline"/>
+                            <label for="group_use_partner_sector_for_person"/>
+                        </div>
+                    </group>
+                </div>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
By default only companies have sectors. To activate sectors in individuals also,
you need to activate the following setting:

* Go to *Settings > General Settings > Sector in contacts > Use sector in individuals*

Or, if you have *Sales* or *CRM* modules installed:

* Go to *Sales > Configuration > Settings > Partner Sector > Use sector in individuals*