### PR TITLE
[10.0][FIX] partner_multi_relation. Fix crash when exporting all fields.

### DIFF
--- a/partner_multi_relation/models/res_partner_relation_all.py
+++ b/partner_multi_relation/models/res_partner_relation_all.py
@@ -455,3 +455,16 @@ CREATE OR REPLACE VIEW %%(table)s AS
             base_resource = rec.get_base_resource()
             rec.unlink_resource(base_resource)
         return True
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        """Set type_selection_id field to not exportable.
+
+        Trying to export type_selection_id would result in a crash
+        as it does not refer to a real table.
+        """
+        result = super(ResPartnerRelationAll, self).fields_get(
+            allfields=allfields, attributes=attributes)
+        if 'type_selection_id' in result:
+            result['type_selection_id']['exportable'] = False
+        return result


### PR DESCRIPTION
Exporting all fields crashed with message:
'Exception: You can not export the column ID of model res.partner.relation.type.selection, because the table res_partner_relation_type_selection is not an ordinary table.'

Way to reproduce:
- Go to view Partner Relations
- Select some or all rows (does not matter) to have action menu appear
- Click on Export
- Select radio button Export All data
- Add some fields, this should include Relation Type
- Click on Export to File

Stacktrace:
```
Traceback (most recent call last):
  File ""/home/odownbacp10/odoo/parts/odoo/addons/web/controllers/main.py"", line 74, in wrap
    return f(*args, **kwargs)
  File ""/home/odownbacp10/odoo/parts/odoo/addons/web/controllers/main.py"", line 1380, in index
    return self.base(data, token)
  File ""/home/odownbacp10/odoo/parts/odoo/addons/web/controllers/main.py"", line 1361, in base
    import_data = records.export_data(field_names, self.raw_data).get('datas',[])
  File ""/home/odownbacp10/odoo/parts/odoo/odoo/models.py"", line 835, in export_data
    return {'datas': self._export_rows(fields_to_export)}
  File ""/home/odownbacp10/odoo/parts/odoo/odoo/models.py"", line 806, in _export_rows
    lines2 = value._export_rows(fields2)
  File ""/home/odownbacp10/odoo/parts/odoo/odoo/models.py"", line 783, in _export_rows
    current[i] = record.__export_xml_id()
  File ""/home/odownbacp10/odoo/parts/odoo/odoo/models.py"", line 732, in __export_xml_id
    % (self._name, self._table))
Exception: You can not export the column ID of model res.partner.relation.type.selection, because the table res_partner_relation_type_selection is not an ordinary table.
```