### PR TITLE
[FIX] partner_second_lastname: False value should be set on lastname2

### DIFF
--- a/partner_second_lastname/models/res_partner.py
+++ b/partner_second_lastname/models/res_partner.py
@@ -69,32 +69,50 @@ class ResPartner(models.Model):
         - If the partner is a company, save it in the lastname.
         - Otherwise, make a guess.
         """
-        # Company name goes to the lastname
         result = {
             'firstname': False,
             'lastname': name or False,
             'lastname2': False,
         }
-        if not is_company and name:
-            order = self._get_names_order()
-            result = super(ResPartner, self)._get_inverse_name(
-                name, is_company)
-            parts = []
-            if order == 'last_first':
-                if result['firstname']:
-                    parts = result['firstname'].split(" ", 1)
-                while len(parts) < 2:
-                    parts.append(False)
-                result['lastname2'] = parts[0]
-                result['firstname'] = parts[1]
-            else:
-                if result['lastname']:
-                    parts = result['lastname'].split(" ", 1)
-                while len(parts) < 2:
-                    parts.append(False)
-                result['lastname'] = parts[0]
-                result['lastname2'] = parts[1]
+
+        # Company name goes to the lastname
+        if not name or is_company:
+            return result
+
+        order = self._get_names_order()
+        result.update(
+            super(ResPartner, self)._get_inverse_name(name, is_company))
+
+        if order in ('first_last', 'last_first_comma'):
+            parts = self._split_part('lastname', result)
+            if parts:
+                result.update({
+                    'lastname': parts[0],
+                    'lastname2': u" ".join(parts[1:]),
+                })
+        else:
+            parts = self._split_part('firstname', result)
+            if parts:
+                result.update({
+                    'firstname': parts[-1],
+                    'lastname2': u" ".join(parts[:-1]),
+                })
         return result
+
+    def _split_part(self, name_part, name_split):
+        """Split a given part of a name.
+
+        :param name_split: The parts of the name
+        :type dict
+
+        :param name_part: The part to split
+        :type str
+        """
+        name = name_split.get(name_part, False)
+        parts = name.split(" ", 1) if name else []
+        if not name or len(parts) < 2:
+            return False
+        return parts
 
     @api.constrains("firstname", "lastname", "lastname2")
     def _check_name(self):

--- a/partner_second_lastname/tests/test_name.py
+++ b/partner_second_lastname/tests/test_name.py
@@ -140,6 +140,18 @@ class PersonCase(TransactionCase):
                                    self.firstname),
         }
 
+    def test_firstname_last_wo_comma(self):
+        """Create a person setting his first name last and the order as 'last_first'"""
+        self.env['ir.config_parameter'].set_param(
+            'partner_names_order', 'last_first')
+        self.template = "%(last1)s %(last2)s %(first)s"
+        self.params = {
+            "is_company": False,
+            "name": "%s %s %s" % (self.lastname,
+                                  self.lastname2,
+                                  self.firstname),
+        }
+
     def test_firstname_only(self):
         """Create a person setting his first name only."""
         self.env['ir.config_parameter'].set_param(
@@ -169,6 +181,18 @@ class PersonCase(TransactionCase):
         self.params = {
             "is_company": False,
             "name": "%s, %s" % (self.lastname, self.firstname),
+        }
+
+    def test_lastname_firstname_only_wo_comma(self):
+        """Create a person setting his last name 1 and first name only.
+        Set order to 'last_first' to test name split without comma"""
+        self.env['ir.config_parameter'].set_param(
+            'partner_names_order', 'last_first')
+        self.lastname2 = False
+        self.template = "%(last1)s %(first)s"
+        self.params = {
+            "is_company": False,
+            "name": "%s %s" % (self.lastname, self.firstname),
         }
 
     def test_separately(self):


### PR DESCRIPTION
not firstname

before this commit the following error happen:
name = 'Van-Eyck Jan'

this was converted to

firstname = False
lastname= 'Van-Eyck'
lastname2 = 'Jan'

and it should be like

firstname = 'Jan'
lastname= 'Van-Eyck'
lastname2 = False

Before:
![image](https://user-images.githubusercontent.com/10233975/92129192-d28e3a80-edc8-11ea-8ae6-f95d4ea6cbf7.png)

After
![image](https://user-images.githubusercontent.com/10233975/92129241-e043c000-edc8-11ea-9349-58e2d0c8fe78.png)
