### PR TITLE
[10.0] partner-contact - update res.country.state name on geonames import

### DIFF
--- a/base_location_geonames_import/__manifest__.py
+++ b/base_location_geonames_import/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Base Location Geonames Import',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'category': 'Partner Management',
     'license': 'AGPL-3',
     'summary': 'Import better zip entries from Geonames',

--- a/base_location_geonames_import/wizard/geonames_import.py
+++ b/base_location_geonames_import/wizard/geonames_import.py
@@ -146,6 +146,7 @@ class BetterZipGeonamesImport(models.TransientModel):
         reader = unicodecsv.reader(data_file, encoding='utf-8', delimiter='	')
         for i, row in enumerate(reader):
             zip_code = self.create_better_zip(row, self.country_id)
+            self._update_state_name(row[5], zip_code.state_id)
             if zip_code in zips_to_delete:
                 zips_to_delete -= zip_code
             if max_import and (i + 1) == max_import:
@@ -159,3 +160,11 @@ class BetterZipGeonamesImport(models.TransientModel):
             'The wizard to create better zip entries from geonames '
             'has been successfully completed.')
         return True
+
+    # update state_id.name with state information
+    def _update_state_name(self, state, state_id):
+        if state_id.name != state:
+            logger.info('updating state_id.name to %s', state)
+            state_id.update({
+                'name': state,
+            })


### PR DESCRIPTION
After geonames import was observed that field 'name' in res.country.state table is not changed based the downloaded file information. The module already found a record in DB based 'name', 'city' & 'country_id' from res.better.zip table and 
'country_id' & 'code' from es.country.state and is enough to return it without any check of other fields, particularly the 'name' one.

the modification will update the name field of res.country.state table based the information received from file imported if different from the one returned by DB.