### PR TITLE
[13.0][FIX] partner_fax: Add fax field to partner child_ids form

### DIFF
--- a/partner_fax/views/res_partner.xml
+++ b/partner_fax/views/res_partner.xml
@@ -28,6 +28,12 @@
             <field name="function" position="after">
                 <field name="fax" placeholder="Fax..." widget="phone" />
             </field>
+            <xpath
+                expr="//field[@name='child_ids']/form//field[@name='mobile']"
+                position="after"
+            >
+                <field name="fax" placeholder="Fax..." widget="phone" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
**Impacted versions:**
13.0

**Steps to reproduce:**

1. Open a company contact in Contacts
2. Add a new record (contact/address) on tab "Contacts and Addresses"
3. Fax field is missing on form

**Current behavior:**
- no fax field on Contacts & Addresses form

**Video/Screenshot link (optional):**

![no FaxFieldPartnerV13](https://user-images.githubusercontent.com/226753/88339228-f70ee580-cd39-11ea-8691-2c9ffe45543f.png)


**Solution:**
This PR adds the fax field to Contacts & Addresses (child_ids form)


Thank you