### PR TITLE
[12.0] [ADD] Domain on country_id for partner company type

### DIFF
--- a/partner_company_type/models/res_partner_company_type.py
+++ b/partner_company_type/models/res_partner_company_type.py
@@ -18,6 +18,13 @@ class ResPartnerCompanyType(models.Model):
         string='Abbreviation',
         translate=True,
     )
+    country_id = fields.Many2one(
+        comodel_name="res.country",
+        string="Country",
+        help="Allows this company type to be selected on partners from this "
+        "country only. "
+        "Leave it blank if you want it to appear on any partner.",
+    )
 
     _sql_constraints = [('name_uniq', 'unique (name)',
                          "Partner Company Type already exists!")]

--- a/partner_company_type/readme/CONTRIBUTORS.rst
+++ b/partner_company_type/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Denis Roussel <denis.roussel@acsone.eu> (https://acsone.eu)
 * Gilles Meyomesse <gilles.meyomesse@acsone.eu> (https://acsone.eu)
+* Quentin Groulard <quentin.groulard@acsone.eu> (https://acsone.eu)

--- a/partner_company_type/views/res_partner.xml
+++ b/partner_company_type/views/res_partner.xml
@@ -10,6 +10,7 @@
         <field name="arch" type="xml">
             <field name="title" position="after">
                 <field name="partner_company_type_id" options='{"no_open": True}'
+                domain="['|', ('country_id', '=', False), ('country_id', '=', country_id)]"
                 attrs="{'invisible': [('is_company', '=', False)]}"/>
             </field>
            </field>

--- a/partner_company_type/views/res_partner_company_type.xml
+++ b/partner_company_type/views/res_partner_company_type.xml
@@ -11,6 +11,7 @@
                 <group col="4">
                     <field name="name"/>
                     <field name="shortcut"/>
+                    <field name="country_id"/>
                 </group>
             </form>
         </field>
@@ -33,6 +34,7 @@
             <tree>
                 <field name="name"/>
                 <field name="shortcut"/>
+                <field name="country_id"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
From https://github.com/OCA/partner-contact/pull/798

Add field country_id on company types.
Filter company types on partner based on country_id in order to display only company types from the partner's country and company types with no country_id.

Use case:
Eases the selection of legal form on partners for companies dealing with customers from all around the world by avoiding them to be flooded with company types from other countries than the current partner's one.
