### PR TITLE
[12.0][IMP] partner_multi_relation_tabs: improve res.partner browse performance

### DIFF
--- a/partner_multi_relation_tabs/models/res_partner.py
+++ b/partner_multi_relation_tabs/models/res_partner.py
@@ -15,11 +15,12 @@ class ResPartner(models.Model):
 
     @api.multi
     def browse(self, arg=None, prefetch=None):
-        for tab in self._get_tabs():
-            fieldname = tab.get_fieldname()
-            if fieldname not in self._fields:
-                # Check this for performance reasons.
-                self.add_field(tab)
+        if "update_relation_tab" in self.env.context:
+            for tab in self._get_tabs():
+                fieldname = tab.get_fieldname()
+                if fieldname not in self._fields:
+                    # Check this for performance reasons.
+                    self.add_field(tab)
         return super(ResPartner, self).browse(arg=arg, prefetch=prefetch)
 
     @api.model
@@ -71,10 +72,11 @@ class ResPartner(models.Model):
     @api.depends('is_company', 'category_id')
     def _compute_tabs_visibility(self):
         """Compute for all tabs wether they should be visible."""
-        for tab in self._get_tabs():  # get all tabs
-            for this in self:
-                this[tab.get_visible_fieldname()] = \
-                    tab.compute_visibility(this)
+        if "update_relation_tab" in self.env.context:
+            for tab in self._get_tabs():  # get all tabs
+                for this in self:
+                    this[tab.get_visible_fieldname()] = \
+                        tab.compute_visibility(this)
 
     def _get_tabs(self):
         tab_model = self.env['res.partner.tab']

--- a/partner_multi_relation_tabs/tests/test_partner_tabs.py
+++ b/partner_multi_relation_tabs/tests/test_partner_tabs.py
@@ -140,7 +140,9 @@ class TestPartnerTabs(common.TestCommon):
     def test_compute_visibility(self):
         """Check the computation of visibility on partners."""
         # pylint: disable=protected-access
-        main_partner = self.env.ref('base.main_partner')
+        main_partner = self.env.ref('base.main_partner').with_context({
+            'update_relation_tab': 1
+        })
         main_partner._compute_tabs_visibility()
         tab_obj = Tab(self.tab_departments)
         fieldname = tab_obj.get_fieldname()

--- a/partner_multi_relation_tabs/views/menu.xml
+++ b/partner_multi_relation_tabs/views/menu.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
+        <record id="contacts.action_contacts" model="ir.actions.act_window">
+            <field name="context">{'update_relation_tab': 1}</field>
+        </record>
 
         <act_window
             id="action_res_partner_tab"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Restrict partner relation tab loading to contact forms

**Current behavior before PR:**

- adding the partner_relation_tab xml code using the ORM `browse` method in `res.partner` model leads to performance problems on the whole system (browsing res.partner records is everywhere in Odoo)
- pg_stats_statement view after creating some sales orders (without using the contact form, there are a lot of tab related sql queries)
![pg_stats_statement_tab](https://user-images.githubusercontent.com/226753/80305333-73863c80-87bc-11ea-80fc-d09aa751ce72.png)

```sql
SELECT "res_partner_tab".id FROM "res_partner_tab" LEFT JOIN 
                (SELECT res_id, value FROM "ir_translation"
                 WHERE type=$1 AND name=$2 AND lang=$3 AND value!=$4)
             as "res_partner_tab__name" ON ("res_partner_tab"."id" = "res_partner_tab__name"."res_id") ORDER BY COALESCE("res_partner_tab__name"."value", "res_partner_tab"."name")
```

**Desired behavior after PR is merged:**

- use context `update_relation_tab: 1` to restrict loading of the partner relations only on related contact forms
- pg_stats_statement view after applied changes in code(no tab related sql queries)
![pg_stats_statement_tab_after](https://user-images.githubusercontent.com/226753/80305337-7a14b400-87bc-11ea-877d-29173b385390.png)
