### PR TITLE
[FIX] partner_multi_relation_tabs: use default  widget many2one

### DIFF
--- a/partner_multi_relation_tabs/tablib/tab.py
+++ b/partner_multi_relation_tabs/tablib/tab.py
@@ -47,7 +47,7 @@ class Tab(object):
         type_field = etree.Element(
             'field',
             name='type_selection_id',
-            widget='many2one_clickable')
+            widget='many2one')
         type_field.set('domain', repr([('tab_id', '=', self.tab_record.id)]))
         type_field.set('options', repr({'no_create': True}))
         tree.append(type_field)
@@ -55,7 +55,7 @@ class Tab(object):
             'field',
             string=_('Partner'),
             name='other_partner_id',
-            widget='many2one_clickable')
+            widget='many2one')
         other_partner_field.set('options', repr({'no_create': True}))
         tree.append(other_partner_field)
         tree.append(etree.Element('field', name='date_start'))


### PR DESCRIPTION
This PR removes the many2one_clickable widget with the default many2one to remove Javascript error in console:

**Missing widget:  many2one_clickable  for field type_selection_id of type many2one**

![MissingWidgetMany2OneClickable](https://user-images.githubusercontent.com/226753/79445041-4b3c5800-7fdc-11ea-9475-f58e86f75da6.png)