### PR TITLE
[12.0][FIX] Remove unnecessary test import statements

### DIFF
--- a/base_partner_sequence/__init__.py
+++ b/base_partner_sequence/__init__.py
@@ -1,4 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
-from . import tests

--- a/partner_multi_relation/__init__.py
+++ b/partner_multi_relation/__init__.py
@@ -1,3 +1,2 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import models
-from . import tests


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Remove unnecessary test import statements

**Current behavior before PR:**

- default loading of tests for base_partner_sequence and partner_multi_relation

**Desired behavior after PR is merged:**

- no default loading of tests for base_partner_sequence and partner_multi_relation
