### PR TITLE
[11.0][ADD] partner_certificate_of_conduct

### DIFF
--- a/partner_certificate_of_conduct/__init__.py
+++ b/partner_certificate_of_conduct/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/partner_certificate_of_conduct/__manifest__.py
+++ b/partner_certificate_of_conduct/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2017-2018 Onestein (<https://www.onestein.eu>)
+# Copyright 2018 Therp BV (<https://www.therp.nl>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Partner Certificate of Conduct',
+    'summary': "Adds field 'Certificate of Conduct'",
+    'version': '11.0.1.0.0',
+    'category': 'CRM',
+    'author': 'Therp BV,Onestein,Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/partner-contact/',
+    'license': 'AGPL-3',
+    'depends': [
+        'partner_identification',
+    ],
+    'data': [
+        'data/res_partner_id_category_data.xml',
+        'views/res_partner_view.xml'
+    ],
+    'installable': True,
+}

--- a/partner_certificate_of_conduct/data/res_partner_id_category_data.xml
+++ b/partner_certificate_of_conduct/data/res_partner_id_category_data.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_partner_id_category_certificate_of_conduct" model="res.partner.id_category">
+        <field name="code">co_conduct</field>
+        <field name="name">Certificate of Conduct</field>
+    </record>
+</odoo>

--- a/partner_certificate_of_conduct/models/__init__.py
+++ b/partner_certificate_of_conduct/models/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import res_partner

--- a/partner_certificate_of_conduct/models/res_partner.py
+++ b/partner_certificate_of_conduct/models/res_partner.py
@@ -1,0 +1,22 @@
+# Copyright 2017-2018 Onestein (<https://www.onestein.eu>)
+# Copyright 2018 Therp BV (<https://www.therp.nl>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    coc_certificate_of_conduct = fields.Char(
+        string='Certificate of Conduct',
+        compute=lambda s: s._compute_identification(
+            'coc_certificate_of_conduct', 'co_conduct',
+        ),
+        inverse=lambda s: s._inverse_identification(
+            'coc_certificate_of_conduct', 'co_conduct',
+        ),
+        search=lambda s, *a: s._search_identification(
+            'coc_certificate_of_conduct', 'co_conduct', *a
+        ),
+    )

--- a/partner_certificate_of_conduct/models/res_partner.py
+++ b/partner_certificate_of_conduct/models/res_partner.py
@@ -17,6 +17,6 @@ class ResPartner(models.Model):
             'coc_certificate_of_conduct', 'co_conduct',
         ),
         search=lambda s, *a: s._search_identification(
-            'coc_certificate_of_conduct', 'co_conduct', *a
+            'co_conduct', *a
         ),
     )

--- a/partner_certificate_of_conduct/readme/CONTRIBUTORS.rst
+++ b/partner_certificate_of_conduct/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* Dennis Sluijk <d.sluijk@onestein.nl>
+* Andrea Stirpe <a.stirpe@onestein.nl>
+* Nikos Tsirintanis <ntsirintanis@therp.nl>

--- a/partner_certificate_of_conduct/readme/DESCRIPTION.rst
+++ b/partner_certificate_of_conduct/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module adds the field *Certificate of Conduct* to partners. Refer to https://www.justis.nl/producten/vog/certificate-of-conduct/ for what a Certificate of Conduct is.

--- a/partner_certificate_of_conduct/readme/USAGE.rst
+++ b/partner_certificate_of_conduct/readme/USAGE.rst
@@ -1,0 +1,8 @@
+To use this module, you need to:
+
+#. Go to the partner form;
+#. make sure the partner is not a company.
+#. Go to ID numbers tab and create a new record with Certificate of Conduct as category, and an ID number.
+#. Save the record and form, and observe that there is a new field called Certificate of Conduct with your ID number.
+#. OR
+#. Assign a value to the new field directly, and observe ID numbers right after saving the form 

--- a/partner_certificate_of_conduct/tests/__init__.py
+++ b/partner_certificate_of_conduct/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_partner_certificate_of_conduct

--- a/partner_certificate_of_conduct/tests/test_partner_certificate_of_conduct.py
+++ b/partner_certificate_of_conduct/tests/test_partner_certificate_of_conduct.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Onestein (<https://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestPartnerCertificateOfConduct(TransactionCase):
+    def setUp(self):
+        super(TestPartnerCertificateOfConduct, self).setUp()
+        self.main_partner = self.env.ref('base.main_partner')
+        self.partner_id_category = self.env.ref(
+            'partner_certificate_of_conduct.'
+            'res_partner_id_category_certificate_of_conduct'
+        )
+
+    def test_01_id_number_new(self):
+        # Good CoC
+        vals = {
+            'name': '56048785',
+            'category_id': self.partner_id_category.id,
+        }
+        self.main_partner.write({'id_numbers': [(0, 0, vals)]})
+        id_number = self.main_partner.id_numbers[0]
+
+        self.assertEqual(id_number.name, '56048785')
+
+    def test_02_id_number_duplicate(self):
+        # Duplicate CoC
+        vals = {
+            'name': '56048785',
+            'category_id': self.partner_id_category.id,
+        }
+
+        self.main_partner.write({'id_numbers': [(0, 0, vals)]})
+        id_number_name = self.main_partner.id_numbers[0].name
+        self.assertEqual(id_number_name, '56048785')
+
+        new_partner = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        new_partner.write({'id_numbers': [(0, 0, vals)]})
+        id_number_name = new_partner.id_numbers[0].name
+        self.assertEqual(id_number_name, '56048785')
+
+    def test_03_coc_registration_number_create(self):
+        new_partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'coc_certificate_of_conduct': '56048785',
+        })
+
+        self.assertEqual(new_partner.coc_certificate_of_conduct, '56048785')
+
+        id_numbers = new_partner.id_numbers
+        self.assertTrue(id_numbers)
+        self.assertEqual(len(id_numbers), 1)
+        self.assertEqual(id_numbers.name, '56048785')
+
+    def test_04_coc_registration_number_write(self):
+        self.main_partner.write({
+            'coc_certificate_of_conduct': '56048786'
+        })
+        coc = self.main_partner.coc_certificate_of_conduct
+        self.assertEqual(coc, '56048786')
+
+        id_numbers = self.main_partner.id_numbers
+        self.assertTrue(id_numbers)
+        self.assertEqual(len(id_numbers), 1)
+        self.assertEqual(id_numbers.name, '56048786')

--- a/partner_certificate_of_conduct/views/res_partner_view.xml
+++ b/partner_certificate_of_conduct/views/res_partner_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Add coc_certificate_of_conduct to res partner view -->
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="priority" eval="11"/>
+        <field name="arch" type="xml">
+            <field name="lang" position="after">
+                <field name="coc_certificate_of_conduct" attrs="{'invisible': [('company_type','=','company')]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Introducing a "new" module, that adds a field in partner form, storing information concerning the "Certificate of conduct" of the partner. For more info check here https://www.justis.nl/producten/vog/certificate-of-conduct/ 
This module is a direct copy of partner_coc, maintaining the logic and making the minimum alterations needed to adapt its functionality to res.partner(s) that are NOT a company. Description has been modified to include these changes, while history of the original module has been extended to include our contribution.
We chose partner_certificate_of_conduct as a name because partner_coc is already reserved by the aforementioned module.