### PR TITLE
[FIX] partner_multi_relation: Context Errors With Active ID

### DIFF
--- a/partner_multi_relation/models/res_partner.py
+++ b/partner_multi_relation/models/res_partner.py
@@ -176,9 +176,10 @@ class ResPartner(models.Model):
     def action_view_relations(self):
         for contact in self:
             relation_model = self.env['res.partner.relation.all']
-            relation_ids = relation_model.search(['|', 
-                ('this_partner_id', '=', contact.id),
-                ('other_partner_id', '=', contact.id)])
+            relation_ids = relation_model.\
+                search(['|',
+                       ('this_partner_id', '=', contact.id),
+                       ('other_partner_id', '=', contact.id)])
             action = self.env.ref(
                 'partner_multi_relation.action_res_partner_relation_all'
             ).read()[0]

--- a/partner_multi_relation/models/res_partner.py
+++ b/partner_multi_relation/models/res_partner.py
@@ -171,3 +171,23 @@ class ResPartner(models.Model):
         """
         self.ensure_one()
         return 'c' if self.is_company else 'p'
+
+    @api.multi
+    def action_view_relations(self):
+        for contact in self:
+            relation_ids = self.env['res.partner.relation.all'].\
+                search(['|', ('this_partner_id', '=', contact.id),
+                       ('other_partner_id', '=', contact.id)])
+            action = self.env.\
+                ref('partner_multi_relation.action_res_partner_relation_all').\
+                read()[0]
+            action['context'] = {}
+            action['domain'] = [('id', 'in', relation_ids.ids)]
+            action['context'].\
+                update({'search_default_this_partner_id': contact.id,
+                        'default_this_partner_id': contact.id,
+                        'active_model': 'res.partner',
+                        'active_id': contact.id,
+                        'active_ids': [contact.id],
+                        'active_test': False})
+            return action

--- a/partner_multi_relation/models/res_partner.py
+++ b/partner_multi_relation/models/res_partner.py
@@ -175,13 +175,13 @@ class ResPartner(models.Model):
     @api.multi
     def action_view_relations(self):
         for contact in self:
-            relation_ids = self.env['res.partner.relation.all'].\
-                search(['|', ('this_partner_id', '=', contact.id),
-                       ('other_partner_id', '=', contact.id)])
-            action = self.env.\
-                ref('partner_multi_relation.action_res_partner_relation_all').\
-                read()[0]
-            action['context'] = {}
+            relation_model = self.env['res.partner.relation.all']
+            relation_ids = relation_model.search(['|', 
+                ('this_partner_id', '=', contact.id),
+                ('other_partner_id', '=', contact.id)])
+            action = self.env.ref(
+                'partner_multi_relation.action_res_partner_relation_all'
+            ).read()[0]
             action['domain'] = [('id', 'in', relation_ids.ids)]
             action['context'].\
                 update({'search_default_this_partner_id': contact.id,

--- a/partner_multi_relation/views/res_partner.xml
+++ b/partner_multi_relation/views/res_partner.xml
@@ -21,25 +21,13 @@
             <field name="model">res.partner</field>
             <field type="xml" name="arch">
                 <xpath expr="//div[@name='button_box']" position="inside">
-                    <button
-                        class="oe_inline oe_stat_button"
-                        type="action"
-                        context="{
-                            'search_default_this_partner_id': active_id,
-                            'default_this_partner_id': active_id,
-                            'active_model': 'res.partner',
-                            'active_id': id,
-                            'active_ids': [id],
-                            'active_test': False,
-                        }"
-                        name="%(action_res_partner_relation_all)d"
-                        icon="fa-users"
-                        >
-                        <field
-                            string="Relations"
-                            name="relation_count"
-                            widget="statinfo"
-                            />
+                    <button name="action_view_relations"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-users">
+                    <field name="relation_count"
+                           widget="statinfo"
+                           string="Relations"/>
                     </button>
                 </xpath>
             </field>

--- a/partner_multi_relation/views/res_partner.xml
+++ b/partner_multi_relation/views/res_partner.xml
@@ -25,9 +25,9 @@
                         type="object"
                         class="oe_stat_button"
                         icon="fa-users">
-                    <field name="relation_count"
-                           widget="statinfo"
-                           string="Relations"/>
+                        <field name="relation_count"
+                            widget="statinfo"
+                            string="Relations"/>
                     </button>
                 </xpath>
             </field>


### PR DESCRIPTION
When clicking through multiple buttons from different models the active_id will stay as the original id from the first button that was clicked. In the .xml we are overwriting the active_id which is good practice however we have had multiple reports of the 'search_default_this_partner_id' and 'default_this_partner_id' using the previous active_ids. 

Example: (Moduls installed: fieldservice, partner_multi_relation)
FSM Location -> Contacts
Contacts -> Relations
'search_default_this_partner_id' and 'default_this_partner_id' are using the id from the FSM Location.

The solution is to simply handmake the action in model itself. I believe this way we can easily inherit the action if we need it to be changed and we always can esure the proper default values are being set.
