### PR TITLE
Fix partner contact name settings

### DIFF
--- a/base_location_geonames_import/__init__.py
+++ b/base_location_geonames_import/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 from . import models
 from . import wizard

--- a/base_location_geonames_import/__manifest__.py
+++ b/base_location_geonames_import/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2016 Akretion (Alexis de Lattre
 #                     <alexis.delattre@akretion.com>)
 # Copyright 2014 Lorenzo Battistini <lorenzo.battistini@agilebg.com>

--- a/base_location_geonames_import/models/__init__.py
+++ b/base_location_geonames_import/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Franco Tampieri, Freelancer http://franco.tampieri.info
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/base_location_geonames_import/models/res_country.py
+++ b/base_location_geonames_import/models/res_country.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Franco Tampieri, Freelancer http://franco.tampieri.info
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/base_location_geonames_import/tests/__init__.py
+++ b/base_location_geonames_import/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_base_location_geonames_import

--- a/base_location_geonames_import/tests/test_base_location_geonames_import.py
+++ b/base_location_geonames_import/tests/test_base_location_geonames_import.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/base_location_geonames_import/wizard/__init__.py
+++ b/base_location_geonames_import/wizard/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 
 from . import geonames_import

--- a/base_location_geonames_import/wizard/geonames_import.py
+++ b/base_location_geonames_import/wizard/geonames_import.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2016 Akretion (Alexis de Lattre
 #                     <alexis.delattre@akretion.com>)
 # Copyright 2014 Lorenzo Battistini <lorenzo.battistini@agilebg.com>

--- a/base_location_nuts/__manifest__.py
+++ b/base_location_nuts/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>

--- a/base_location_nuts/wizard/nuts_import.py
+++ b/base_location_nuts/wizard/nuts_import.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # Copyright 2017 David Vidal <jairo.llopis@tecnativa.com>

--- a/base_partner_sequence/tests/__init__.py
+++ b/base_partner_sequence/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2004-2009 Tiny SPRL (<http://tiny.be>).
 # Copyright 2013 initOS GmbH & Co. KG (<http://www.initos.com>).
 # Copyright 2016 Tecnativa - Vicent Cubells

--- a/base_partner_sequence/tests/test_base_partner_sequence.py
+++ b/base_partner_sequence/tests/test_base_partner_sequence.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015 ACSONE SA/NV (<http://acsone.eu>).
 # Copyright 2016 Tecnativa - Vicent Cubells
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/partner_affiliate/__init__.py
+++ b/partner_affiliate/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012 Camptocamp SA - Yannick Vaucher
 # Copyright 2018 brain-tec AG - Raul Martin
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/partner_affiliate/__manifest__.py
+++ b/partner_affiliate/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012 Camptocamp SA - Yannick Vaucher
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2018 brain-tec AG - Raul Martin

--- a/partner_affiliate/models/__init__.py
+++ b/partner_affiliate/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012 Camptocamp SA - Yannick Vaucher
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012 Camptocamp SA - Yannick Vaucher
 # Copyright 2018 brain-tec AG - Raul Martin
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/partner_contact_in_several_companies/__manifest__.py
+++ b/partner_contact_in_several_companies/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {

--- a/partner_contact_in_several_companies/models/__init__.py
+++ b/partner_contact_in_several_companies/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import res_partner, ir_actions

--- a/partner_contact_in_several_companies/models/ir_actions.py
+++ b/partner_contact_in_several_companies/models/ir_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, models

--- a/partner_contact_in_several_companies/models/res_partner.py
+++ b/partner_contact_in_several_companies/models/res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models, _

--- a/partner_contact_in_several_companies/tests/__init__.py
+++ b/partner_contact_in_several_companies/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_partner_contact_in_several_companies

--- a/partner_contact_in_several_companies/tests/test_partner_contact_in_several_companies.py
+++ b/partner_contact_in_several_companies/tests/test_partner_contact_in_several_companies.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.tests import common
 

--- a/partner_contact_personal_information_page/__manifest__.py
+++ b/partner_contact_personal_information_page/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {

--- a/partner_external_map/__init__.py
+++ b/partner_external_map/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 from . import models
 from .hooks import set_default_map_settings

--- a/partner_external_map/__manifest__.py
+++ b/partner_external_map/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2016 Akretion - Alexis de Lattre
 # Copyright 2016-2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/partner_external_map/hooks.py
+++ b/partner_external_map/hooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Alexis de Lattre <alexis.delattre@akretion.com>
 # © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/partner_external_map/models/__init__.py
+++ b/partner_external_map/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 from . import map_website
 from . import res_partner

--- a/partner_external_map/models/map_website.py
+++ b/partner_external_map/models/map_website.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/partner_external_map/models/res_partner.py
+++ b/partner_external_map/models/res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/partner_external_map/models/res_users.py
+++ b/partner_external_map/models/res_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/partner_external_map/tests/__init__.py
+++ b/partner_external_map/tests/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 
 from . import test_partner_external_map

--- a/partner_external_map/tests/test_partner_external_map.py
+++ b/partner_external_map/tests/test_partner_external_map.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/partner_firstname/__init__.py
+++ b/partner_firstname/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Nicolas Bessi (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/__manifest__.py
+++ b/partner_firstname/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Nicolas Bessi (Camptocamp SA)
 # © 2014 Agile Business Group (<http://www.agilebg.com>)
 # © 2015 Grupo ESOC (<http://www.grupoesoc.es>)

--- a/partner_firstname/exceptions.py
+++ b/partner_firstname/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2014-2015 Grupo ESOC (<http://www.grupoesoc.es>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, exceptions

--- a/partner_firstname/hooks.py
+++ b/partner_firstname/hooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/i18n/am.po
+++ b/partner_firstname/i18n/am.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/ar.po
+++ b/partner_firstname/i18n/ar.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/bg.po
+++ b/partner_firstname/i18n/bg.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/bs.po
+++ b/partner_firstname/i18n/bs.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/ca.po
+++ b/partner_firstname/i18n/ca.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/cs.po
+++ b/partner_firstname/i18n/cs.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/da.po
+++ b/partner_firstname/i18n/da.po
@@ -92,7 +92,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/de.po
+++ b/partner_firstname/i18n/de.po
@@ -90,5 +90,5 @@ msgstr "Anwender"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
-msgstr "res.config.settings"
+msgid "partner.firstname.settings"
+msgstr "partner.firstname.settings"

--- a/partner_firstname/i18n/el_GR.po
+++ b/partner_firstname/i18n/el_GR.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/en_GB.po
+++ b/partner_firstname/i18n/en_GB.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/es.po
+++ b/partner_firstname/i18n/es.po
@@ -90,5 +90,5 @@ msgstr "Usuarios"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
-msgstr "res.config.settings"
+msgid "partner.firstname.settings"
+msgstr "partner.firstname.settings"

--- a/partner_firstname/i18n/es_CR.po
+++ b/partner_firstname/i18n/es_CR.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/es_EC.po
+++ b/partner_firstname/i18n/es_EC.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/es_MX.po
+++ b/partner_firstname/i18n/es_MX.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/es_VE.po
+++ b/partner_firstname/i18n/es_VE.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/et.po
+++ b/partner_firstname/i18n/et.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/eu.po
+++ b/partner_firstname/i18n/eu.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/fi.po
+++ b/partner_firstname/i18n/fi.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/fr.po
+++ b/partner_firstname/i18n/fr.po
@@ -91,5 +91,5 @@ msgstr "Utilisateurs"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
-msgstr "res.config.settings"
+msgid "partner.firstname.settings"
+msgstr "partner.firstname.settings"

--- a/partner_firstname/i18n/fr_CA.po
+++ b/partner_firstname/i18n/fr_CA.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/fr_CH.po
+++ b/partner_firstname/i18n/fr_CH.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/gl.po
+++ b/partner_firstname/i18n/gl.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/hr.po
+++ b/partner_firstname/i18n/hr.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/hr_HR.po
+++ b/partner_firstname/i18n/hr_HR.po
@@ -89,5 +89,5 @@ msgstr "Korisnici"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""

--- a/partner_firstname/i18n/hu.po
+++ b/partner_firstname/i18n/hu.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/it.po
+++ b/partner_firstname/i18n/it.po
@@ -87,5 +87,5 @@ msgstr "Utenti"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""

--- a/partner_firstname/i18n/ja.po
+++ b/partner_firstname/i18n/ja.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/lt.po
+++ b/partner_firstname/i18n/lt.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/lv.po
+++ b/partner_firstname/i18n/lv.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/mk.po
+++ b/partner_firstname/i18n/mk.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/mn.po
+++ b/partner_firstname/i18n/mn.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/nb.po
+++ b/partner_firstname/i18n/nb.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/nb_NO.po
+++ b/partner_firstname/i18n/nb_NO.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/nl.po
+++ b/partner_firstname/i18n/nl.po
@@ -87,5 +87,5 @@ msgstr "Gebruikers"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""

--- a/partner_firstname/i18n/nl_BE.po
+++ b/partner_firstname/i18n/nl_BE.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/nl_NL.po
+++ b/partner_firstname/i18n/nl_NL.po
@@ -90,5 +90,5 @@ msgstr "Gebruikers"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
-msgstr "res.config.settings"
+msgid "partner.firstname.settings"
+msgstr "partner.firstname.settings"

--- a/partner_firstname/i18n/partner_firstname.pot
+++ b/partner_firstname/i18n/partner_firstname.pot
@@ -80,6 +80,6 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 

--- a/partner_firstname/i18n/pl.po
+++ b/partner_firstname/i18n/pl.po
@@ -89,7 +89,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/pt.po
+++ b/partner_firstname/i18n/pt.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/pt_BR.po
+++ b/partner_firstname/i18n/pt_BR.po
@@ -88,5 +88,5 @@ msgstr "Usuarios"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""

--- a/partner_firstname/i18n/pt_PT.po
+++ b/partner_firstname/i18n/pt_PT.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/ro.po
+++ b/partner_firstname/i18n/ro.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/ru.po
+++ b/partner_firstname/i18n/ru.po
@@ -89,7 +89,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/sk.po
+++ b/partner_firstname/i18n/sk.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/sl.po
+++ b/partner_firstname/i18n/sl.po
@@ -88,5 +88,5 @@ msgstr "Uporabniki"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""

--- a/partner_firstname/i18n/sr@latin.po
+++ b/partner_firstname/i18n/sr@latin.po
@@ -89,7 +89,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/sv.po
+++ b/partner_firstname/i18n/sv.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/th.po
+++ b/partner_firstname/i18n/th.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/tr.po
+++ b/partner_firstname/i18n/tr.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/tr_TR.po
+++ b/partner_firstname/i18n/tr_TR.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/vi.po
+++ b/partner_firstname/i18n/vi.po
@@ -87,7 +87,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/zh_CN.po
+++ b/partner_firstname/i18n/zh_CN.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/i18n/zh_TW.po
+++ b/partner_firstname/i18n/zh_TW.po
@@ -88,7 +88,7 @@ msgstr ""
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_config_settings
-msgid "res.config.settings"
+msgid "partner.firstname.settings"
 msgstr ""
 
 #~ msgid "Partner"

--- a/partner_firstname/models/__init__.py
+++ b/partner_firstname/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/models/base_config_settings.py
+++ b/partner_firstname/models/base_config_settings.py
@@ -9,6 +9,7 @@ _logger = logging.getLogger(__name__)
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
+    _name = 'partner.firstname.settings'
 
     partner_names_order = fields.Selection(
         string="Partner names order",

--- a/partner_firstname/models/base_config_settings.py
+++ b/partner_firstname/models/base_config_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Nicolas Bessi (Camptocamp SA)
 # © 2014 Agile Business Group (<http://www.agilebg.com>)
 # © 2015 Grupo ESOC (<http://www.grupoesoc.es>)

--- a/partner_firstname/models/res_users.py
+++ b/partner_firstname/models/res_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Nicolas Bessi (Camptocamp SA)
 # © 2014 Agile Business Group (<http://www.agilebg.com>)
 # © 2015 Grupo ESOC (<http://www.grupoesoc.es>)

--- a/partner_firstname/tests/__init__.py
+++ b/partner_firstname/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2014 Nemry Jonathan (Acsone SA/NV) (http://www.acsone.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/tests/base.py
+++ b/partner_firstname/tests/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2014 Nemry Jonathan (Acsone SA/NV) (http://www.acsone.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/tests/test_create.py
+++ b/partner_firstname/tests/test_create.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Grupo ESOC Ingeniería de Servicios, S.L. - Jairo Llopis.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/tests/test_defaults.py
+++ b/partner_firstname/tests/test_defaults.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Grupo ESOC Ingeniería de Servicios, S.L. - Jairo Llopis.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/tests/test_delete.py
+++ b/partner_firstname/tests/test_delete.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Grupo ESOC
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/tests/test_empty.py
+++ b/partner_firstname/tests/test_empty.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2014-2015 Grupo ESOC <www.grupoesoc.es>
 # © 2016 Yannick Vaucher (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/partner_firstname/tests/test_name.py
+++ b/partner_firstname/tests/test_name.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 # Authors: Nemry Jonathan
 # Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)

--- a/partner_firstname/tests/test_onchange.py
+++ b/partner_firstname/tests/test_onchange.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Grupo ESOC <www.grupoesoc.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/tests/test_order.py
+++ b/partner_firstname/tests/test_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_firstname/tests/test_user_onchange.py
+++ b/partner_firstname/tests/test_user_onchange.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Yannick Vaucher (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/partner_firstname/views/base_config_view.xml
+++ b/partner_firstname/views/base_config_view.xml
@@ -5,7 +5,7 @@
 
     <record id="view_general_configuration" model="ir.ui.view">
         <field name="name">Add partner_names_order config parameter</field>
-        <field name="model">res.config.settings</field>
+        <field name="model">partner.firstname.settings</field>
         <field name="inherit_id"
                ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">

--- a/partner_second_lastname/__init__.py
+++ b/partner_second_lastname/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # © 2015 Grupo ESOC Ingeniería de Servicios, S.L.U.
 

--- a/partner_second_lastname/__manifest__.py
+++ b/partner_second_lastname/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015 Grupo ESOC Ingeniería de Servicios, S.L.U. - Jairo Llopis
 # Copyright 2015 Antiun Ingenieria S.L. - Antonio Espinosa
 # Copyright 2017 Tecnativa - Pedro M. Baeza

--- a/partner_second_lastname/models/__init__.py
+++ b/partner_second_lastname/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_second_lastname/models/res_config_settings.py
+++ b/partner_second_lastname/models/res_config_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_second_lastname/models/res_partner.py
+++ b/partner_second_lastname/models/res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # Copyright 2015 Grupo ESOC Ingeniería de Servicios, S.L.U. - Jairo Llopis
 # Copyright 2015 Antiun Ingenieria S.L. - Antonio Espinosa

--- a/partner_second_lastname/tests/__init__.py
+++ b/partner_second_lastname/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_name

--- a/partner_second_lastname/tests/test_config.py
+++ b/partner_second_lastname/tests/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/partner_second_lastname/tests/test_name.py
+++ b/partner_second_lastname/tests/test_name.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # © 2015 Grupo ESOC Ingeniería de Servicios, S.L.U.
 # © 2015 Antiun Ingenieria S.L. - Antonio Espinosa

--- a/partner_second_lastname/tests/test_onchange.py
+++ b/partner_second_lastname/tests/test_onchange.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # © 2015 Grupo ESOC Ingeniería de Servicios, S.L.U.
 # © 2015 Antiun Ingenieria S.L. - Antonio Espinosa


### PR DESCRIPTION
FIX bad inheritance of class `res.config.settings` which could break other settings wizards. It should not override the base class but create a new child class instead.

I also removed the unneeded UTF8 headers.