### PR TITLE
[12.0][FIX] portal_partner_select_all: fix call to unavailable self.portal_id

### DIFF
--- a/portal_partner_select_all/README.rst
+++ b/portal_partner_select_all/README.rst
@@ -23,9 +23,9 @@ Portal Partner Select All
     :target: https://runbot.odoo-community.org/runbot/134/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
-When a user wants invite a lot of custumers to the portal it can be a pain to
+When a user wants invite a lot of customers to the portal it can be a pain to
 select them all one by one.
 
 This module adds a helper in the wizard to toggle between all selected and only

--- a/portal_partner_select_all/__manifest__.py
+++ b/portal_partner_select_all/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2018 Tecnativa - David Vidal
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Portal Partner Select All',
     'version': '12.0.1.0.1',

--- a/portal_partner_select_all/readme/DESCRIPTION.rst
+++ b/portal_partner_select_all/readme/DESCRIPTION.rst
@@ -1,4 +1,4 @@
-When a user wants invite a lot of custumers to the portal it can be a pain to
+When a user wants invite a lot of customers to the portal it can be a pain to
 select them all one by one.
 
 This module adds a helper in the wizard to toggle between all selected and only

--- a/portal_partner_select_all/static/description/index.html
+++ b/portal_partner_select_all/static/description/index.html
@@ -368,7 +368,7 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/partner-contact/tree/12.0/portal_partner_select_all"><img alt="OCA/partner-contact" src="https://img.shields.io/badge/github-OCA%2Fpartner--contact-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/partner-contact-12-0/partner-contact-12-0-portal_partner_select_all"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/134/12.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
-<p>When a user wants invite a lot of custumers to the portal it can be a pain to
+<p>When a user wants invite a lot of customers to the portal it can be a pain to
 select them all one by one.</p>
 <p>This module adds a helper in the wizard to toggle between all selected and only
 the ones that already exist.</p>

--- a/portal_partner_select_all/tests/__init__.py
+++ b/portal_partner_select_all/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_portal_partner_select_all

--- a/portal_partner_select_all/tests/test_portal_partner_select_all.py
+++ b/portal_partner_select_all/tests/test_portal_partner_select_all.py
@@ -1,0 +1,39 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.tests import common, Form
+
+
+class TestPortalPartnerSelctAll(common.TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+
+        Partner = self.env["res.partner"]
+        self.partner1 = Partner.create({'name': 'P1', 'email': 'p1@p1'})
+        self.partner2 = Partner.create({'name': 'P2', 'email': 'p2@p2'})
+        self.partner3 = Partner.create({'name': 'P3', 'email': 'p3@p3'})
+        self.wizard_all = self.env["portal.wizard"].with_context({
+            'active_ids': [self.partner1.id, self.partner2.id]
+        }).create({})
+        self.wizard_default = self.env["portal.wizard"].with_context({
+            'active_ids': [self.partner1.id, self.partner2.id, self.partner3.id]
+        }).create({})
+
+    def test_portal_partner_select_all_wizard(self):
+        # check selecting all
+        wizard_all_form = Form(self.wizard_all)
+        wizard_all_form.set_all_users = True
+        w = wizard_all_form.save()
+        w.action_apply()
+        # partner should have user records with assigned portal group
+        self.assertTrue(self.partner1.user_ids, "Partner should have user")
+        self.assertTrue(self.partner2.user_ids, "Partner should have user")
+        self.assertTrue(self.partner1.user_ids[0].has_group('base.group_portal'))
+        self.assertTrue(self.partner2.user_ids[0].has_group('base.group_portal'))
+
+        # checking toogle
+        wizard_default_form = Form(self.wizard_default)
+        wizard_default_form.set_all_users = True
+        wizard_default_form.set_all_users = False
+        w = wizard_default_form.save()
+        w.action_apply()
+        self.assertFalse(self.partner3.user_ids, "Partner shouldn't have a user")

--- a/portal_partner_select_all/wizard/__init__.py
+++ b/portal_partner_select_all/wizard/__init__.py
@@ -1,2 +1,2 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import portal_wizard

--- a/portal_partner_select_all/wizard/portal_wizard.py
+++ b/portal_partner_select_all/wizard/portal_wizard.py
@@ -1,5 +1,5 @@
 # Copyright 2018 Tecnativa - David Vidal
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import api, fields, models
 
 
@@ -18,7 +18,7 @@ class PortalWizard(models.TransientModel):
             for user in self.user_ids:
                 user.in_portal = (
                     user.partner_id.user_ids and
-                    self.portal_id in user.partner_id.user_ids[0].groups_id
+                    user.partner_id.user_ids[0].has_group("base.group_portal")
                 )
         else:
             not_in_portal = self.user_ids.filtered(lambda x: not x.in_portal)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Avoid error on opening portal wizard with partner records that are already portal users
**Current behavior before PR:**

1. Go to Contacts => Change to List view
2. Select a partner that is already a portal user
3. Open Action Grant Portal Access
5. Error appears 

![portal_wizard_error](https://user-images.githubusercontent.com/226753/80960814-e705fa80-8e09-11ea-89bb-63a95350e79b.png)

```python
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/.repo_requirements/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/.repo_requirements/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/.repo_requirements/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/.repo_requirements/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/.repo_requirements/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/OCB-12.0/addons/web/controllers/main.py", line 962, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/OCB-12.0/addons/web/controllers/main.py", line 954, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 759, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 746, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/models.py", line 5533, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/.repo_requirements/odoo/odoo/models.py", line 5377, in _onchange_eval
    method_res = method(self)
  File "/home/odoo/build/OCA/partner-contact/portal_partner_select_all/wizard/portal_wizard.py", line 21, in onchange_set_all_users
    self.portal_id in user.partner_id.user_ids[0].groups_id
AttributeError: 'portal.wizard' object has no attribute 'portal_id'
```




**Desired behavior after PR is merged:**

- Open Portal Wizard without errors
