### PR TITLE
Fix migration when state_id is NULL

### DIFF
--- a/base_location/migrations/12.0.1.0.0/post-migration.py
+++ b/base_location/migrations/12.0.1.0.0/post-migration.py
@@ -36,7 +36,7 @@ def migrate(env, version):
         SET city_id = rc.id
         FROM res_city rc
         WHERE rc.name = rbz.city
-            AND rc.state_id = rbz.state_id
+            AND rc.state_id IS NOT DISTINCT FROM rbz.state_id
             AND rc.country_id = rbz.country_id
             AND rbz.city_id IS NULL""",
     )


### PR DESCRIPTION
Use "IS NOT DISTINCT FROM" instead of the equal operator since state_id could be NULL in some countries.

Note that I also applied it to country_id even if the previous query exclude null country_id, in order to be more consistent.