### PR TITLE
[FIX] corrected bug in partner_coc search method

### DIFF
--- a/partner_coc/models/res_partner.py
+++ b/partner_coc/models/res_partner.py
@@ -16,6 +16,6 @@ class ResPartner(models.Model):
             'coc_registration_number', 'coc',
         ),
         search=lambda s, *a: s._search_identification(
-            'coc_registration_number', 'coc', *a
+            'coc', *a
         ),
     )


### PR DESCRIPTION
The following error appeared every time the search method was called (e.g. adding a filter via XML or just by clicking through Odoo):

TypeError: _search_identification() takes 4 positional arguments but 5 were given

With this commit the bug is fixed and search() works normally.