### PR TITLE
[12.0][FIX] base_location_geonames_import: fix test redefining builtin zip

### DIFF
--- a/base_location_geonames_import/tests/test_base_location_geonames_import.py
+++ b/base_location_geonames_import/tests/test_base_location_geonames_import.py
@@ -81,10 +81,10 @@ class TestBaseLocationGeonamesImport(common.SavepointCase):
     def test_import_title(self):
         self.wizard.letter_case = 'title'
         self.wizard.with_context(max_import=1).run_import()
-        zip = self.env['res.city.zip'].search(
+        zip_entry = self.env['res.city.zip'].search(
             [('city_id.country_id', '=', self.country.id)], limit=1
         )
-        self.assertEqual(zip.city_id.name, zip.city_id.name.title())
+        self.assertEqual(zip_entry.city_id.name, zip_entry.city_id.name.title())
 
         city = self.env['res.city'].search(
             [('country_id', '=', self.country.id)], limit=1
@@ -94,10 +94,10 @@ class TestBaseLocationGeonamesImport(common.SavepointCase):
     def test_import_upper(self):
         self.wizard.letter_case = 'upper'
         self.wizard.with_context(max_import=1).run_import()
-        zip = self.env['res.city.zip'].search(
+        zip_entry = self.env['res.city.zip'].search(
             [('city_id.country_id', '=', self.country.id)], limit=1
         )
-        self.assertEqual(zip.city_id.name, zip.city_id.name.upper())
+        self.assertEqual(zip_entry.city_id.name, zip_entry.city_id.name.upper())
 
         city = self.env['res.city'].search(
             [('country_id', '=', self.country.id)], limit=1


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- Rename variable `zip`  to avoid redefining Python's built-in `zip` function

**Current behavior before PR:**

1.  Log message in Travis CI Output

```fish
************* Module base_location_geonames_import.tests.test_base_location_geonames_import

base_location_geonames_import/tests/test_base_location_geonames_import.py:84: [W0622(redefined-builtin), TestBaseLocationGeonamesImport.test_import_title] Redefining built-in 'zip'

base_location_geonames_import/tests/test_base_location_geonames_import.py:97: [W0622(redefined-builtin), TestBaseLocationGeonamesImport.test_import_upper] Redefining built-in 'zip'
```

**Desired behavior after PR is merged:**

-  No log message in Travis CI Output