### PR TITLE
[FIX] partner_second_lastname: False value should be set on lastname2

### DIFF
--- a/partner_second_lastname/models/res_partner.py
+++ b/partner_second_lastname/models/res_partner.py
@@ -85,8 +85,8 @@ class ResPartner(models.Model):
                     parts = result['firstname'].split(" ", 1)
                 while len(parts) < 2:
                     parts.append(False)
-                result['lastname2'] = parts[0]
-                result['firstname'] = parts[1]
+                result['firstname'] = parts[0]
+                result['lastname2'] = parts[1]
             else:
                 if result['lastname']:
                     parts = result['lastname'].split(" ", 1)


### PR DESCRIPTION
not firstname

before this commit the following error happen:
name = 'Van-Eyck Jan'

this was converted to

firstname = False
lastname= 'Van-Eyck'
lastname2 = 'Jan'

and it should be like

firstname = 'Jan'
lastname= 'Van-Eyck'
lastname2 = False