### PR TITLE
[11.0] [FIX] Partner_affiliate bugfix

### DIFF
--- a/partner_affiliate/README.rst
+++ b/partner_affiliate/README.rst
@@ -42,6 +42,7 @@ Contributors
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
 * Raul Martin <raul.martin@braintec-group.com>
+* Miguel Ángel Gómez <miguel.gomez@braintec-group.com>
 * Dave Lasley <dave@laslabs.com>
 
 Maintainer

--- a/partner_affiliate/README.rst
+++ b/partner_affiliate/README.rst
@@ -9,6 +9,8 @@ Partner Affiliates
 This module allows to use parent_id in company partner to refer to a parent
 company, plus will show a tab in parent company of affiliated companies.
 
+The module will also add a new partner type of ('affiliate', 'Affiliate').
+
 Usage
 =====
 
@@ -44,6 +46,7 @@ Contributors
 * Raul Martin <raul.martin@braintec-group.com>
 * Miguel Ángel Gómez <miguel.gomez@braintec-group.com>
 * Dave Lasley <dave@laslabs.com>
+* Ronald Portier <ronald@therp.nl>
 
 Maintainer
 ----------

--- a/partner_affiliate/__init__.py
+++ b/partner_affiliate/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright 2012 Camptocamp SA - Yannick Vaucher
-# Copyright 2018 brain-tec AG - Raul Martin
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models

--- a/partner_affiliate/__manifest__.py
+++ b/partner_affiliate/__manifest__.py
@@ -3,20 +3,16 @@
 # Copyright 2018 brain-tec AG - Raul Martin
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
-    'name': 'Partner Affiliates',
-    'version': '11.0.1.0.0',
-    'author': "Camptocamp, "
-              "Tecnativa, "
-              "brain-tec AG, "
-              "Odoo Community Association (OCA)",
-    'website': 'https://github.com/OCA/partner-contact',
-    'category': 'CRM',
-    'license': 'AGPL-3',
-    'installable': True,
-    'depends': [
-        'base',
-    ],
-    'data': [
-        'views/res_partner_view.xml',
-    ],
+    "name": "Partner Affiliates",
+    "version": "11.0.1.0.0",
+    "author": "Camptocamp, "
+    "Tecnativa, "
+    "brain-tec AG, "
+    "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/partner-contact",
+    "category": "CRM",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": ["base"],
+    "data": ["views/res_partner_view.xml"],
 }

--- a/partner_affiliate/__manifest__.py
+++ b/partner_affiliate/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012 Camptocamp SA - Yannick Vaucher
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2018 brain-tec AG - Raul Martin
@@ -10,7 +9,7 @@
               "Tecnativa, "
               "brain-tec AG, "
               "Odoo Community Association (OCA)",
-    'website': 'http://www.camptocamp.com',
+    'website': 'https://github.com/OCA/partner-contact',
     'category': 'CRM',
     'license': 'AGPL-3',
     'installable': True,

--- a/partner_affiliate/models/__init__.py
+++ b/partner_affiliate/models/__init__.py
@@ -1,5 +1,2 @@
-# -*- coding: utf-8 -*-
-# Copyright 2012 Camptocamp SA - Yannick Vaucher
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import res_partner

--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -8,33 +8,34 @@ from odoo import fields, models, api
 
 class ResPartner(models.Model):
     """Add relation affiliate_ids."""
+
     _inherit = "res.partner"
 
-    type = fields.Selection(selection_add=[('affiliate', 'Affiliate')])
+    type = fields.Selection(selection_add=[("affiliate", "Affiliate")])
 
     # force "active_test" domain to bypass _search() override
     child_ids = fields.One2many(
-        'res.partner', 'parent_id',
-        string='Contacts',
-        domain=[('active', '=', True), ('is_company', '=', False)],
+        "res.partner",
+        "parent_id",
+        string="Contacts",
+        domain=[("active", "=", True), ("is_company", "=", False)],
     )
     # force "active_test" domain to bypass _search() override
     affiliate_ids = fields.One2many(
-        'res.partner', 'parent_id',
-        string='Affiliates',
-        domain=[('active', '=', True), ('is_company', '=', True)],
+        "res.partner",
+        "parent_id",
+        string="Affiliates",
+        domain=[("active", "=", True), ("is_company", "=", True)],
     )
 
     def get_original_address(self):
         def convert(value):
             return value.id if isinstance(value, models.BaseModel) else value
 
-        result = {
-            'value': {key: convert(self[key]) for key in self._address_fields()}
-        }
+        result = {"value": {key: convert(self[key]) for key in self._address_fields()}}
         return result
 
-    @api.onchange('parent_id')
+    @api.onchange("parent_id")
     def onchange_parent_id(self):
         """Keep the original address info to set it back if its a company."""
         original_address = self.get_original_address()
@@ -44,5 +45,5 @@ class ResPartner(models.Model):
         # In addition, the type must be set to affiliate instead of contact.
         if new_partner and self.is_company:
             new_partner.update(original_address)
-            new_partner['value'].update({'type': 'affiliate'})
+            new_partner["value"].update({"type": "affiliate"})
         return new_partner

--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -3,12 +3,14 @@
 # Copyright 2018 brain-tec AG - Raul Martin
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class ResPartner(models.Model):
     """Add relation affiliate_ids."""
     _inherit = "res.partner"
+
+    type = fields.Selection(selection_add=[('affiliate', 'Affiliate')])
 
     # force "active_test" domain to bypass _search() override
     child_ids = fields.One2many('res.partner', 'parent_id',

--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012 Camptocamp SA - Yannick Vaucher
 # Copyright 2018 brain-tec AG - Raul Martin
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2020 Therp BV - <https://therp.nl>.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models, api
 
@@ -13,38 +13,36 @@ class ResPartner(models.Model):
     type = fields.Selection(selection_add=[('affiliate', 'Affiliate')])
 
     # force "active_test" domain to bypass _search() override
-    child_ids = fields.One2many('res.partner', 'parent_id',
-                                string='Contacts',
-                                domain=[('active', '=', True),
-                                        ('is_company', '=', False)])
-
+    child_ids = fields.One2many(
+        'res.partner', 'parent_id',
+        string='Contacts',
+        domain=[('active', '=', True), ('is_company', '=', False)],
+    )
     # force "active_test" domain to bypass _search() override
-    affiliate_ids = fields.One2many('res.partner', 'parent_id',
-                                    string='Affiliates',
-                                    domain=[('active', '=', True),
-                                            ('is_company', '=', True)])
+    affiliate_ids = fields.One2many(
+        'res.partner', 'parent_id',
+        string='Affiliates',
+        domain=[('active', '=', True), ('is_company', '=', True)],
+    )
 
     def get_original_address(self):
         def convert(value):
             return value.id if isinstance(value, models.BaseModel) else value
 
-        result = {'value': {key: convert(self[key])
-                            for key in self._address_fields()}}
-
+        result = {
+            'value': {key: convert(self[key]) for key in self._address_fields()}
+        }
         return result
 
     @api.onchange('parent_id')
     def onchange_parent_id(self):
-        # Keep the original address info to set it back if its a company.
+        """Keep the original address info to set it back if its a company."""
         original_address = self.get_original_address()
-
         new_partner = super(ResPartner, self).onchange_parent_id()
-
         # When the affiliate is a company, we must set back its address
         # because the super call changes its address by the new parent address.
         # In addition, the type must be set to affiliate instead of contact.
-        if self.is_company:
+        if new_partner and self.is_company:
             new_partner.update(original_address)
             new_partner['value'].update({'type': 'affiliate'})
-
         return new_partner

--- a/partner_affiliate/tests/__init__.py
+++ b/partner_affiliate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_partner_affiliate

--- a/partner_affiliate/tests/__init__.py
+++ b/partner_affiliate/tests/__init__.py
@@ -1,1 +1,2 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import test_partner_affiliate

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -7,83 +7,89 @@ class TestPartnerAffiliate(common.TransactionCase):
         super(TestPartnerAffiliate, self).setUp()
         self.partner_obj = self.env['res.partner']
 
-        self.first_parent = self.partner_obj.create({
-            'name': 'MyFirstParentForTheAffiliate',
+        self.first_company = self.partner_obj.create({
+            'name': 'MyFirstCompanyForTheAffiliate',
             'type': 'contact',
             'is_company': True,
-            'street': 'first parent street',
-            'street2': 'number 99',
-            'zip': 123,
-            'city': 'Test City',
+            'street': 'first company street',
         })
 
-        self.second_parent = self.partner_obj.create({
-            'name': 'MySecondParentForTheAffiliate',
+        self.second_company = self.partner_obj.create({
+            'name': 'MySecondCompanyForTheAffiliate',
             'type': 'contact',
             'is_company': True,
-            'street': 'second parent street',
-            'street2': 'number 44',
-            'zip': 999,
-            'city': 'Test City',
+            'street': 'second company street',
         })
 
     # Check data integrity of the objects when an affiliate is given a new
     # parent. So both objects keeps their data.
     def test_change_parent_from_a_new_affiliate(self):
-        new_affiliate = self.partner_obj.create({
-            'name': 'MyTestAffiliate',
+        my_affiliate = self.partner_obj.create({
+            'name': 'MyAffiliate',
             'is_company': True,
-            'parent_id': self.first_parent.id,
+            'parent_id': self.first_company.id,
             'type': 'affiliate',
             'street': 'affiliate street',
-            'street2': 'number 11',
-            'zip': 567,
-            'city': 'Test City',
-            'email': 'myAffiliate@test.com',
         })
 
         # Checks for data integrity in affiliate and his parent.
-        self.assertTrue(new_affiliate, "The new affiliate have been created.")
+        self.assertTrue(my_affiliate, "The new affiliate have been created.")
 
-        self.assertEquals(new_affiliate.type, 'affiliate',
+        self.assertEquals(my_affiliate.type, 'affiliate',
                           "Check type must be 'affiliate'")
-        self.assertEquals(new_affiliate.parent_id.id, self.first_parent.id,
+        self.assertEquals(my_affiliate.parent_id.id, self.first_company.id,
                           "Must be child of the parent defined in the setup")
-        self.assertEquals(new_affiliate.street, "affiliate street",
+        self.assertEquals(my_affiliate.street, "affiliate street",
                           "The street have been correctly set.")
-        self.assertEquals(self.first_parent.street, "first parent street",
+        self.assertEquals(self.first_company.street, "first company street",
                           "The parent continues with his original street")
 
         # Change the parent of the affiliate for the second one in the set-up.
-        new_affiliate.parent_id = self.second_parent.id
-        new_affiliate.onchange_parent_id()
+        my_affiliate.parent_id = self.second_company.id
+        my_affiliate.onchange_parent_id()
 
         # The parent have been changed. And is not the first one.
-        self.assertEquals(new_affiliate.parent_id.id, self.second_parent.id)
+        self.assertEquals(my_affiliate.parent_id.id, self.second_company.id)
 
-        # The affiliate keeps its data for the street. Not modified.
-        self.assertEquals(new_affiliate.street, "affiliate street",
+        # The affiliate keeps its data for the street (address). Not modified.
+        self.assertEquals(my_affiliate.street, "affiliate street",
                           "keeps the same street")
         # The data for the street of the first parent have not been changed.
-        self.assertEquals(self.first_parent.street, "first parent street",
+        self.assertEquals(self.first_company.street, "first company street",
                           "keeps the same street")
-
 
     # Check that the default value for 'type' defined by default in the view
     # is set correctly when a new affiliate is created.
     def test_new_affiliate_is_created_with_type_affiliate_by_default(self):
         new_affiliate = self.partner_obj.with_context(
-            {'default_parent_id': self.first_parent.id,
+            {'default_parent_id': self.first_company.id,
              'default_is_company': True,
              'default_type': 'affiliate'
              }
         ).create({
             'name': 'MyTestAffiliate',
             'street': 'affiliate street',
-            'street2': 'number 11',
-            'zip': 567,
-            'city': 'Test City',
-            'email': 'myAffiliate@test.com',
         })
 
         self.assertEquals(new_affiliate.type, 'affiliate')
+
+    # Check that when changing the parent from an individual, it changes also
+    # the address keeping the expected behaviour.
+    def test_individual_changes_address_when_changing_parent_id(self):
+        my_individual = self.partner_obj.create({
+            'name': 'MyIndividual',
+            'parent_id': self.first_company.id,
+            'type': 'contact',
+            'is_company': False,
+            'street': 'individual street',
+        })
+
+        my_individual.parent_id = self.second_company.id
+        my_individual.onchange_parent_id()
+
+        # The parent have been changed.
+        self.assertEquals(my_individual.parent_id.id, self.second_company.id)
+
+        # The affiliate gets the address from the new parent.
+        self.assertEquals(my_individual.street, "second company street",
+                          "keeps the same street")

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -1,12 +1,14 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+"""Tests for partner_affiliate."""
 from odoo.tests import common
 
 
 class TestPartnerAffiliate(common.TransactionCase):
-    def setUp(self):
-        super(TestPartnerAffiliate, self).setUp()
-        self.partner_obj = self.env["res.partner"]
+    """Tests for partner_affiliate."""
 
+    def setUp(self):
+        super().setUp()
+        self.partner_obj = self.env["res.partner"]
         self.first_company = self.partner_obj.create(
             {
                 "name": "MyFirstCompanyForTheAffiliate",
@@ -15,7 +17,6 @@ class TestPartnerAffiliate(common.TransactionCase):
                 "street": "first company street",
             }
         )
-
         self.second_company = self.partner_obj.create(
             {
                 "name": "MySecondCompanyForTheAffiliate",
@@ -25,9 +26,10 @@ class TestPartnerAffiliate(common.TransactionCase):
             }
         )
 
-    # Check data integrity of the objects when an affiliate is given a new
-    # parent. So both objects keeps their data.
     def test_change_parent_from_a_new_affiliate(self):
+        """Check data integrity of the objects when an affiliate is given a new
+        parent. So both objects keeps their data.
+        """
         my_affiliate = self.partner_obj.create(
             {
                 "name": "MyAffiliate",
@@ -37,48 +39,48 @@ class TestPartnerAffiliate(common.TransactionCase):
                 "street": "affiliate street",
             }
         )
-
         # Checks for data integrity in affiliate and his parent.
-        self.assertTrue(my_affiliate, "The new affiliate have been created.")
-
-        self.assertEquals(
+        self.assertTrue(my_affiliate, "Failed to create the new affiliate.")
+        self.assertEqual(
             my_affiliate.type, "affiliate", "Check type must be 'affiliate'"
         )
-        self.assertEquals(
+        self.assertEqual(
             my_affiliate.parent_id.id,
             self.first_company.id,
             "Must be child of the parent defined in the setup",
         )
-        self.assertEquals(
+        self.assertEqual(
             my_affiliate.street,
             "affiliate street",
-            "The street have been correctly set.",
+            "The street has not been correctly set.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.first_company.street,
             "first company street",
-            "The parent continues with his original street",
+            "Unexpected change in parent street",
         )
-
         # Change the parent of the affiliate for the second one in the set-up.
         my_affiliate.parent_id = self.second_company.id
         my_affiliate.onchange_parent_id()
-
-        # The parent have been changed. And is not the first one.
-        self.assertEquals(my_affiliate.parent_id.id, self.second_company.id)
-
+        # The parent has been changed. And is not the first one.
+        self.assertEqual(my_affiliate.parent_id.id, self.second_company.id)
         # The affiliate keeps its data for the street (address). Not modified.
-        self.assertEquals(
-            my_affiliate.street, "affiliate street", "keeps the same street"
+        self.assertEqual(
+            my_affiliate.street,
+            "affiliate street",
+            "Affilliate street should not have changed",
         )
         # The data for the street of the first parent have not been changed.
-        self.assertEquals(
-            self.first_company.street, "first company street", "keeps the same street"
+        self.assertEqual(
+            self.first_company.street,
+            "first company street",
+            "First company street should not have changed",
         )
 
-    # Check that the default value for 'type' defined by default in the view
-    # is set correctly when a new affiliate is created.
     def test_new_affiliate_is_created_with_type_affiliate_by_default(self):
+        """Check that the default value for 'type' defined by default in the view
+        is set correctly when a new affiliate is created.
+        """
         new_affiliate = self.partner_obj.with_context(
             {
                 "default_parent_id": self.first_company.id,
@@ -86,12 +88,12 @@ class TestPartnerAffiliate(common.TransactionCase):
                 "default_type": "affiliate",
             }
         ).create({"name": "MyTestAffiliate", "street": "affiliate street"})
+        self.assertEqual(new_affiliate.type, "affiliate")
 
-        self.assertEquals(new_affiliate.type, "affiliate")
-
-    # Check that when changing the parent from an individual, it changes also
-    # the address keeping the expected behaviour.
     def test_individual_changes_address_when_changing_parent_id(self):
+        """Check that when changing the parent from an individual, it changes also
+        the address keeping the expected behaviour.
+        """
         my_individual = self.partner_obj.create(
             {
                 "name": "MyIndividual",
@@ -101,14 +103,41 @@ class TestPartnerAffiliate(common.TransactionCase):
                 "street": "individual street",
             }
         )
-
         my_individual.parent_id = self.second_company.id
         my_individual.onchange_parent_id()
-
-        # The parent have been changed.
-        self.assertEquals(my_individual.parent_id.id, self.second_company.id)
-
+        # The parent has been changed.
+        self.assertEqual(my_individual.parent_id.id, self.second_company.id)
         # The affiliate gets the address from the new parent.
-        self.assertEquals(
-            my_individual.street, "second company street", "keeps the same street"
+        self.assertEqual(
+            my_individual.street,
+            "second company street",
+            "Street of affiliate individual should heve been set to company street",
+        )
+
+    def test_company_keeps_address_when_changing_parent_id(self):
+        """Check that when changing the parent from a company, it keeps its own
+        address.
+        """
+        my_affiliate_company = self.partner_obj.create(
+            {
+                "name": "My Affiliate Company",
+                "parent_id": self.first_company.id,
+                "type": "contact",
+                "is_company": True,
+                "street": "affiliate_company street",
+            }
+        )
+        my_affiliate_company.parent_id = self.second_company.id
+        my_affiliate_company.onchange_parent_id()
+        # The parent has been changed.
+        self.assertEqual(my_affiliate_company.parent_id.id, self.second_company.id)
+        # The affiliate should keep its own address.
+        self.assertEqual(
+            my_affiliate_company.street,
+            "affiliate_company street",
+            "Street of affiliate company should not have changed",
+        )
+        # Change of parent should not affect the type.
+        self.assertEqual(
+            my_affiliate_company.type, "affiliate", "Check type must remain 'affiliate'"
         )

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -1,3 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo.tests import common
 
 

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -104,7 +104,6 @@ class TestPartnerAffiliate(common.TransactionCase):
             }
         )
         my_individual.parent_id = self.second_company.id
-        my_individual.onchange_parent_id()
         # The parent has been changed.
         self.assertEqual(my_individual.parent_id.id, self.second_company.id)
         # The affiliate gets the address from the new parent.
@@ -128,7 +127,6 @@ class TestPartnerAffiliate(common.TransactionCase):
             }
         )
         my_affiliate_company.parent_id = self.second_company.id
-        my_affiliate_company.onchange_parent_id()
         # The parent has been changed.
         self.assertEqual(my_affiliate_company.parent_id.id, self.second_company.id)
         # The affiliate should keep its own address.
@@ -137,7 +135,7 @@ class TestPartnerAffiliate(common.TransactionCase):
             "affiliate_company street",
             "Street of affiliate company should not have changed",
         )
-        # Change of parent should not affect the type.
+        # Change of parent should set type to affiliate (why?? RP).
         self.assertEqual(
             my_affiliate_company.type, "affiliate", "Check type must remain 'affiliate'"
         )

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -1,0 +1,89 @@
+from odoo.tests import common
+
+
+class TestPartnerAffiliate(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPartnerAffiliate, self).setUp()
+        self.partner_obj = self.env['res.partner']
+
+        self.first_parent = self.partner_obj.create({
+            'name': 'MyFirstParentForTheAffiliate',
+            'type': 'contact',
+            'is_company': True,
+            'street': 'first parent street',
+            'street2': 'number 99',
+            'zip': 123,
+            'city': 'Test City',
+        })
+
+        self.second_parent = self.partner_obj.create({
+            'name': 'MySecondParentForTheAffiliate',
+            'type': 'contact',
+            'is_company': True,
+            'street': 'second parent street',
+            'street2': 'number 44',
+            'zip': 999,
+            'city': 'Test City',
+        })
+
+    # Check data integrity of the objects when an affiliate is given a new
+    # parent. So both objects keeps their data.
+    def test_change_parent_from_a_new_affiliate(self):
+        new_affiliate = self.partner_obj.create({
+            'name': 'MyTestAffiliate',
+            'is_company': True,
+            'parent_id': self.first_parent.id,
+            'type': 'affiliate',
+            'street': 'affiliate street',
+            'street2': 'number 11',
+            'zip': 567,
+            'city': 'Test City',
+            'email': 'myAffiliate@test.com',
+        })
+
+        # Checks for data integrity in affiliate and his parent.
+        self.assertTrue(new_affiliate, "The new affiliate have been created.")
+
+        self.assertEquals(new_affiliate.type, 'affiliate',
+                          "Check type must be 'affiliate'")
+        self.assertEquals(new_affiliate.parent_id.id, self.first_parent.id,
+                          "Must be child of the parent defined in the setup")
+        self.assertEquals(new_affiliate.street, "affiliate street",
+                          "The street have been correctly set.")
+        self.assertEquals(self.first_parent.street, "first parent street",
+                          "The parent continues with his original street")
+
+        # Change the parent of the affiliate for the second one in the set-up.
+        new_affiliate.parent_id = self.second_parent.id
+        new_affiliate.onchange_parent_id()
+
+        # The parent have been changed. And is not the first one.
+        self.assertEquals(new_affiliate.parent_id.id, self.second_parent.id)
+
+        # The affiliate keeps its data for the street. Not modified.
+        self.assertEquals(new_affiliate.street, "affiliate street",
+                          "keeps the same street")
+        # The data for the street of the first parent have not been changed.
+        self.assertEquals(self.first_parent.street, "first parent street",
+                          "keeps the same street")
+
+
+    # Check that the default value for 'type' defined by default in the view
+    # is set correctly when a new affiliate is created.
+    def test_new_affiliate_is_created_with_type_affiliate_by_default(self):
+        new_affiliate = self.partner_obj.with_context(
+            {'default_parent_id': self.first_parent.id,
+             'default_is_company': True,
+             'default_type': 'affiliate'
+             }
+        ).create({
+            'name': 'MyTestAffiliate',
+            'street': 'affiliate street',
+            'street2': 'number 11',
+            'zip': 567,
+            'city': 'Test City',
+            'email': 'myAffiliate@test.com',
+        })
+
+        self.assertEquals(new_affiliate.type, 'affiliate')

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -3,47 +3,62 @@ from odoo.tests import common
 
 
 class TestPartnerAffiliate(common.TransactionCase):
-
     def setUp(self):
         super(TestPartnerAffiliate, self).setUp()
-        self.partner_obj = self.env['res.partner']
+        self.partner_obj = self.env["res.partner"]
 
-        self.first_company = self.partner_obj.create({
-            'name': 'MyFirstCompanyForTheAffiliate',
-            'type': 'contact',
-            'is_company': True,
-            'street': 'first company street',
-        })
+        self.first_company = self.partner_obj.create(
+            {
+                "name": "MyFirstCompanyForTheAffiliate",
+                "type": "contact",
+                "is_company": True,
+                "street": "first company street",
+            }
+        )
 
-        self.second_company = self.partner_obj.create({
-            'name': 'MySecondCompanyForTheAffiliate',
-            'type': 'contact',
-            'is_company': True,
-            'street': 'second company street',
-        })
+        self.second_company = self.partner_obj.create(
+            {
+                "name": "MySecondCompanyForTheAffiliate",
+                "type": "contact",
+                "is_company": True,
+                "street": "second company street",
+            }
+        )
 
     # Check data integrity of the objects when an affiliate is given a new
     # parent. So both objects keeps their data.
     def test_change_parent_from_a_new_affiliate(self):
-        my_affiliate = self.partner_obj.create({
-            'name': 'MyAffiliate',
-            'is_company': True,
-            'parent_id': self.first_company.id,
-            'type': 'affiliate',
-            'street': 'affiliate street',
-        })
+        my_affiliate = self.partner_obj.create(
+            {
+                "name": "MyAffiliate",
+                "is_company": True,
+                "parent_id": self.first_company.id,
+                "type": "affiliate",
+                "street": "affiliate street",
+            }
+        )
 
         # Checks for data integrity in affiliate and his parent.
         self.assertTrue(my_affiliate, "The new affiliate have been created.")
 
-        self.assertEquals(my_affiliate.type, 'affiliate',
-                          "Check type must be 'affiliate'")
-        self.assertEquals(my_affiliate.parent_id.id, self.first_company.id,
-                          "Must be child of the parent defined in the setup")
-        self.assertEquals(my_affiliate.street, "affiliate street",
-                          "The street have been correctly set.")
-        self.assertEquals(self.first_company.street, "first company street",
-                          "The parent continues with his original street")
+        self.assertEquals(
+            my_affiliate.type, "affiliate", "Check type must be 'affiliate'"
+        )
+        self.assertEquals(
+            my_affiliate.parent_id.id,
+            self.first_company.id,
+            "Must be child of the parent defined in the setup",
+        )
+        self.assertEquals(
+            my_affiliate.street,
+            "affiliate street",
+            "The street have been correctly set.",
+        )
+        self.assertEquals(
+            self.first_company.street,
+            "first company street",
+            "The parent continues with his original street",
+        )
 
         # Change the parent of the affiliate for the second one in the set-up.
         my_affiliate.parent_id = self.second_company.id
@@ -53,37 +68,39 @@ class TestPartnerAffiliate(common.TransactionCase):
         self.assertEquals(my_affiliate.parent_id.id, self.second_company.id)
 
         # The affiliate keeps its data for the street (address). Not modified.
-        self.assertEquals(my_affiliate.street, "affiliate street",
-                          "keeps the same street")
+        self.assertEquals(
+            my_affiliate.street, "affiliate street", "keeps the same street"
+        )
         # The data for the street of the first parent have not been changed.
-        self.assertEquals(self.first_company.street, "first company street",
-                          "keeps the same street")
+        self.assertEquals(
+            self.first_company.street, "first company street", "keeps the same street"
+        )
 
     # Check that the default value for 'type' defined by default in the view
     # is set correctly when a new affiliate is created.
     def test_new_affiliate_is_created_with_type_affiliate_by_default(self):
         new_affiliate = self.partner_obj.with_context(
-            {'default_parent_id': self.first_company.id,
-             'default_is_company': True,
-             'default_type': 'affiliate'
-             }
-        ).create({
-            'name': 'MyTestAffiliate',
-            'street': 'affiliate street',
-        })
+            {
+                "default_parent_id": self.first_company.id,
+                "default_is_company": True,
+                "default_type": "affiliate",
+            }
+        ).create({"name": "MyTestAffiliate", "street": "affiliate street"})
 
-        self.assertEquals(new_affiliate.type, 'affiliate')
+        self.assertEquals(new_affiliate.type, "affiliate")
 
     # Check that when changing the parent from an individual, it changes also
     # the address keeping the expected behaviour.
     def test_individual_changes_address_when_changing_parent_id(self):
-        my_individual = self.partner_obj.create({
-            'name': 'MyIndividual',
-            'parent_id': self.first_company.id,
-            'type': 'contact',
-            'is_company': False,
-            'street': 'individual street',
-        })
+        my_individual = self.partner_obj.create(
+            {
+                "name": "MyIndividual",
+                "parent_id": self.first_company.id,
+                "type": "contact",
+                "is_company": False,
+                "street": "individual street",
+            }
+        )
 
         my_individual.parent_id = self.second_company.id
         my_individual.onchange_parent_id()
@@ -92,5 +109,6 @@ class TestPartnerAffiliate(common.TransactionCase):
         self.assertEquals(my_individual.parent_id.id, self.second_company.id)
 
         # The affiliate gets the address from the new parent.
-        self.assertEquals(my_individual.street, "second company street",
-                          "keeps the same street")
+        self.assertEquals(
+            my_individual.street, "second company street", "keeps the same street"
+        )

--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -14,7 +14,7 @@
             <xpath expr='//page[@name="internal_notes"]' position="before">
                 <page string="Affiliates" attrs="{'invisible': [('is_company','=',False)]}">
                     <field name="affiliate_ids"
-                           context="{'default_parent_id': active_id, 'default_is_company': True, 'default_type':'other'}" mode="kanban">
+                           context="{'default_parent_id': active_id, 'default_is_company': True, 'default_type':'affiliate'}" mode="kanban">
                         <kanban>
                             <field name="color"/>
                             <field name="name"/>

--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -14,7 +14,7 @@
             <xpath expr='//page[@name="internal_notes"]' position="before">
                 <page string="Affiliates" attrs="{'invisible': [('is_company','=',False)]}">
                     <field name="affiliate_ids"
-                           context="{'default_parent_id': active_id, 'default_is_company': True, 'default_type':'affiliate'}" mode="kanban">
+                           context="{'default_parent_id': active_id, 'default_is_company': True}" mode="kanban">
                         <kanban>
                             <field name="color"/>
                             <field name="name"/>

--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -11,6 +11,14 @@
             <xpath expr="/form/sheet//div[hasclass('o_row')]/field[@name='parent_id']" position="attributes">
                 <attribute name="attrs"></attribute>
             </xpath>
+            <xpath
+                expr="/form/sheet//group/group/field[@name='vat']"
+                position="attributes"
+                >
+                <attribute
+                    name="attrs"
+                    >{'readonly': [('type', '!=', 'affiliate'), ('parent_id','!=',False)]}</attribute>
+            </xpath>
             <xpath expr='//page[@name="internal_notes"]' position="before">
                 <page string="Affiliates" attrs="{'invisible': [('is_company','=',False)]}">
                     <field name="affiliate_ids"


### PR DESCRIPTION
Taking up from pr #592 

Added: 
- Review comments taken up
- Code blacked

Original pr:
Author: MIGUEL ANGEL GOMEZ TRILLO:
Fixing functionality not to change address of existing company when assigning a parent
    (cherry picked from commit aa45aab)

Author: BT-mgomez:

    [IMP] Changes to avoid some data being changed when swapping the parent from the Affiliate.
    Created new Affiliate type and set it as default when creating a new affiliate.
