### PR TITLE
[12.0][IMP] UX form view order first and last name

### DIFF
--- a/partner_firstname/views/res_partner.xml
+++ b/partner_firstname/views/res_partner.xml
@@ -15,12 +15,12 @@
 
                 <xpath expr="//h1//field[@name='name']/.." position="before">
                     <group attrs="{'invisible': [('is_company', '=', True)]}">
-                        <field name="lastname" attrs=
-                            "{'required': [('firstname', '=', False),
-                            ('is_company', '=', False),
-                            ('type', '=', 'contact')]}"/>
                         <field name="firstname" attrs=
                             "{'required': [('lastname', '=', False),
+                            ('is_company', '=', False),
+                            ('type', '=', 'contact')]}"/>
+                        <field name="lastname" attrs=
+                            "{'required': [('firstname', '=', False),
                             ('is_company', '=', False),
                             ('type', '=', 'contact')]}"/>
                     </group>
@@ -45,12 +45,12 @@
                 <xpath expr="//h1//field[@name='name']/.." position="after">
                     <div class="oe_edit_only">
                         <group attrs="{'invisible': [('is_company', '=', True)]}">
-                            <field name="lastname" attrs=
-                                "{'required': [('firstname', '=', False),
-                                ('is_company', '=', False),
-                                ('type', '=', 'contact')]}"/>
                             <field name="firstname" attrs=
                                 "{'required': [('lastname', '=', False),
+                                ('is_company', '=', False),
+                                ('type', '=', 'contact')]}"/>
+                            <field name="lastname" attrs=
+                                "{'required': [('firstname', '=', False),
                                 ('is_company', '=', False),
                                 ('type', '=', 'contact')]}"/>
                         </group>
@@ -71,12 +71,12 @@
                     <div class="oe_edit_only" colspan="2">
                         <field name="is_company" invisible="True"/>
                         <group attrs="{'invisible': [('is_company', '=', True)]}">
-                            <field name="lastname" attrs=
-                                "{'required': [('firstname', '=', False),
-                                ('is_company', '=', False),
-                                ('type', '=', 'contact')]}"/>
                             <field name="firstname" attrs=
                                 "{'required': [('lastname', '=', False),
+                                ('is_company', '=', False),
+                                ('type', '=', 'contact')]}"/>
+                            <field name="lastname" attrs=
+                                "{'required': [('firstname', '=', False),
                                 ('is_company', '=', False),
                                 ('type', '=', 'contact')]}"/>
                         </group>


### PR DESCRIPTION
Change to order of the fields first and last name of partner view to improve UX.
Entering 1. "first name" and 2. "lastname" is the official order format in any western countries by improving this code, users do not mix up first and last name accidentally and avoid many data input errors. 
