### PR TITLE
[FIX] make res.partner.relation.all#write work for multiple records

### DIFF
--- a/partner_multi_relation/models/res_partner_relation_all.py
+++ b/partner_multi_relation/models/res_partner_relation_all.py
@@ -386,8 +386,9 @@ CREATE OR REPLACE VIEW %%(table)s AS
             if type_id:
                 is_inverse = vals.get('is_inverse')
                 type_selection_id = type_id * 2 + (is_inverse and 1 or 0)
-        return type_selection_id and self.type_selection_id.browse(
-            type_selection_id) or False
+        return self.env['res.partner.relation.type.selection'].browse(
+            type_selection_id or []
+        )
 
     @api.multi
     def write(self, vals):


### PR DESCRIPTION
accessing `self`'s fields in an `@api.model` function is dangerous, and we just need the model anyways. I changed this to always return a recordset, it will be falsy if empty