### PR TITLE
Add normalization and optional duplicate filter to partner_email_check

### DIFF
--- a/partner_email_check/README.rst
+++ b/partner_email_check/README.rst
@@ -18,7 +18,7 @@ although validation and normalization are still supported in such cases.
 Configuration
 =============
 
-Install python package validate_email: ``sudo pip install email-validator``.
+Install python package email-validator: ``sudo pip install email-validator``.
 
 To not allow multiple partners to have the same email address, use the
 "Filter duplicate email addresses"/``partner_email_check_filter_duplicates``

--- a/partner_email_check/README.rst
+++ b/partner_email_check/README.rst
@@ -6,12 +6,23 @@
 Partner Email Check
 ===================
 
-This module validate the field ``email`` in the module ``res.partner``.
+This module validates and normalizes the field ``email`` in the module
+``res.partner``.
+
+As part of the normalization, email addresses are converted to lowercase.
+
+Optionally, multiple partners can not be allowed to have the same address.
+This will not work with multiple comma-separated email addresses in the field,
+although validation and normalization are still supported in such cases.
 
 Configuration
 =============
 
-Install python package validate_email: ``sudo pip install validate_email``.
+Install python package validate_email: ``sudo pip install email-validator``.
+
+To not allow multiple partners to have the same email address, use the
+"Filter duplicate email addresses"/``partner_email_check_filter_duplicates``
+setting.
 
 Usage
 =====

--- a/partner_email_check/__manifest__.py
+++ b/partner_email_check/__manifest__.py
@@ -9,11 +9,14 @@
     'author': "Komit, Odoo Community Association (OCA)",
     'website': 'http://komit-consulting.com',
     'category': 'Tools',
-    'depends': ['base'],
+    'depends': ['base_setup'],
     'installable': True,
     'application': False,
     'license': 'AGPL-3',
     'external_dependencies': {
-        'python': ['validate_email']
+        'python': ['email_validator']
     },
+    'data': [
+        'views/base_config_view.xml',
+    ]
 }

--- a/partner_email_check/models/__init__.py
+++ b/partner_email_check/models/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2017 Komit <http://komit-consulting.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import res_partner
+from . import base_config_settings, res_partner

--- a/partner_email_check/models/__init__.py
+++ b/partner_email_check/models/__init__.py
@@ -2,4 +2,5 @@
 # Copyright 2017 Komit <http://komit-consulting.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import base_config_settings, res_partner
+from . import base_config_settings
+from . import res_partner

--- a/partner_email_check/models/base_config_settings.py
+++ b/partner_email_check/models/base_config_settings.py
@@ -1,0 +1,26 @@
+from odoo import api, fields, models
+
+
+class BaseConfigSettings(models.TransientModel):
+    _inherit = 'base.config.settings'
+
+    partner_email_check_filter_duplicates = fields.Boolean(
+        string="Filter duplicate partner email addresses",
+        help="Don't allow multiple partners to have the same email address.",
+    )
+
+    @api.multi
+    def set_partner_email_check_filter_duplicates(self):
+        self.env['ir.config_parameter'].set_param(
+            'partner_email_check_filter_duplicates',
+            str(self.partner_email_check_filter_duplicates)
+        )
+
+    @api.model
+    def get_default_partner_email_check_filter_duplicates(self, fields):
+        return {
+            'partner_email_check_filter_duplicates':
+                self.env['ir.config_parameter'].get_param(
+                    'partner_email_check_filter_duplicates', False
+                ) == 'True'
+        }

--- a/partner_email_check/models/base_config_settings.py
+++ b/partner_email_check/models/base_config_settings.py
@@ -9,6 +9,11 @@ class BaseConfigSettings(models.TransientModel):
         help="Don't allow multiple partners to have the same email address.",
     )
 
+    partner_email_check_check_deliverability = fields.Boolean(
+        string="Check deliverability of email addresses",
+        help="Don't allow email addresses with providers that don't exist",
+    )
+
     @api.multi
     def set_partner_email_check_filter_duplicates(self):
         self.env['ir.config_parameter'].set_param(
@@ -24,11 +29,6 @@ class BaseConfigSettings(models.TransientModel):
                     'partner_email_check_filter_duplicates', 'False'
                 ) == 'True'
         }
-
-    partner_email_check_check_deliverability = fields.Boolean(
-        string="Check deliverability of email addresses",
-        help="Don't allow email addresses with providers that don't exist",
-    )
 
     @api.multi
     def set_partner_email_check_check_deliverability(self):

--- a/partner_email_check/models/base_config_settings.py
+++ b/partner_email_check/models/base_config_settings.py
@@ -21,6 +21,27 @@ class BaseConfigSettings(models.TransientModel):
         return {
             'partner_email_check_filter_duplicates':
                 self.env['ir.config_parameter'].get_param(
-                    'partner_email_check_filter_duplicates', False
+                    'partner_email_check_filter_duplicates', 'False'
+                ) == 'True'
+        }
+
+    partner_email_check_check_deliverability = fields.Boolean(
+        string="Check deliverability of email addresses",
+        help="Don't allow email addresses with providers that don't exist",
+    )
+
+    @api.multi
+    def set_partner_email_check_check_deliverability(self):
+        self.env['ir.config_parameter'].set_param(
+            'partner_email_check_check_deliverability',
+            str(self.partner_email_check_check_deliverability)
+        )
+
+    @api.model
+    def get_default_partner_email_check_check_deliverability(self, fields):
+        return {
+            'partner_email_check_check_deliverability':
+                self.env['ir.config_parameter'].get_param(
+                    'partner_email_check_check_deliverability', 'False'
                 ) == 'True'
         }

--- a/partner_email_check/models/res_partner.py
+++ b/partner_email_check/models/res_partner.py
@@ -24,8 +24,7 @@ class ResPartner(models.Model):
         return ','.join(self._normalize_email(email.strip())
                         for email in emails.split(','))
 
-    @staticmethod
-    def _normalize_email(email):
+    def _normalize_email(self, email):
         if validate_email is None:
             _logger.warning(
                 'Can not validate email, '
@@ -35,7 +34,7 @@ class ResPartner(models.Model):
         try:
             result = validate_email(
                 email,
-                check_deliverability=not tools.config['test_enable'],
+                check_deliverability=self._should_check_deliverability(),
             )
         except EmailNotValidError as e:
             raise ValidationError(
@@ -45,7 +44,13 @@ class ResPartner(models.Model):
 
     def _should_filter_duplicates(self):
         conf = self.env['ir.config_parameter'].get_param(
-            'partner_email_check_filter_duplicates', False
+            'partner_email_check_filter_duplicates', 'False'
+        )
+        return conf == 'True'
+
+    def _should_check_deliverability(self):
+        conf = self.env['ir.config_parameter'].get_param(
+            'partner_email_check_check_deliverability', 'False'
         )
         return conf == 'True'
 

--- a/partner_email_check/models/res_partner.py
+++ b/partner_email_check/models/res_partner.py
@@ -3,36 +3,85 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
-from odoo import api, models, _
+from odoo import api, models, tools, _
 from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
 try:
-    from validate_email import validate_email
+    from email_validator import validate_email, EmailNotValidError
 except ImportError:
-    _logger.debug('Cannot import "validate_email".')
+    _logger.debug('Cannot import "email_validator".')
 
-    def validate_email(email):
-        _logger.warning(
-            'Can not validate email, '
-            'python dependency required "validate_email"')
-        return True
+    validate_email = None
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    @api.constrains('email')
-    def constrains_email(self):
-        for rec in self.filtered("email"):
-            self.email_check(rec.email)
-
     @api.model
     def email_check(self, emails):
-        for email in emails.split(','):
-            if not validate_email(email):
-                raise ValidationError(
-                    _("%s is an invalid email") % email.strip()
-                )
-        return True
+        return ','.join(self._normalize_email(email.strip())
+                        for email in emails.split(','))
+
+    @staticmethod
+    def _normalize_email(email):
+        if validate_email is None:
+            _logger.warning(
+                'Can not validate email, '
+                'python dependency required "email_validator"')
+            return email
+
+        try:
+            result = validate_email(
+                email,
+                check_deliverability=not tools.config['test_enable'],
+            )
+        except EmailNotValidError as e:
+            raise ValidationError(
+                _("%s is an invalid email: %s") % (email.strip(), e.message)
+            )
+        return result['local'].lower() + '@' + result['domain_i18n']
+
+    def _should_filter_duplicates(self):
+        conf = self.env['ir.config_parameter'].get_param(
+            'partner_email_check_filter_duplicates', False
+        )
+        return conf == 'True'
+
+    def _validate_no_duplicates(self, email):
+        is_existing_record = bool(self)
+        if is_existing_record:
+            self.ensure_one()
+
+        if is_existing_record and email == self.email:
+            # No change, no need to check
+            return
+
+        if ',' in email:
+            raise ValidationError(
+                _("Field contains multiple email addresses. This is not "
+                  "supported when duplicate email addresses are not allowed.")
+            )
+
+        domain = [('email', '=', email)]
+        if is_existing_record:
+            domain.append(('id', '!=', self.id))
+        if self.search(domain, limit=1):
+            raise ValidationError(_("Email '%s' is already in use.") % email)
+
+    @api.model
+    def create(self, vals):
+        if vals.get('email', False):
+            vals['email'] = self.email_check(vals['email'])
+            if self._should_filter_duplicates():
+                self._validate_no_duplicates(vals['email'])
+        return super(ResPartner, self).create(vals)
+
+    @api.multi
+    def write(self, vals):
+        if vals.get('email', False):
+            vals['email'] = self.email_check(vals['email'])
+            if self._should_filter_duplicates():
+                self._validate_no_duplicates(vals['email'])
+        return super(ResPartner, self).write(vals)

--- a/partner_email_check/models/res_partner.py
+++ b/partner_email_check/models/res_partner.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
-from odoo import api, models, tools, _
+from odoo import api, models, _
 from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)

--- a/partner_email_check/tests/test_partner_email_check.py
+++ b/partner_email_check/tests/test_partner_email_check.py
@@ -15,6 +15,9 @@ class TestPartnerEmailCheck(TransactionCase):
         self.env['ir.config_parameter'].set_param(
             'partner_email_check_filter_duplicates', False
         )
+        self.env['ir.config_parameter'].set_param(
+            'partner_email_check_check_deliverability', False
+        )
 
     def test_bad_email(self):
         """Test rejection of bad emails."""

--- a/partner_email_check/tests/test_partner_email_check.py
+++ b/partner_email_check/tests/test_partner_email_check.py
@@ -12,6 +12,9 @@ class TestPartnerEmailCheck(TransactionCase):
         self.test_partner = self.env['res.partner'].create({
             'name': 'test',
         })
+        self.env['ir.config_parameter'].set_param(
+            'partner_email_check_filter_duplicates', False
+        )
 
     def test_bad_email(self):
         """Test rejection of bad emails."""
@@ -32,3 +35,67 @@ class TestPartnerEmailCheck(TransactionCase):
         """Test acceptance of good"""
         self.test_partner.email = 'goodemail@domain.com,goodemail2@domain.com'
         self.assertTrue(self.test_partner.email)
+
+    def test_email_domain_normalization(self):
+        """Test normalization of email domain names, including punycode."""
+        self.test_partner.write({'email': 'goodemail@xn--xamPle-9ua.com'})
+        self.assertEqual(self.test_partner.email, u'goodemail@éxample.com')
+
+    def test_multi_email_domain_normalization(self):
+        """Test normalization of email domain names of multiple addresses."""
+        self.test_partner.write({
+            'email': 'goodemail@doMAIN.com,othergood@xn--xample-9ua.com'
+        })
+        self.assertEqual(
+            self.test_partner.email,
+            u'goodemail@domain.com,othergood@éxample.com'
+        )
+
+    def test_email_local_normalization(self):
+        """Test normalization of the local part of email addresses."""
+        self.test_partner.write({'email': 'Me@mail.org'})
+        # .lower() is locale-dependent, so don't hardcode the result
+        self.assertEqual(self.test_partner.email, 'Me'.lower() + '@mail.org')
+
+    def test_multi_email_local_normalization(self):
+        """Test normalization of the local part of multiple addresses."""
+        self.test_partner.write({'email': 'You@mAiL.net,mE@mail.com'})
+        self.assertEqual(
+            self.test_partner.email,
+            'You'.lower() + '@mail.net,' + 'mE'.lower() + '@mail.com'
+        )
+
+    def disallow_duplicates(self):
+        self.env['ir.config_parameter'].set_param(
+            'partner_email_check_filter_duplicates', True
+        )
+
+    def test_duplicate_addresses_disallowed(self):
+        self.disallow_duplicates()
+        self.test_partner.write({'email': 'email@domain.tld'})
+        with self.assertRaises(ValidationError):
+            self.env['res.partner'].create({
+                'name': 'alsotest',
+                'email': 'email@domain.tld'
+            })
+
+    def test_duplicate_after_normalization_addresses_disallowed(self):
+        self.disallow_duplicates()
+        self.env['res.partner'].create({
+            'name': 'alsotest',
+            'email': 'email@doMAIN.tld'
+        })
+        with self.assertRaises(ValidationError):
+            self.test_partner.email = 'email@domain.tld'
+
+    def test_multiple_addresses_disallowed_when_duplicates_filtered(self):
+        self.disallow_duplicates()
+        with self.assertRaises(ValidationError):
+            self.test_partner.email = 'foo@bar.org,email@domain.tld'
+
+    def test_duplicate_addresses_allowed_by_default(self):
+        self.env['res.partner'].create({
+            'name': 'alsotest',
+            'email': 'email@domain.tld',
+        })
+        self.test_partner.email = 'email@domain.tld'

--- a/partner_email_check/views/base_config_view.xml
+++ b/partner_email_check/views/base_config_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="view_general_configuration" model="ir.ui.view">
-        <field name="name">partner_email_check_filter_duplicates</field>
+        <field name="name">partner_email_check</field>
         <field name="model">base.config.settings</field>
         <field name="inherit_id" ref="base_setup.view_general_configuration" />
         <field name="arch" type="xml">
@@ -11,6 +11,14 @@
                 <div>
                     <div>
                         <field name="partner_email_check_filter_duplicates" class="oe_inline" />
+                    </div>
+                </div>
+            </group>
+            <group>
+                <label for="partner_email_check_check_deliverability" />
+                <div>
+                    <div>
+                        <field name="partner_email_check_check_deliverability" class="oe_inline" />
                     </div>
                 </div>
             </group>

--- a/partner_email_check/views/base_config_view.xml
+++ b/partner_email_check/views/base_config_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_general_configuration" model="ir.ui.view">
+        <field name="name">partner_email_check_filter_duplicates</field>
+        <field name="model">base.config.settings</field>
+        <field name="inherit_id" ref="base_setup.view_general_configuration" />
+        <field name="arch" type="xml">
+            <xpath expr="//label[@name='email_label']/.." position='after'>
+            <group>
+                <label for="partner_email_check_filter_duplicates" />
+                <div>
+                    <div>
+                        <field name="partner_email_check_filter_duplicates" class="oe_inline" />
+                    </div>
+                </div>
+            </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- `partner_email_check` now uses the `email-validator` package instead of `validate_email`
- Email addresses are normalized
- There is a setting to not allow multiple partners to use the same email address