### PR TITLE
[12.0] Fix partner_company_group filter priority

### DIFF
--- a/partner_company_group/readme/CONTRIBUTORS.rst
+++ b/partner_company_group/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 Timon Tschanz <timon.tschanz@camptocamp.com>
+Yannick Vaucher <yannick.vaucher@camptocamp.com>

--- a/partner_company_group/views/account_invoice_view.xml
+++ b/partner_company_group/views/account_invoice_view.xml
@@ -6,7 +6,7 @@
         <field name="priority">2</field>
         <field name="inherit_id" ref="account.view_account_invoice_filter"/>
         <field name="arch" type="xml">
-            <field name="number" position="before">
+            <field name="number" position="after">
                 <field name="company_group_id" />
             </field>
             <filter name="group_by_partner_id" position="before">

--- a/partner_company_group/views/opportunity_view.xml
+++ b/partner_company_group/views/opportunity_view.xml
@@ -5,7 +5,7 @@
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.view_crm_case_opportunities_filter" />
         <field name="arch" type="xml">
-            <field name="name" position="before">
+            <field name="name" position="after">
                 <field name="company_group_id" />
             </field>
             <filter name="salesperson" position="before">

--- a/partner_company_group/views/sale_order_view.xml
+++ b/partner_company_group/views/sale_order_view.xml
@@ -5,7 +5,7 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_sales_order_filter" />
         <field name="arch" type="xml">
-            <field name="name" position="before">
+            <field name="name" position="after">
                 <field name="company_group_id" />
             </field>
             <filter name="customer" position="before">


### PR DESCRIPTION
Search on company group shouldn't overwrite the default invoice number search.

First search field needs to be the name/number in order to now have to go in the dropdown list to make your search on the most important field.