### PR TITLE
[11.0][IMP] partner_vat_unique: More rigorous check

### DIFF
--- a/partner_vat_unique/models/res_partner.py
+++ b/partner_vat_unique/models/res_partner.py
@@ -1,4 +1,5 @@
 # Copyright 2017 Grant Thornton Spain - Ismael Calvo <ismael.calvo@es.gt.com>
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, fields, models
@@ -20,12 +21,19 @@ class ResPartner(models.Model):
                               not self.env.context.get('test_vat'))
             if test_condition:
                 continue
-            results = self.env['res.partner'].search_count([
+            if self.env['res.partner'].sudo().with_context(
+                active_test=False,
+            ).search_count([
                 ('parent_id', '=', False),
                 ('vat', '=', record.vat),
-                ('id', '!=', record.id)
-            ])
-            if results:
+                ('id', '!=', record.id),
+                "|",
+                ("company_id", "=", False),
+                ("company_id", "=", record.company_id.id),
+            ]):
                 raise ValidationError(_(
                     "The VAT %s already exists in another "
-                    "partner.") % record.vat)
+                    "partner."
+                ) + " " + _(
+                    "NOTE: This partner may be archived."
+                ) % record.vat)

--- a/partner_vat_unique/tests/test_vat_unique.py
+++ b/partner_vat_unique/tests/test_vat_unique.py
@@ -21,6 +21,14 @@ class TestVatUnique(SavepointCase):
                 'vat': 'ESA12345674'
             })
 
+    def test_duplicated_vat_creation_inactive(self):
+        self.partner.active = False
+        with self.assertRaises(ValidationError):
+            self.env['res.partner'].with_context(test_vat=True).create({
+                'name': 'Second partner',
+                'vat': 'ESA12345674'
+            })
+
     def test_duplicate_partner(self):
         partner_copied = self.partner.copy()
         self.assertFalse(partner_copied.vat)


### PR DESCRIPTION
Two cases are not covered:

- If the partner with duplicated VAT is inactive
- If there are specific contact record rules that hides some of the results for that user.

We cover both with this modification.

@Tecnativa TT24455