### PR TITLE
[10.0][IMP] partner_noncommercial. Reorganize menu's.

### DIFF
--- a/partner_multi_relation/i18n/nl.po
+++ b/partner_multi_relation/i18n/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-26 15:33+0000\n"
+"POT-Creation-Date: 2018-11-19 10:48+0000\n"
 "PO-Revision-Date: 2017-12-26 15:33+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
@@ -40,7 +40,6 @@ msgid "All relation types"
 msgstr "Alle connectietypes"
 
 #. module: partner_multi_relation
-#: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_alias_relation_all_ids
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_relation_all_ids
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_users_relation_all_ids
 msgid "All relations with current partner"
@@ -141,21 +140,18 @@ msgid "Has former employee"
 msgstr "Heeft voormalig werknemer"
 
 #. module: partner_multi_relation
-#: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_alias_search_relation_type_id
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_search_relation_type_id
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_users_search_relation_type_id
 msgid "Has relation of type"
 msgstr "heeft connectie van type"
 
 #. module: partner_multi_relation
-#: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_alias_search_relation_partner_id
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_search_relation_partner_id
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_users_search_relation_partner_id
 msgid "Has relation with"
 msgstr "Heeft connectie met"
 
 #. module: partner_multi_relation
-#: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_alias_search_relation_partner_category_id
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_search_relation_partner_category_id
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_users_search_relation_partner_category_id
 msgid "Has relation with a partner in category"
@@ -245,7 +241,7 @@ msgstr "Type linkerrelatie"
 #. module: partner_multi_relation
 #: model:ir.ui.view,arch_db:partner_multi_relation.form_res_partner_relation_type
 msgid "Left side of relation"
-msgstr "Linkerkant van relatie"
+msgstr "Linkerkant van connectie"
 
 #. module: partner_multi_relation
 #: model:ir.ui.view,arch_db:partner_multi_relation.search_res_partner_relation_all
@@ -268,7 +264,7 @@ msgstr "Geen %s relatie beschikbaar voor dit connectietype."
 #: code:addons/partner_multi_relation/models/res_partner_relation_all.py:434
 #, python-format
 msgid "No relation type specified in vals: %s."
-msgstr ""
+msgstr "Geen connectietype opgegeven in vals: %s."
 
 #. module: partner_multi_relation
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_relation_all_this_partner_id
@@ -316,12 +312,6 @@ msgid "Partner Relations"
 msgstr "Connecties"
 
 #. module: partner_multi_relation
-#: model:ir.actions.act_window,name:partner_multi_relation.action_res_partner_relation_type
-#: model:ir.ui.menu,name:partner_multi_relation.menu_res_partner_relation_type
-msgid "Partner Relations Types"
-msgstr "Connectietypes"
-
-#. module: partner_multi_relation
 #: model:ir.model,name:partner_multi_relation.model_res_partner_relation
 msgid "Partner relation"
 msgstr "Connectie"
@@ -349,7 +339,7 @@ msgid ""
 "Record and track your partners' relations. Relations may\n"
 "                    be linked to other partners with a type either directly\n"
 "                    or inversely."
-msgstr ""
+msgstr "Hou gegevens bij over de connecties van uw relaties."
 
 #. module: partner_multi_relation
 #: model:ir.model.fields,help:partner_multi_relation.field_res_partner_relation_all_active
@@ -363,7 +353,6 @@ msgid "Reflexive"
 msgstr "Wederkerig"
 
 #. module: partner_multi_relation
-#: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_alias_relation_count
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_relation_count
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_users_relation_count
 msgid "Relation Count"
@@ -375,13 +364,18 @@ msgid "Relation Type"
 msgstr "Type connectie"
 
 #. module: partner_multi_relation
+#: model:ir.actions.act_window,name:partner_multi_relation.action_res_partner_relation_type
+#: model:ir.ui.menu,name:partner_multi_relation.menu_res_partner_relation_type
+msgid "Relation Types"
+msgstr "Connectie types"
+
+#. module: partner_multi_relation
 #: code:addons/partner_multi_relation/models/res_partner_relation_all.py:302
 #, python-format
 msgid "Relation type incompatible with selected partner(s)."
 msgstr "Type connectie komt niet overeen met geselecteerde relatie(s)."
 
 #. module: partner_multi_relation
-#: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_alias_search_relation_date
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_search_relation_date
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_users_search_relation_date
 msgid "Relation valid"
@@ -401,12 +395,12 @@ msgstr "Type connectie"
 #. module: partner_multi_relation
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_relation_all_res_id
 msgid "Resource ID"
-msgstr ""
+msgstr "Resource ID"
 
 #. module: partner_multi_relation
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_relation_all_res_model
 msgid "Resource Model"
-msgstr ""
+msgstr "Resource Model"
 
 #. module: partner_multi_relation
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_relation_type_partner_category_right
@@ -459,7 +453,7 @@ msgstr "Symmetrisch"
 #: code:addons/partner_multi_relation/models/res_partner_relation.py:103
 #, python-format
 msgid "The %s partner does not have category %s."
-msgstr ""
+msgstr "Relatie %s heeft niet categorie %s."
 
 #. module: partner_multi_relation
 #: code:addons/partner_multi_relation/models/res_partner_relation.py:97
@@ -470,12 +464,12 @@ msgstr "De %s relatie is niet geldig voor dit type connectie."
 #. module: partner_multi_relation
 #: model:ir.model.fields,help:partner_multi_relation.field_res_partner_relation_all_res_model
 msgid "The database object this relation is based on."
-msgstr ""
+msgstr "Database object waar deze connectie op is gebaseerd."
 
 #. module: partner_multi_relation
 #: model:ir.model.fields,help:partner_multi_relation.field_res_partner_relation_all_res_id
 msgid "The id of the object in the model this relation is based on."
-msgstr ""
+msgstr "Het id van het object in het model waarop deze connectie is gebaseerd."
 
 #. module: partner_multi_relation
 #: code:addons/partner_multi_relation/models/res_partner_relation.py:63
@@ -518,9 +512,8 @@ msgstr "Type"
 
 #. module: partner_multi_relation
 #: model:ir.model.fields,field_description:partner_multi_relation.field_res_partner_relation_all_type_id
-#, fuzzy
 msgid "Underlying Relation Type"
-msgstr "Type connectie"
+msgstr "Onderliggend connectietype"
 
 #. module: partner_multi_relation
 #: code:addons/partner_multi_relation/models/res_partner.py:80
@@ -531,22 +524,22 @@ msgstr "Zoek operator \"%s\" wordt niet ondersteund "
 #. module: partner_multi_relation
 #: model:res.partner.category,name:partner_multi_relation.res_partner_category_pmr_0
 msgid "Washing Companies"
-msgstr ""
+msgstr "Wasserettes"
 
 #. module: partner_multi_relation
 #: model:res.partner.category,name:partner_multi_relation.res_partner_category_pmr_4
 msgid "Washing Gold"
-msgstr ""
+msgstr "Wasseretes van de gouden categorie"
 
 #. module: partner_multi_relation
 #: model:res.partner.category,name:partner_multi_relation.res_partner_category_pmr_11
 msgid "Washing Services"
-msgstr ""
+msgstr "Wasserij diensten"
 
 #. module: partner_multi_relation
 #: model:res.partner.category,name:partner_multi_relation.res_partner_category_pmr_5
 msgid "Washing Silver"
-msgstr ""
+msgstr "Wasseretes van de zilveren categorie"
 
 #. module: partner_multi_relation
 #: model:ir.model.fields,help:partner_multi_relation.field_res_partner_relation_type_handle_invalid_onchange
@@ -573,15 +566,3 @@ msgstr "andere"
 #, python-format
 msgid "this"
 msgstr "deze"
-
-#~ msgid "Left partner to right partner"
-#~ msgstr "Van linker naar rechterrelatie"
-
-#~ msgid "Record Type"
-#~ msgstr "Recordtype"
-
-#~ msgid "Relation"
-#~ msgstr "Connectie"
-
-#~ msgid "Right partner to left partner"
-#~ msgstr "Rechter naar linkerrelatie"

--- a/partner_multi_relation/views/menu.xml
+++ b/partner_multi_relation/views/menu.xml
@@ -12,7 +12,7 @@
             id="action_res_partner_relation_type"
             res_model="res.partner.relation.type"
             view_mode="tree,form"
-            name="Partner Relations Types"
+            name="Relation Types"
         />
 
         <menuitem

--- a/partner_noncommercial/i18n/nl.po
+++ b/partner_noncommercial/i18n/nl.po
@@ -4,11 +4,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 6.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-01 12:32+0000\n"
+"POT-Creation-Date: 2018-11-19 10:48+0000\n"
 "PO-Revision-Date: 2012-03-12 09:28+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
+"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -41,6 +41,11 @@ msgstr "Klik voor het toevoegen van een organisatie aan het adresboek."
 #: model:ir.actions.act_window,help:partner_noncommercial.action_address_form
 msgid "Click to add item to your address book."
 msgstr "Klik voor toevoeging aan het adresboek"
+
+#. module: partner_noncommercial
+#: model:ir.ui.menu,name:partner_noncommercial.menu_partner_config
+msgid "Configuration"
+msgstr "Instellingen"
 
 #. module: partner_noncommercial
 #: model:ir.actions.act_window,name:partner_noncommercial.action_company_form

--- a/partner_noncommercial/views/menu.xml
+++ b/partner_noncommercial/views/menu.xml
@@ -23,7 +23,7 @@
         sequence="4"
         />
 
-    <!-- Add menu item to show all relations -->
+    <!-- Add menu item to show all partners -->
     <record id="action_all_partner_form" model="ir.actions.act_window">
         <field name="name">All partners</field>
         <field name="type">ir.actions.act_window</field>
@@ -80,7 +80,7 @@
         sequence="31"
         />
 
-    <!-- Add menu item to show all relations and other addresses -->
+    <!-- Add menu item to show all true partners and other addresses -->
     <record id="action_address_form" model="ir.actions.act_window">
         <field name="name">All addresses</field>
         <field name="type">ir.actions.act_window</field>
@@ -99,12 +99,18 @@
         sequence="41"
         />
 
-    <!-- Move address book configuration to partner menu -->
+    <!-- Create configuration menu -->
     <menuitem
-        id="sales_team.menu_config_address_book"
-        name="Contacts"
-        parent="menu_partner"
-        sequence="90"
+        id="menu_partner_config"
+        name="Configuration"
+        parent="menu_partner_main"
+        groups="base.group_partner_manager"
+        sequence="99"
         />
+
+    <!-- Move address book configuration to partner menu -->
+    <record id="sales_team.menu_config_address_book" model="ir.ui.menu">
+        <field name="parent_id" ref="menu_partner_config" />
+    </record>
 
 </odoo>

--- a/partner_noncommercial/views/menu.xml
+++ b/partner_noncommercial/views/menu.xml
@@ -92,6 +92,22 @@
             <p class="oe_view_nocontent_create"
                 >Click to add item to your address book.</p></field>
     </record>
+    <record
+        id="action_window_address_tree"
+        model="ir.actions.act_window.view"
+        >
+        <field name="view_mode">tree</field>
+        <field name="act_window_id" ref="action_address_form"/>
+        <field name="view_id" ref="base.view_partner_tree"/>
+    </record>
+    <record
+        id="action_window_address_form"
+        model="ir.actions.act_window.view"
+        >
+        <field name="view_mode">form</field>
+        <field name="act_window_id" ref="action_address_form"/>
+        <field name="view_id" ref="base.view_partner_address_form"/>
+    </record>
     <menuitem
         id="menu_address_form"
         parent="menu_partner"

--- a/partner_noncommercial_multi_relation/i18n/nl.po
+++ b/partner_noncommercial_multi_relation/i18n/nl.po
@@ -1,0 +1,5 @@
+#. module: partner_noncommercial_multi_relation
+#: model:ir.ui.menu,name:partner_noncommercial_multi_relation.menu_partner_relation_config
+#: model:ir.ui.menu,name:partner_noncommercial_multi_relation.menu_partner_relations
+msgid "Partner Relations"
+msgstr "Connecties"

--- a/partner_noncommercial_multi_relation/views/menu.xml
+++ b/partner_noncommercial_multi_relation/views/menu.xml
@@ -1,11 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
+    <!-- Create relations menu -->
     <menuitem
-        id="partner_multi_relation.menu_res_partner_relation_sales"
-        parent="partner_noncommercial.menu_partner"
+        id="menu_partner_relations"
         name="Partner Relations"
+        parent="partner_noncommercial.menu_partner_main"
         sequence="36"
         />
+
+    <!-- Move view on all relations under this menu -->
+    <record
+        id="partner_multi_relation.menu_res_partner_relation_sales"
+        model="ir.ui.menu"
+        >
+        <field name="parent_id" ref="menu_partner_relations" />
+        <field name="sequence">11</field>
+    </record>
+
+    <!-- Create relations configuration menu -->
+    <menuitem
+        id="menu_partner_relation_config"
+        name="Partner Relations"
+        parent="partner_noncommercial.menu_partner_config"
+        sequence="21"
+        />
+
+    <!-- Move configuration of relation types under this menu -->
+    <record
+        id="partner_multi_relation.menu_res_partner_relation_type"
+        model="ir.ui.menu"
+        >
+        <field name="parent_id" ref="menu_partner_relation_config" />
+        <field name="sequence">11</field>
+    </record>
 
 </odoo>


### PR DESCRIPTION
There were menu-options for partners and relations interspersed, and no clear separation between normal menu's and configuration. This commit tries to rectify this.

I abandoned the idea for 10.0 of bringing everything under the contact menu. In 11.0 relations are under the contact menu and the dependency on sales_team can be easily removed.

But for 10.0 I would not confuse existing users and installations by changing the dependency graph of modules and putting stuff under a new main menu (contacts instead of partners).

New options have been translated into Dutch. The rest can be done through weblate.