### PR TITLE
[11.0][FIX] partner_multi_relation: unlinking partner relations

### DIFF
--- a/partner_multi_relation/models/res_partner_relation_all.py
+++ b/partner_multi_relation/models/res_partner_relation_all.py
@@ -7,7 +7,7 @@ import logging
 from psycopg2.extensions import AsIs
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import MissingError, ValidationError
 from odoo.tools import drop_view_if_exists
 
 
@@ -466,6 +466,9 @@ CREATE OR REPLACE VIEW %%(table)s AS
         """For model 'res.partner.relation' call unlink on underlying model.
         """
         for rec in self:
-            base_resource = rec.get_base_resource()
+            try:
+                base_resource = rec.get_base_resource()
+            except MissingError:
+                continue
             rec.unlink_resource(base_resource)
         return True

--- a/partner_multi_relation/tests/test_partner_relation_all.py
+++ b/partner_multi_relation/tests/test_partner_relation_all.py
@@ -168,6 +168,8 @@ class TestPartnerRelation(TestPartnerRelationCommon):
         base_relation = base_model.browse([relation.res_id])
         relation.unlink()
         self.assertFalse(base_relation.exists())
+        # Check unlinking record sets with both derived relation records
+        self.assertTrue(self.relation_all_model.search([]).unlink())
 
     def test_on_change_type_selection(self):
         """Test on_change_type_selection."""


### PR DESCRIPTION
Taking up from pr #896

**Description of the issue/feature this PR addresses:**

Allow unlinking of partner relation recordsets containing records with same res_id

**Current behavior before PR:**

1. Go to Contacts => Relations => Relations
2. Filter for Partner `Bart` (2 records)
3. Select both records in tree view (global checkbox)
4. Delete records
5. Error appears

**Desired behavior after PR is merged:**

- unlink all checked partner relations in tree view without any error
