### PR TITLE
[10.0][FIX] partner_email_check, partner_identification, partner_sector

### DIFF
--- a/partner_email_check/__manifest__.py
+++ b/partner_email_check/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Email Format Checker',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'summary': 'Validate email address field',
     'author': "Komit, Odoo Community Association (OCA)",
     'website': 'http://komit-consulting.com',

--- a/partner_email_check/models/res_partner.py
+++ b/partner_email_check/models/res_partner.py
@@ -4,7 +4,7 @@
 
 import logging
 from odoo import api, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class ResPartner(models.Model):
     def email_check(self, emails):
         for email in emails.split(','):
             if not validate_email(email):
-                raise UserError(
+                raise ValidationError(
                     _("%s is an invalid email") % email.strip()
                 )
         return True

--- a/partner_identification/__manifest__.py
+++ b/partner_identification/__manifest__.py
@@ -11,7 +11,7 @@
 {
     'name': 'Partner Identification Numbers',
     'category': 'Customer Relationship Management',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'depends': [
         'sales_team',
     ],

--- a/partner_identification/models/res_partner_id_category.py
+++ b/partner_identification/models/res_partner_id_category.py
@@ -11,7 +11,7 @@
 
 
 from odoo import api, models, fields, _
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import ValidationError
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -63,7 +63,7 @@ class ResPartnerIdCategory(models.Model):
                       mode='exec',
                       nocopy=True)
         except Exception as e:
-            raise UserError(
+            raise ValidationError(
                 _('Error when evaluating the id_category validation code:'
                   ':\n %s \n(%s)') % (self.name, e))
         if eval_context.get('failed', False):

--- a/partner_sector/__manifest__.py
+++ b/partner_sector/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Partner Sector",
     "summary": "Add partner sectors",
-    "version": "10.0.1.2.0",
+    "version": "10.0.1.2.1",
     "category": "Customer Relationship Management",
     "website": "https://github.com/OCA/partner-contact",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/partner_sector/models/res_partner.py
+++ b/partner_sector/models/res_partner.py
@@ -3,7 +3,8 @@
 # © 2016 Tecnativa S.L. - Vicent Cubells
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api, exceptions, _
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -19,5 +20,6 @@ class ResPartner(models.Model):
     @api.constrains('sector_id', 'secondary_sector_ids')
     def _check_sectors(self):
         if self.sector_id in self.secondary_sector_ids:
-            raise exceptions.Warning(_('The main sector must be different '
-                                       'from the secondary sectors.'))
+            raise ValidationError(
+                _('The main sector must be different '
+                  'from the secondary sectors.'))


### PR DESCRIPTION
Raise correct ValidationError in a constrains decorated method.

Due to https://github.com/odoo/odoo/commit/2b1d3ff82dd23fb0372b3b73ecb84841a0d593d3,
constrains must raise ValidationError only not to have an 'ERROR' in log that makes
tests failing