### PR TITLE
[12.0][FIX] partner_fax: Add fax field to partner child_ids form

### DIFF
--- a/partner_fax/views/res_partner.xml
+++ b/partner_fax/views/res_partner.xml
@@ -31,6 +31,9 @@
             <field name="function" position="after">
                 <field name="fax" placeholder="Fax..." widget="phone"/>
             </field>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='function']" position="after">
+                <field name="fax" placeholder="Fax..." widget="phone"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
**Impacted versions:**
12.0

**Steps to reproduce:**

1. Open a company contact in Contacts
2. Add a new record (contact/address) on tab "Contacts and Addresses"
3. Fax field is missing on form

**Current behavior:**
- no fax field on Contacts & Addresses form

**Video/Screenshot link (optional):**

![no FaxFieldPartner](https://user-images.githubusercontent.com/226753/88338362-874c2b00-cd38-11ea-9a15-86e4ee160b43.png)

**Solution:**
This PR adds the fax field to Contacts & Addresses (child_ids form)


Thank you