### PR TITLE
[10.0] [FIX] Fix partner_email_check conflict with portal, bump version

### DIFF
--- a/partner_email_check/__manifest__.py
+++ b/partner_email_check/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Email Format Checker',
-    'version': '10.0.1.0.2',
+    'version': '10.0.1.1.0',
     'summary': 'Validate email address field',
     'author': "Komit, Odoo Community Association (OCA)",
     'website': 'http://komit-consulting.com',

--- a/partner_email_check/models/res_partner.py
+++ b/partner_email_check/models/res_partner.py
@@ -5,6 +5,7 @@
 import logging
 from odoo import api, models, _
 from odoo.exceptions import ValidationError
+from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
 
@@ -25,6 +26,9 @@ class ResPartner(models.Model):
 
     @api.model
     def email_check(self, emails):
+        if (config['test_enable'] and
+                not self.env.context.get('test_partner_email_check')):
+            return emails
         return ','.join(self._normalize_email(email.strip())
                         for email in emails.split(','))
 

--- a/partner_email_check/tests/test_partner_email_check.py
+++ b/partner_email_check/tests/test_partner_email_check.py
@@ -12,7 +12,11 @@ from odoo.tools.misc import mute_logger
 class TestPartnerEmailCheck(TransactionCase):
     def setUp(self):
         super(TestPartnerEmailCheck, self).setUp()
-        self.test_partner = self.env['res.partner'].create({
+        # Checks are disabled during tests unless this key is set
+        self.res_partner = self.env['res.partner'].with_context(
+            test_partner_email_check=True
+        )
+        self.test_partner = self.res_partner.create({
             'name': 'test',
         })
         self.wizard = self.env['base.config.settings'].create({})
@@ -78,14 +82,14 @@ class TestPartnerEmailCheck(TransactionCase):
         self.disallow_duplicates()
         self.test_partner.write({'email': 'email@domain.tld'})
         with self.assertRaises(ValidationError):
-            self.env['res.partner'].create({
+            self.res_partner.create({
                 'name': 'alsotest',
                 'email': 'email@domain.tld'
             })
 
     def test_duplicate_after_normalization_addresses_disallowed(self):
         self.disallow_duplicates()
-        self.env['res.partner'].create({
+        self.res_partner.create({
             'name': 'alsotest',
             'email': 'email@doMAIN.tld'
         })
@@ -98,7 +102,7 @@ class TestPartnerEmailCheck(TransactionCase):
             self.test_partner.email = 'foo@bar.org,email@domain.tld'
 
     def test_duplicate_addresses_allowed_by_default(self):
-        self.env['res.partner'].create({
+        self.res_partner.create({
             'name': 'alsotest',
             'email': 'email@domain.tld',
         })
@@ -143,9 +147,17 @@ class TestPartnerEmailCheck(TransactionCase):
         self.disallow_duplicates()
         with patch('odoo.addons.partner_email_check.models.res_partner.'
                    'validate_email', None):
-            self.env['res.partner'].create({
+            self.res_partner.create({
                 'name': 'alsotest',
                 'email': 'email@domain.tld'
             })
             with self.assertRaises(ValidationError):
                 self.test_partner.email = 'email@domain.tld'
+
+    def test_invalid_email_addresses_allowed_during_tests(self):
+        # Note: testing without test_partner_email_check in the context
+        new_partner = self.env['res.partner'].create({
+            'name': 'invalidly emailed',
+            'email': 'invalid'
+        })
+        self.assertEqual('invalid', new_partner.email)


### PR DESCRIPTION
`portal`'s tests [set an invalid email address, `c@c`](https://github.com/OCA/OCB/blob/10.0/addons/portal/tests/test_portal.py#L41), that's rejected by the current version of `partner_email_check`. If `partner_email_check` is installed before `portal`'s tests run then they fail. To solve this, use [`base_manifest_extension`](https://github.com/OCA/server-tools/tree/10.0/base_manifest_extension) to force `portal`'s tests to run first.

The previous update to `partner_email_check` didn't bump the version number, so do that now too.