### PR TITLE
[12.0] Fix migration script 12.0.1.0.0 of partner_firstname

### DIFF
--- a/partner_firstname/migrations/12.0.1.0.0/pre-ir_config_param.py
+++ b/partner_firstname/migrations/12.0.1.0.0/pre-ir_config_param.py
@@ -4,7 +4,7 @@ def store_ir_config_param(cr):
     store the config parameter if it is not present.
     """
     cr.execute("SELECT 1 FROM ir_config_parameter "
-               "WHERE name = 'partner_names_order'")
+               "WHERE key = 'partner_names_order'")
     if not cr.fetchone():
         cr.execute("INSERT INTO ir_config_parameter (key, value) VALUES "
                    "('partner_names_order', 'last_first')")


### PR DESCRIPTION
Fixes the error in the migration:

psycopg2.ProgrammingError: column "name" does not exist
LINE 1: SELECT 1 FROM ir_config_parameter WHERE name = 'partner_name...
