### PR TITLE
[FIX] partner_firstname: Avoid error with demo data.

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -46,7 +46,7 @@ class ResPartner(models.Model):
                     vals[key] = value
 
             # Remove the combined fields
-            if "name" in vals:
+            if "name" in vals and not self._context.get('install_mode'):
                 del vals["name"]
             if "default_name" in context:
                 del context["default_name"]


### PR DESCRIPTION
In the next case:

Module A dependencies:
  - partner_firstname
  - moduleB

If is installed partner_firstname and after moduleB loads a partner with
demo data, this returns the next error:

``"null value in column "name" violates not-null constraint"``

This, because the name is removed from vals, to get the correct name
with the compute method, but with demo data this not works, for this
reason, was improved to not remove the ``name`` in write method when is
the installed the module.