### PR TITLE
[FIX] partner_email_unique: duplicating partner sets empty email

### DIFF
--- a/partner_email_unique/models/res_partner.py
+++ b/partner_email_unique/models/res_partner.py
@@ -3,13 +3,15 @@
 #   Robin Keunen <robin@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, api, _
+from openerp import models, api, _, fields
 from openerp.exceptions import ValidationError
 from openerp.tools import config
 
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
+
+    email = fields.Char(copy=False)
 
     @api.multi
     @api.constrains('email')

--- a/partner_email_unique/tests/test_res_partner_email.py
+++ b/partner_email_unique/tests/test_res_partner_email.py
@@ -37,3 +37,6 @@ class TestResPartnerEmailUnique(common.SavepointCase):
         # Empty email addresses don't raise
         self.partner1.email = False
         self.partner2.email = False
+
+    def test_copy_does_not_raise_duplicate_email_error(self):
+        self.partner1.copy()


### PR DESCRIPTION
**before**: the check on unique email addresses makes it impossible to duplicate a partner (raises Validation Error).

**after**: the duplicated partner email address is set to False