### PR TITLE
[13.0][IMP] partner_company_group: Change group search field after name

### DIFF
--- a/partner_company_group/views/contact_view.xml
+++ b/partner_company_group/views/contact_view.xml
@@ -18,7 +18,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_res_partner_filter" />
         <field name="arch" type="xml">
-            <field name="name" position="before">
+            <field name="name" position="after">
                 <field name="company_group_id" />
             </field>
             <filter name="group_company" position="before">


### PR DESCRIPTION
When user makes a search always does by company group, with this PR we do not modifu the odoo standard search workflow on partners.

cc @Tecnativa TT24337