### PR TITLE
[12.0][FIX] partner_firstname. LDAP user: TypeError on name partner if byte found

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -137,7 +137,7 @@ class ResPartner(models.Model):
         """
         try:
             name = " ".join(name.split()) if name else name
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, TypeError):
             # with users coming from LDAP, name can be a str encoded as utf-8
             # this happens with ActiveDirectory for instance, and in that case
             # we get a UnicodeDecodeError during the automatic ASCII -> Unicode


### PR DESCRIPTION
with users coming from LDAP, the value name is a byte type
```
File "/usr/lib/python3/dist-packages/odoo/addons/base/models/res_users.py", line 630, in authenticate
    uid = cls._login(db, login, password)
  File "/opt/odoo/extra-addons/custom/auth_ldap/models/res_users.py", line 28, in _login
    return Ldap._get_or_create_user(conf, login, entry)
  File "/opt/odoo/extra-addons/custom/auth_ldap/models/res_company_ldap.py", line 198, in _get_or_create_user
    return SudoUser.browse(conf['user'][0]).copy(default=values).id
  File "/usr/lib/python3/dist-packages/odoo/addons/auth_signup/models/res_users.py", line 232, in copy
    return sup.copy(default=default)
  File "/opt/odoo/extra-addons/custom/partner_firstname/models/res_users.py", line 47, in copy
    default['name'], False)
  File "/opt/odoo/extra-addons/custom/partner_firstname/models/res_partner.py", line 176, in _get_inverse_name
    name, comma=(order == 'last_first_comma'))
  File "/opt/odoo/extra-addons/custom/partner_firstname/models/res_partner.py", line 139, in _get_whitespace_cleaned_name
    name = " ".join(name.split()) if name else name
TypeError: sequence item 0: expected str instance, bytes found - - -
```