### PR TITLE
[FIX] partner_phone_search: Return None when name is False/empty

### DIFF
--- a/partner_phone_search/README.rst
+++ b/partner_phone_search/README.rst
@@ -31,6 +31,7 @@ Contributors
 
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Nikul Chaudhary <nikul.chaudhary.serpentcs@gmail.com>
+* Isaac Gallart <igallart@puntsistemes.es>
 
 Maintainer
 ----------

--- a/partner_phone_search/__manifest__.py
+++ b/partner_phone_search/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Search Partner Phone/Mobile/Email',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Extra Tools',
     'summary': 'Partner Search by Phone/Mobile/Email',
     'author': "Serpent Consulting Services Pvt. Ltd.,"

--- a/partner_phone_search/models/res_partner.py
+++ b/partner_phone_search/models/res_partner.py
@@ -15,7 +15,7 @@ class ResPartner(models.Model):
             domain = ['|', '|', ('phone', operator, name),
                       ('mobile', operator, name), ('email', operator, name)
                       ]
-            partners = self.search(domain + args, limit=limit,)
+            partners = self.search(domain + args, limit=limit, )
             res = partners.name_get()
             if limit:
                 limit_rest = limit - len(partners)
@@ -23,6 +23,9 @@ class ResPartner(models.Model):
                 limit_rest = limit
             if limit_rest or not limit:
                 args += [('id', 'not in', partners.ids)]
-                res += super(ResPartner, self).name_search(
+                res += super().name_search(
                     name, args=args, operator=operator, limit=limit_rest)
             return res
+        return super().name_search(
+            name, args=args, operator=operator, limit=limit
+        )


### PR DESCRIPTION
When we do not have a name, it returns None, and another module that read the result could fail.
For example, in the previous commit of this module: res + = super (ResPartner, self) .name_search ..., will fail.