### PR TITLE
[FIX] partver_vat_unique: Avoid formatting error due to missing parenthesis

### DIFF
--- a/partner_vat_unique/models/res_partner.py
+++ b/partner_vat_unique/models/res_partner.py
@@ -31,9 +31,9 @@ class ResPartner(models.Model):
                 ("company_id", "=", False),
                 ("company_id", "=", record.company_id.id),
             ]):
-                raise ValidationError(_(
+                raise ValidationError((_(
                     "The VAT %s already exists in another "
                     "partner."
                 ) + " " + _(
                     "NOTE: This partner may be archived."
-                ) % record.vat)
+                )) % record.vat)


### PR DESCRIPTION
cc @Tecnativa

@carlosdauden @Tardo can you review?

Confusing validation error message
![Selección_806](https://user-images.githubusercontent.com/7689807/86728967-3a284380-c02d-11ea-878e-a667675109fe.png)
Instead of
![Selección_807](https://user-images.githubusercontent.com/7689807/86729155-6f349600-c02d-11ea-97bf-1c57b4369d61.png)

