### PR TITLE
[10.0][FIX] Fix issue during write on base_partner_sequence

### DIFF
--- a/base_partner_sequence/models/partner.py
+++ b/base_partner_sequence/models/partner.py
@@ -52,7 +52,7 @@ class ResPartner(models.Model):
         for partner in self:
             if not vals.get('ref') and partner._needsRef(vals) and \
                not partner.ref:
-                vals['ref'] = self._get_next_ref(vals=vals)
+                vals['ref'] = partner._get_next_ref(vals=vals)
 
             super(ResPartner, partner).write(vals)
         return True


### PR DESCRIPTION
**Actual bug**
During the write, we are trying to generate a reference to fill the `ref` field (using a `_get_next_ref()` function). But we should call this function on 1 recordset/partner and not on the `self`.
Actually the bug is not visible because we call a `ir.sequence` function, but in case of inheritance (our customer case) we have the `self` of the `write` and it's not correct.

**Fix**
Just use the current partner into the `write`.