### PR TITLE
[12.0][IMP] partner_contact_address_default: allow selecting all partner

### DIFF
--- a/partner_contact_address_default/__manifest__.py
+++ b/partner_contact_address_default/__manifest__.py
@@ -16,6 +16,8 @@
         'base',
     ],
     'data': [
+        'security/res_groups_security.xml',
         'views/res_partner_views.xml',
+        'views/res_config_settings_views.xml',
     ],
 }

--- a/partner_contact_address_default/models/__init__.py
+++ b/partner_contact_address_default/models/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import res_config_settings
 from . import res_partner

--- a/partner_contact_address_default/models/res_config_settings.py
+++ b/partner_contact_address_default/models/res_config_settings.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    group_address_default_allow_all_partner = fields.Boolean(
+        'Allow selecting from all partners as address default',
+        help='Allow selecting from all partners as address default',
+        implied_group='partner_contact_address_default.group_allow_all_partner',
+        default=False,
+    )

--- a/partner_contact_address_default/security/res_groups_security.xml
+++ b/partner_contact_address_default/security/res_groups_security.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="group_allow_all_partner" model="res.groups">
+        <field name="name">Allow selecting all partner records as address default</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+</odoo>

--- a/partner_contact_address_default/views/res_config_settings_views.xml
+++ b/partner_contact_address_default/views/res_config_settings_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+
+    <record id="view_general_configuration" model="ir.ui.view">
+        <field name="name">Add partner_contact_address_default config parameter</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id"
+               ref="base_setup.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+          <xpath expr="//div[@name='multi_company']" position="after">
+              <h2>Partner Contact Address Default</h2>
+              <div class="row mt16 o_settings_container" name="partner_contact_address_default">
+                  <div class="col-xs-12 col-md-6 o_setting_box">
+                      <div class="o_setting_left_pane">
+                          <field name="group_address_default_allow_all_partner"/>
+                      </div>
+                      <div class="o_setting_right_pane">
+                          <label string="Allow all partner" for="group_address_default_allow_all_partner"/>
+                          <div class="text-muted">
+                              Allow selecting all partner as default invoice or delivery address
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/partner_contact_address_default/views/res_partner_views.xml
+++ b/partner_contact_address_default/views/res_partner_views.xml
@@ -37,4 +37,25 @@
         </field>
     </record>
 
+    <record id="view_partner_form_allow_all_partner_as_default" model="ir.ui.view">
+        <field name="name">Partner Contact Address Default - Allow all partners as default</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="partner_contact_address_default.view_partner_form"/>
+        <field name="groups_id" eval="[(4,ref('partner_contact_address_default.group_allow_all_partner'))]"/>
+        <field name="arch" type="xml">
+            <field name="partner_delivery_id" position="attributes">
+                <attribute name="domain"></attribute>
+            </field>
+            <field name="partner_invoice_id" position="attributes">
+                <attribute name="domain"></attribute>
+            </field>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='partner_delivery_id']" position="attributes">
+                <attribute name="domain"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='partner_invoice_id']" position="attributes">
+                <attribute name="domain"></attribute>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
By default only partner records with the same commercial_partner_id could be selected as default delivery or invoice address

With this PR this behaviour could be changed per configuration to allow selecting all partner contact records as delivery or invoice address. 

![SettingsPartnerDefault](https://user-images.githubusercontent.com/226753/90432194-7c33b300-e0ca-11ea-84e4-e1793fda39fd.png)
![SelectAllPartner](https://user-images.githubusercontent.com/226753/90432202-7d64e000-e0ca-11ea-880f-6956b3c66cdf.png)
