### PR TITLE
[7.0] [IMP] partner_relations_in_tab. Clean Code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
 
   matrix:
   - LINT_CHECK="1"
-  - TRANSIFEX="1"
   - TESTS="1" ODOO_REPO="odoo/odoo"
   - TESTS="1" ODOO_REPO="OCA/OCB"
 

--- a/partner_relations/__openerp__.py
+++ b/partner_relations/__openerp__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# © 2013-2017 Therp BV <http://therp.nl>.
+# Copyright 2013-2018 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later <http://www.gnu.org/licenses/agpl.html>.
 {
     "name": "Partner relations",
-    "version": "7.0.1.1.1",
+    "version": "7.0.1.2.0",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "complexity": "normal",

--- a/partner_relations_in_tab/__openerp__.py
+++ b/partner_relations_in_tab/__openerp__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2014-2017 Therp BV <http://therp.nl>.
-# License AGPL-3.0 or later <http://www.gnu.org/licenses/agpl.html>.
+# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Show partner relations in own tab",
     "version": "7.0.1.0.0",

--- a/partner_relations_in_tab/model/res_partner.py
+++ b/partner_relations_in_tab/model/res_partner.py
@@ -1,179 +1,72 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from lxml import etree
-from openerp.osv.orm import Model, transfer_modifiers_to_node
-from openerp.osv import expression
-from openerp.tools.translate import _
+
+from openerp.osv import orm
 
 
-class ResPartner(Model):
+class ResPartner(orm.Model):
     _inherit = 'res.partner'
 
-    def _get_relation_ids_select(self, cr, uid, ids, field_name, arg,
-                                 context=None):
-        cr.execute(
-            '''select r.id, left_partner_id, right_partner_id
-            from res_partner_relation r
-                join res_partner_relation_type t
-                    on r.type_id = t.id
-            where ((left_partner_id in %s and own_tab_left=False)
-                or (right_partner_id in %s and own_tab_right=False))''' +
-            ' order by ' + self.pool['res.partner.relation']._order,
-            (tuple(ids), tuple(ids))
-        )
-        return cr.fetchall()
+    def browse(
+            self, cr, uid, select, context=None, list_class=None,
+            fields_process=None):
+        for tab in self._get_tabs(cr, uid, context=context):
+            fieldname = tab.get_fieldname()
+            if fieldname not in self._columns:
+                # Check this for performance reasons.
+                self._columns[fieldname] = tab.make_field()
+        return super(ResPartner, self).browse(
+            cr, uid, select, context=context, list_class=list_class,
+            fields_process=fields_process)
 
-    def _create_relation_type_tab(
-            self, cr, uid, rel_type, inverse, field_names, context=None):
-        '''Create an xml node containing the relation's tab to be added to the
-        view. Add the field(s) created on the form to field_names.'''
-        name = rel_type.name if not inverse else rel_type.name_inverse
-        contact_type = rel_type['contact_type_' +
-                                ('left' if not inverse else 'right')]
-        partner_category = rel_type['partner_category_' +
-                                    ('left' if not inverse
-                                     else 'right')]
-        tab = etree.Element('page')
-        tab.set('string', name)
-
-        invisible = [('id', '=', False)]
-        if contact_type:
-            invisible = expression.OR([
-                invisible,
-                [('is_company', '=', contact_type != 'c')]])
-        if partner_category:
-            invisible = expression.OR([
-                invisible,
-                [('category_id', '!=', partner_category.id)]])
-        attrs = {
-            'invisible': invisible,
-        }
-        tab.set('attrs', repr(attrs))
-        transfer_modifiers_to_node(attrs, tab)
-
-        field_name = 'relation_ids_own_tab_%s_%s' % (
-            rel_type.id,
-            'left' if not inverse else 'right')
-        field_names.append(field_name)
-        this_partner_name = '%s_partner_id' % (
-            'left' if not inverse else 'right')
-        other_partner_name = '%s_partner_id' % (
-            'left' if inverse else 'right')
-
-        field = etree.Element(
-            'field',
-            name=field_name,
-            context=('{"default_type_id": %s, "default_%s": id, '
-                     '"active_test": False}') % (
-                rel_type.id,
-                this_partner_name))
-        tab.append(field)
-        tree = etree.Element('tree', editable='bottom')
-        field.append(tree)
-
-        onchange_type_values = self.pool['res.partner.relation']\
-            .on_change_type_selection_id(cr, uid, None,
-                                         rel_type.id * 10 +
-                                         (1 if inverse else 0),
-                                         context=context)
-        tree.append(etree.Element(
-            'field',
-            string=_('Partner'),
-            domain=repr(
-                onchange_type_values['domain']['partner_id_display']),
-            widget='many2one_clickable',
-            name=other_partner_name))
-        tree.append(etree.Element(
-            'field',
-            name='date_start'))
-        tree.append(etree.Element(
-            'field',
-            name='date_end'))
-        tree.append(etree.Element(
-            'field',
-            name='active'))
-        tree.append(etree.Element('field', name='type_id',
-                                  invisible='True'))
-        tree.append(etree.Element('field', name=this_partner_name,
-                                  invisible='True'))
-        return tab
-
-    def _add_relation_type_tab(
-            self, cr, uid, rel_type, inverse, field_names, relation_tab,
-            context=None):
-        '''add the xml node to the view'''
-        tab = self._create_relation_type_tab(
-            cr, uid, rel_type, inverse, field_names, context=context)
-        relation_tab.addnext(tab)
-
-    def fields_view_get(self, cr, uid, view_id=None, view_type='form',
-                        context=None, toolbar=False, submenu=False):
-        if context is None:
-            context = {}
+    def fields_view_get(
+            self, cr, uid, view_id=None, view_type='form', context=None,
+            toolbar=False, submenu=False):
+        context = context or {}
         result = super(ResPartner, self).fields_view_get(
             cr, uid, view_id=view_id, view_type=view_type, context=context,
             toolbar=toolbar, submenu=submenu)
-        if view_type == 'form' and not context.get('check_view_ids'):
-            res_partner_relation_type = self.pool['res.partner.relation.type']
-            own_tab_types = res_partner_relation_type.browse(
-                cr, uid,
-                res_partner_relation_type.search(
-                    cr, uid,
-                    [
-                        '|',
-                        ('own_tab_left', '=', True),
-                        ('own_tab_right', '=', True)
-                    ],
-                    context=context),
-                context=context)
-            view = etree.fromstring(result['arch'])
-
-            relation_tab = view.xpath(
-                '//field[@name="relation_ids"]/ancestor::page')
-            if not relation_tab:
-                return result
-            relation_tab = relation_tab[0]
-
-            field_names = []
-
-            if not view.xpath('//field[@name="id"]'):
-                view.append(etree.Element('field', name='id',
-                                          invisible='True'))
-                field_names.append('id')
-
-            for rel_type in own_tab_types:
-                if rel_type.own_tab_left:
-                    self._add_relation_type_tab(
-                        cr, uid, rel_type, False, field_names, relation_tab,
-                        context=context)
-                if rel_type.own_tab_right:
-                    self._add_relation_type_tab(
-                        cr, uid, rel_type, True, field_names, relation_tab,
-                        context=context)
-
-            result['arch'], fields = self\
-                ._BaseModel__view_look_dom_arch(
-                    cr, uid, view, result['view_id'], context=context)
-
-            for field_name in field_names:
-                result['fields'][field_name] = fields[field_name]
-
+        if view_type != 'form' or context.get('check_view_ids'):
+            return result
+        view = etree.fromstring(result['arch'])
+        extra_fields = self._add_tab_pages(cr, uid, view, context=context)
+        result['arch'], view_fields = self._BaseModel__view_look_dom_arch(
+            cr, uid, view, result['view_id'], context=context)
+        for fieldname in extra_fields:
+            result['fields'][fieldname] = view_fields[fieldname]
         return result
+
+    def _add_tab_pages(self, cr, uid, view, context=None):
+        """Adds the relevant tabs to the partner's formview."""
+        extra_fields = []
+        if not view.xpath('//field[@name="id"]'):
+            view.append(
+                etree.Element('field', name='id', invisible='True'))
+            extra_fields.append('id')
+        element_last_page_hook = view.xpath('//page[last()]')[0]
+        for tab in self._get_tabs(cr, uid, context=context):
+            fieldname = tab.get_fieldname()
+            self._columns[fieldname] = tab.make_field()
+            extra_fields.append(fieldname)
+            tab_page = tab.create_page()
+            element_last_page_hook.addnext(tab_page)
+        return extra_fields
+
+    def _get_tabs(self, cr, uid, context=None):
+        relation_type_model = self.pool['res.partner.relation.type']
+        return relation_type_model.get_tabs(cr, uid, context=context)
+
+    def _get_relation_ids_select_from(self, field_name=None):
+        base_from = super(ResPartner, self)\
+            ._get_relation_ids_select_from(field_name=field_name)
+        from_extend = \
+            "JOIN res_partner_relation_type rprt ON rpr.type_id = rprt.id"
+        return "%s %s" % (base_from, from_extend)
+
+    def _get_relation_ids_select_where(self, field_name=None):
+        # Need to completely override the super method!
+        return (
+            "WHERE ((rpr.left_partner_id in %s AND rprt.own_tab_left=False)"
+            " OR (rpr.right_partner_id in %s AND rprt.own_tab_right=False))")

--- a/partner_relations_in_tab/model/res_partner_relation_type.py
+++ b/partner_relations_in_tab/model/res_partner_relation_type.py
@@ -1,29 +1,12 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-from openerp.osv.orm import Model
-from openerp.osv import fields
-from openerp import SUPERUSER_ID
+# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.osv import fields, orm
+
+from ..tablib import Tab
 
 
-class ResPartnerRelationType(Model):
+class ResPartnerRelationType(orm.Model):
     _inherit = 'res.partner.relation.type'
 
     _columns = {
@@ -36,55 +19,21 @@ class ResPartnerRelationType(Model):
         'own_tab_right': False,
     }
 
-    def _update_res_partner_fields(self, cr):
-        field_name_prefix = 'relation_ids_own_tab_'
-        field_name_format = field_name_prefix + '%s_%s'
-        res_partner = self.pool['res.partner']
-        for field_name in res_partner._columns.copy():
-            if field_name.startswith(field_name_prefix):
-                del res_partner._columns[field_name]
+    def make_tab(self, source, side):
+        new_tab = Tab(source, side)
+        return new_tab
 
-        def add_field(relation, inverse):
-            field = fields.one2many(
-                'res.partner.relation',
-                '%s_partner_id' % ('left' if not inverse else 'right'),
-                string=relation['name' if not inverse else 'name_inverse'],
-                domain=[('type_id', '=', relation.id),
-                        '|',
-                        ('active', '=', True),
-                        ('active', '=', False)])
-            field_name = field_name_format % (
-                relation.id,
-                'left' if not inverse else 'right')
-            res_partner._columns[field_name] = field
+    def get_tabs(self, cr, uid, context=None):
+        tabs = []
+        tab_domain = self._get_tab_domain()
+        tab_type_ids = self.search(cr, uid, tab_domain, context=context)
+        for this in self.browse(cr, uid, tab_type_ids, context=context):
+            if this.own_tab_left:
+                tabs.append(self.make_tab(this, 'left'))
+            if this.own_tab_right:
+                tabs.append(self.make_tab(this, 'right'))
+        return tabs
 
-        for relation in self.browse(
-                cr, SUPERUSER_ID,
-                self.search(
-                    cr, SUPERUSER_ID,
-                    [
-                        '|',
-                        ('own_tab_left', '=', True),
-                        ('own_tab_right', '=', True),
-                    ])):
-            if relation.own_tab_left:
-                add_field(relation, False)
-            if relation.own_tab_right:
-                add_field(relation, True)
-
-    def _register_hook(self, cr):
-        self._update_res_partner_fields(cr)
-
-    def create(self, cr, uid, vals, context=None):
-        result = super(ResPartnerRelationType, self).create(
-            cr, uid, vals, context=context)
-        if vals.get('own_tab_left') or vals.get('own_tab_right'):
-            self._update_res_partner_fields(cr)
-        return result
-
-    def write(self, cr, uid, ids, vals, context=None):
-        result = super(ResPartnerRelationType, self).write(
-            cr, uid, ids, vals, context=context)
-        if 'own_tab_left' in vals or 'own_tab_right' in vals:
-            self._update_res_partner_fields(cr)
-        return result
+    def _get_tab_domain(self):
+        return [
+            '|', ('own_tab_left', '=', True), ('own_tab_right', '=', True)]

--- a/partner_relations_in_tab/tablib/__init__.py
+++ b/partner_relations_in_tab/tablib/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# Copyright 2018 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from . import tablib
-from . import model
+from .tab import Tab

--- a/partner_relations_in_tab/tablib/tab.py
+++ b/partner_relations_in_tab/tablib/tab.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+from lxml import etree
+
+from openerp.osv import expression, fields
+from openerp.osv.orm import transfer_modifiers_to_node
+from openerp.tools.translate import _
+
+
+_logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+NAME_PREFIX = 'relation_ids_tab'
+
+
+class Tab(object):
+
+    def __init__(self, source, side):
+        """Create tab from source.
+
+        In this version source can be assumed to be a partner.relation.type.
+        """
+        self.id = source.id
+        self.side = side
+        if side == 'left':
+            self.name = source.name
+            self.contact_type = source.contact_type_left
+            self.category_id = source.partner_category_left
+            self.other_contact_type = source.contact_type_right
+            self.other_category_id = source.partner_category_right
+            self.other_side = 'right'
+        else:
+            self.name = source.name_inverse
+            self.contact_type = source.contact_type_right
+            self.category_id = source.partner_category_right
+            self.other_contact_type = source.contact_type_left
+            self.other_category_id = source.partner_category_left
+            self.other_side = 'left'
+
+    def get_fieldname(self):
+        return '%s_%s_%s' % (NAME_PREFIX, self.id, self.side)
+
+    def make_field(self):
+        return fields.one2many(
+            'res.partner.relation',
+            '%s_partner_id' % self.side,
+            string=self.name,
+            domain=self.get_domain())
+
+    def get_domain(self):
+        return [('type_id', '=', self.id)]
+
+    def create_page(self):
+        tab_page = etree.Element('page')
+        self._set_page_attrs(tab_page)
+        field = etree.Element(
+            'field',
+            name=self.get_fieldname(),
+            context=(
+                '{"default_type_id": %s, "default_%s_partner_id": id, '
+                '"active_test": False}') % (self.id, self.side))
+        tab_page.append(field)
+        tree = etree.Element('tree', editable='bottom')
+        field.append(tree)
+        tree.append(etree.Element(
+            'field', name='%s_partner_id' % self.side, invisible='True'))
+        tree.append(etree.Element(
+            'field',
+            string=_('Partner'),
+            domain=repr(self._get_other_partner_domain()),
+            widget='many2one_clickable',
+            name='%s_partner_id' % self.other_side))
+        tree.append(etree.Element('field', name='date_start'))
+        tree.append(etree.Element('field', name='date_end'))
+        tree.append(etree.Element('field', name='active'))
+        tree.append(etree.Element('field', name='type_id', invisible='True'))
+        _logger.debug(
+            _("Created page for %s tab %s with arch: %s"),
+            self.side, self.name, etree.tostring(tab_page))
+        return tab_page
+
+    def _get_other_partner_domain(self):
+        partner_domain = []
+        if self.other_contact_type == 'c':
+            partner_domain.append(('is_company', '=', True))
+        if self.other_contact_type == 'p':
+            partner_domain.append(('is_company', '=', False))
+        if self.other_category_id:
+            partner_domain.append(
+                ('category_id', 'child_of', self.other_category_id.id))
+        return partner_domain
+
+    def _set_page_attrs(self, tab_page):
+        tab_page.set('string', self.name)
+        invisible = [('id', '=', False)]
+        if self.contact_type:
+            invisible = expression.OR([
+                invisible,
+                [('is_company', '=', self.contact_type != 'c')]])
+        if self.category_id:
+            invisible = expression.OR([
+                invisible,
+                [('category_id', '!=', self.category_id.id)]])
+        attrs = {'invisible': invisible}
+        tab_page.set('attrs', repr(attrs))
+        transfer_modifiers_to_node(attrs, tab_page)

--- a/partner_relations_in_tab/tests/__init__.py
+++ b/partner_relations_in_tab/tests/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import common
+from . import test_tab
+from . import test_res_partner_relation_type
+from . import test_res_partner
+from . import test_res_partner_relation
+
+checks = [
+    test_tab,
+    test_res_partner_relation_type,
+    test_res_partner,
+    test_res_partner_relation,
+]

--- a/partner_relations_in_tab/tests/common.py
+++ b/partner_relations_in_tab/tests/common.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.tests import common
+
+
+class TestCommon(common.SingleTransactionCase):
+
+    post_install = True
+
+    def setUp(self):
+        super(TestCommon, self).setUp()
+        self.type_model = self.registry('res.partner.relation.type')
+        self.category_model = self.registry('res.partner.category')
+        self.partner_model = self.registry('res.partner')
+        self.relation_model = self.registry('res.partner.relation')
+        self.type_has_chairperson = self._make_relation_type({
+            'name': 'has chairperson',
+            'name_inverse': 'is chairperson for',
+            'contact_type_left': 'c',
+            'own_tab_left': True,
+            'contact_type_right': 'p'})
+        self.chairperson_tab = self.type_model.make_tab(
+            self.type_has_chairperson, 'left')
+        self.child_category = self._make_category({'name': 'child'})
+        self.type_is_father = self._make_relation_type({
+            'name': 'is father',
+            'name_inverse': 'is child of',
+            'contact_type_left': 'p',
+            'own_tab_left': True,
+            'contact_type_right': 'p',
+            'partner_category_right': self.child_category.id})
+        self.is_father_tab = self.type_model.make_tab(
+            self.type_is_father, 'left')
+
+    def _make_relation_type(self, vals):
+        cr, uid = self.cr, self.uid
+        relation_type_id = self.type_model.create(cr, uid, vals)
+        relation_type = self.type_model.browse(
+            cr, uid, relation_type_id)
+        self.assertTrue(bool(relation_type))
+        return relation_type
+
+    def _make_partner(self, vals):
+        cr, uid = self.cr, self.uid
+        partner_id = self.partner_model.create(cr, uid, vals)
+        partner = self.partner_model.browse(cr, uid, partner_id)
+        self.assertTrue(bool(partner))
+        return partner
+
+    def _make_relation(self, vals):
+        cr, uid = self.cr, self.uid
+        relation_id = self.relation_model.create(cr, uid, vals)
+        relation = self.relation_model.browse(cr, uid, relation_id)
+        self.assertTrue(bool(relation))
+        return relation
+
+    def _make_category(self, vals):
+        cr, uid = self.cr, self.uid
+        category_id = self.category_model.create(cr, uid, vals)
+        category = self.category_model.browse(cr, uid, category_id)
+        self.assertTrue(bool(category))
+        return category

--- a/partner_relations_in_tab/tests/test_res_partner.py
+++ b/partner_relations_in_tab/tests/test_res_partner.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from lxml import etree
+
+from . import common
+
+
+class TestResPartner(common.TestCommon):
+
+    def test_fields_view_get(self):
+        self.assertTrue(bool(self.type_has_chairperson))
+        # The form view for partner should contain id:
+        field = self._get_partner_view_field('form', 'id')
+        self.assertTrue(field, 'Id field not in form.')
+        # And we should have a field for the tab:
+        fieldname = self.chairperson_tab.get_fieldname()
+        field = self._get_partner_view_field('form', fieldname)
+        self.assertTrue(field, 'Field %s not in form.' % fieldname)
+        # There should be no effect on the tree view:
+        field = self._get_partner_view_field('tree', fieldname)
+        self.assertFalse(field, 'Field %s should not be in tree.' % fieldname)
+
+    def _get_partner_view_field(self, view_type, fieldname):
+        cr, uid = self.cr, self.uid
+        view = self.partner_model.fields_view_get(cr, uid, view_type=view_type)
+        tree = etree.fromstring(view['arch'])
+        field = tree.xpath('//field[@name="%s"]' % fieldname)
+        return field

--- a/partner_relations_in_tab/tests/test_res_partner_relation.py
+++ b/partner_relations_in_tab/tests/test_res_partner_relation.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import common
+
+
+class TestResPartnerRelation(common.TestCommon):
+
+    def test_relations(self):
+        """Test relations shown on tab."""
+        self.assertTrue(bool(self.chairperson_tab))
+        big_company = self._make_partner({
+            'name': 'Big company',
+            'is_company': True,
+            'ref': 'BIG'})
+        important_person = self._make_partner({
+            'name': 'Bart Simpson',
+            'is_company': False,
+            'ref': 'BS'})
+        relation_company_chair = self._make_relation({
+            'left_partner_id': big_company.id,
+            'type_id': self.type_has_chairperson.id,
+            'right_partner_id': important_person.id})
+        # We should find the chairperson of the company through the tab:
+        fieldname = self.chairperson_tab.get_fieldname()
+        executive_relations = big_company[fieldname]
+        self.assertEqual(len(executive_relations), 1)
+        self.assertEqual(
+            executive_relations[0].id, relation_company_chair.id)
+        self.assertEqual(
+            executive_relations[0].right_partner_id.id, important_person.id)

--- a/partner_relations_in_tab/tests/test_res_partner_relation_type.py
+++ b/partner_relations_in_tab/tests/test_res_partner_relation_type.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import common
+
+
+class TestResPartnerRelationType(common.TestCommon):
+
+    def test_get_tabs(self):
+        cr, uid = self.cr, self.uid
+        self.assertTrue(bool(self.type_has_chairperson))
+        # We should find the tab in get_tabs
+        tabs = self.type_model.get_tabs(cr, uid)
+        self.assertTrue(
+            self.type_has_chairperson.id in [tab.id for tab in tabs])

--- a/partner_relations_in_tab/tests/test_tab.py
+++ b/partner_relations_in_tab/tests/test_tab.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import common
+
+
+class TestTab(common.TestCommon):
+
+    def test_make_field(self):
+        self.assertTrue(bool(self.chairperson_tab))
+        field = self.chairperson_tab.make_field()
+        self.assertEqual(field.string, self.type_has_chairperson.name)
+        self.assertEqual(field._obj, 'res.partner.relation')
+        self.assertEqual(field._fields_id, 'left_partner_id')
+        self.assertEqual(
+            field._domain, [('type_id', '=', self.type_has_chairperson.id)])
+
+    def test_get_other_partner_domain(self):
+        self.assertTrue(bool(self.chairperson_tab))
+        self.assertEqual(
+            self.chairperson_tab._get_other_partner_domain(),
+            [('is_company', '=', False)])
+        self.assertEqual(
+            self.is_father_tab._get_other_partner_domain(),
+            [('is_company', '=', False),
+             ('category_id', 'child_of', self.child_category.id)])
+
+    def test_create_page(self):
+        self.assertTrue(bool(self.chairperson_tab))
+        page = self.chairperson_tab.create_page()
+        # And we should have a field for (amongst others) type_id.
+        field = page.xpath('//field[@name="type_id"]')
+        self.assertTrue(field, 'Field type_id not in page.')


### PR DESCRIPTION
Solves problem with tabs for left side relations.

Also:
- Add tests;
- No more need for _register_hook;
- Handles deletions and other changes in relation types directly on loading view.