### PR TITLE
[FIX] [partner_firstname] don't update user's name in onchange

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -246,6 +246,22 @@ class ResPartner(models.Model):
         records._inverse_name()
         _logger.info("%d partners updated installing module.", len(records))
 
+    @api.multi
+    def onchange(self, values, field_name, field_onchange):
+        """when one of our name fields is changed, suppress updates to the
+        connected user's (user_ids) name, as this in turn would cause another
+        write on the partner's name, with possible mistakes in parsing the
+        parts"""
+        if field_name in getattr(self._compute_name, '_depends', {}):
+            field_onchange = {
+                field_path: value
+                for field_path, value in field_onchange.iteritems()
+                if field_path != 'user_ids.name'
+            }
+        return super(ResPartner, self).onchange(
+            values, field_name, field_onchange,
+        )
+
     # Disabling SQL constraint givint a more explicit error using a Python
     # contstraint
     _sql_constraints = [(


### PR DESCRIPTION
to reproduce the problem, go to runbot, and open the demo user's partner form as admin. Fill in ``Mary Jane`` as first name, and ``Watson`` as last name. We will end up with the result of `Mary Jane Watson` being parsed as name, which is wrong.

This is caused by the writable (invisible) [`user_ids`](https://github.com/OCA/OCB/blob/10.0/odoo/addons/base/res/res_partner_view.xml#L79) field on the form, as with this, we get an updated user name, which in turn triggers a write on the partner, overwriting what we just set with the result of `_inverse_name`.

I considered other options to tackle this (making the field in this form readonly works, but is not general enough, and suppressing this on write might have side effects we don't like), but I consider this the version with the least possible side effects.

On framework level, we should actually throw away writes to fields that will be recomputed by the same write anyways, but I've very little hope to get this merged so I don't even try.