### PR TITLE
[FIX] partner_email_unique: allow empty emails

### DIFF
--- a/partner_email_unique/models/res_partner.py
+++ b/partner_email_unique/models/res_partner.py
@@ -22,6 +22,7 @@ class ResPartner(models.Model):
             domain = [
                 ('id', '!=', partner.id),
                 ('email', '=', partner.email),
+                ('email', '!=', False),
             ]
             other_partners = self.search(domain)
 

--- a/partner_email_unique/tests/test_res_partner_email.py
+++ b/partner_email_unique/tests/test_res_partner_email.py
@@ -33,3 +33,7 @@ class TestResPartnerEmailUnique(common.SavepointCase):
         # Test can't create/modify partner with same email
         with self.assertRaises(ValidationError):
             self.partner2.email = 'same_email@test.com'
+
+        # Empty email addresses don't raise
+        self.partner1.email = False
+        self.partner2.email = False


### PR DESCRIPTION
**Before fix**: allows only one empty address in the database

**After fix**: allows multiple contact with empty email addresses, still enforces unique non-empty email addresses