### PR TITLE
[FIX] 11.0 partner_second_last_name required only if type = contact

### DIFF
--- a/partner_second_lastname/views/res_partner.xml
+++ b/partner_second_lastname/views/res_partner.xml
@@ -9,13 +9,13 @@
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//field[@name='firstname']" position="attributes">
-                    <attribute name="attrs">{'required': [('lastname', '=', False), ('lastname2', '=', False), ('is_company', '=', False)]}</attribute>
+                    <attribute name="attrs">{'required': [('lastname', '=', False), ('lastname2', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='lastname']" position="attributes">
-                    <attribute name="attrs">{'required': [('firstname', '=', False), ('lastname2', '=', False), ('is_company', '=', False)]}</attribute>
+                    <attribute name="attrs">{'required': [('firstname', '=', False), ('lastname2', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='lastname']" position="after">
-                    <field name="lastname2" attrs="{'required': [('firstname', '=', False), ('lastname', '=', False), ('is_company', '=', False)]}"/>
+                    <field name="lastname2" attrs="{'required': [('firstname', '=', False), ('lastname', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}"/>
                 </xpath>
             </data>
         </field>
@@ -28,24 +28,24 @@
             <data>
                 <!-- Main form -->
                 <xpath expr="//field[@name='firstname']" position="attributes">
-                    <attribute name="attrs">{'required': [('lastname', '=', False), ('lastname2', '=', False), ('is_company', '=', False)]}</attribute>
+                    <attribute name="attrs">{'required': [('lastname', '=', False), ('lastname2', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}</attribute>
                 </xpath>
 
                 <xpath expr="//field[@name='lastname']" position="attributes">
-                    <attribute name="attrs">{'required': [('firstname', '=', False), ('lastname2', '=', False), ('is_company', '=', False)]}</attribute>
+                    <attribute name="attrs">{'required': [('firstname', '=', False), ('lastname2', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='lastname']" position="after">
-                    <field name="lastname2" attrs="{'required': [('firstname', '=', False), ('lastname', '=', False), ('is_company', '=', False)]}"/>
+                    <field name="lastname2" attrs="{'required': [('firstname', '=', False), ('lastname', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}"/>
                 </xpath>
                 <!-- Inner contact form of child_ids -->
                 <xpath expr="//field[@name='child_ids']/form//field[@name='firstname']" position="attributes">
-                    <attribute name="attrs">{'required': [('lastname', '=', False), ('lastname2', '=', False), ('is_company', '=', False)]}</attribute>
+                    <attribute name="attrs">{'required': [('lastname', '=', False), ('lastname2', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='child_ids']/form//field[@name='lastname']" position="attributes">
-                    <attribute name="attrs">{'required': [('firstname', '=', False), ('lastname2', '=', False), ('is_company', '=', False)]}</attribute>
+                    <attribute name="attrs">{'required': [('firstname', '=', False), ('lastname2', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='child_ids']/form//field[@name='lastname']" position="after">
-                    <field name="lastname2" attrs="{'required': [('firstname', '=', False), ('lastname', '=', False), ('is_company', '=', False)]}"/>
+                    <field name="lastname2" attrs="{'required': [('firstname', '=', False), ('lastname', '=', False), ('is_company', '=', False), ('type', '=', 'contact')]}"/>
                 </xpath>
             </data>
       </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

firstname, lastname and lastname2 fields should only be required if
contact `type` is `contact`. In partner_firstname module this is done
right with `('type', '=', 'contact')` leave in attrs required domain.
But in partner_second_last_name there is no such leave, so if the
contact is an address, the fields are mandatory too.

Current behavior:

Either firstname, lastname or lastname2 are mandatory when a contact is
not a company.

Desired behavior after PR is merged:

firstname, lastname or lastname2 are mandatory when the contact is of
type `contact`