### PR TITLE
[12.0] FIX base_location blocking editing company address.

### DIFF
--- a/base_location/__manifest__.py
+++ b/base_location/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Location management (aka Better ZIP)',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'depends': [
         'base_address_city',
         'contacts',

--- a/base_location/models/res_company.py
+++ b/base_location/models/res_company.py
@@ -47,11 +47,21 @@ class ResCompany(models.Model):
 
     def _inverse_city_id(self):
         for company in self:
-            company.partner_id.city_id = company.city_id
+            company.with_context(
+                skip_check_zip=True).partner_id.city_id = company.city_id
 
     def _inverse_zip_id(self):
         for company in self:
-            company.partner_id.zip_id = company.zip_id
+            company.with_context(
+                skip_check_zip=True).partner_id.zip_id = company.zip_id
+
+    def _inverse_state(self):
+        return super(ResCompany, self.with_context(
+            skip_check_zip=True))._inverse_state()
+
+    def _inverse_country(self):
+        return super(ResCompany, self.with_context(
+            skip_check_zip=True))._inverse_country()
 
     @api.onchange('zip_id')
     def _onchange_zip_id(self):

--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -52,6 +52,8 @@ class ResPartner(models.Model):
 
     @api.constrains('zip_id', 'country_id', 'city_id', 'state_id')
     def _check_zip(self):
+        if self.env.context.get('skip_check_zip'):
+            return
         for rec in self:
             if not rec.zip_id:
                 continue

--- a/base_location/tests/test_base_location.py
+++ b/base_location/tests/test_base_location.py
@@ -135,6 +135,9 @@ class TestBaseLocation(common.SavepointCase):
                 'zip_id': self.barcelona.id,
             })
 
+    def test_writing_company(self):
+        self.company.zip_id = self.barcelona
+
     def test_constrains_partner_country(self):
         """Test partner country constraints"""
         partner = self.partner_obj.create({


### PR DESCRIPTION
Steps:

 - Open company form
 - Set 'city completion' field

Get 'The state of the partner My Company differs from that in location X'

Disabling _check_zip while writing 'zip' fields from company, as incompatible with the sequence of write operations