### PR TITLE
Fix symmetric tab - copy left tab id to right

### DIFF
--- a/partner_multi_relation_tabs/models/res_partner_relation_type.py
+++ b/partner_multi_relation_tabs/models/res_partner_relation_type.py
@@ -57,3 +57,13 @@ class ResPartnerRelationType(models.Model):
                     tab_partner_category_id != rec.partner_category_right:
                 raise ValidationError(_(
                     "Partner category right not compatible with right tab"))
+
+    @api.multi
+    def _update_right_vals(self, vals):
+        """Make sure that on symmetric relations, right vals follow left vals.
+
+        @attention: original method only handles properties ending with _left
+                    and we need to update tab_right_id as well
+        """
+        vals['tab_right_id'] = vals.get('tab_left_id', self['tab_left_id'])
+        super(ResPartnerRelationType, self)._update_right_vals(vals)


### PR DESCRIPTION
This fixes setting up tab on symmetric relations because original method only handles properties having names ending with '_left' and we need to extend it to tab_left_id.

Hope this is final attempt to do this right. Thanx @NL66278 for help.