### PR TITLE
[12.0][FIX] Update partner tabs for all partner actions.

### DIFF
--- a/partner_multi_relation_tabs/models/__init__.py
+++ b/partner_multi_relation_tabs/models/__init__.py
@@ -1,4 +1,5 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import ir_actions_act_window
 from . import res_partner_tab
 from . import res_partner_relation_type
 from . import res_partner_relation_type_selection

--- a/partner_multi_relation_tabs/models/ir_actions_act_window.py
+++ b/partner_multi_relation_tabs/models/ir_actions_act_window.py
@@ -1,0 +1,28 @@
+# Copyright 2020 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class IrActionsActWindow(models.Model):
+    """Make sure tabs visibility updated when loading partner forms."""
+
+    _inherit = "ir.actions.act_window"
+
+    @api.multi
+    def read(self, fields=None, load='_classic_read'):
+        """Add update_tabs_visibility if called for partner model."""
+        remove_res_model = False
+        if fields and "context" in fields and "res_model" not in fields:
+            fields.append("res_model")
+            remove_res_model = True
+        result = super().read(fields=fields, load=load)
+        if not fields or "context" in fields:
+            for values in result:
+                if values["res_model"] == "res.partner":
+                    ctx = values.get("context", "{}")
+                    if "update_relation_tab" not in ctx:
+                        ctx = ctx.replace("{", "{\"update_relation_tab\": 1,  ", 1)
+                        values["context"] = ctx
+                if remove_res_model:
+                    del values["res_model"]
+        return result

--- a/partner_multi_relation_tabs/tests/__init__.py
+++ b/partner_multi_relation_tabs/tests/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import common
 from . import test_partner_tabs
+from . import test_partner_view_actions
 from . import test_tab

--- a/partner_multi_relation_tabs/tests/test_partner_view_actions.py
+++ b/partner_multi_relation_tabs/tests/test_partner_view_actions.py
@@ -1,0 +1,66 @@
+# Copyright 2020 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+"""Test tabs visibility will be recomputed on partner views."""
+from . import common
+
+
+UPDATE_KEY = "update_relation_tab"
+DQ = "\""
+UPDATE_CONTEXT = "{%(dq)s%(key)s%(dq)s: 1}" % {"dq": DQ, "key": UPDATE_KEY}
+
+
+class TestPartnerViewActions(common.TestCommon):
+    """Test the functionality in window action model."""
+    post_install = True
+
+    def test_non_partner_action(self):
+        """Test action to open a view for a model that is not res.partner."""
+        action_dict = self._read_model_action("res.country")
+        self.assertIn("context", action_dict)
+        self.assertIn("res_model", action_dict)
+        self.assertNotIn(UPDATE_KEY, action_dict["context"])
+
+    def test_all_fields(self):
+        """Test action to open a partner view and read all fields."""
+        action_dict = self._read_model_action("res.partner")
+        self.assertIn("context", action_dict)
+        self.assertIn("res_model", action_dict)
+        self.assertIn(UPDATE_KEY, action_dict["context"])
+
+    def test_no_duplicate(self):
+        """If key already in context, do not add it again."""
+        # No guarantee that using _read_model_action will always use same action...
+        action_model = self.env["ir.actions.act_window"]
+        action = action_model.search([("res_model", "=", "res.partner")], limit=1)
+        action.write({"context": UPDATE_CONTEXT})
+        action_dict = action.read(fields=["context"])[0]
+        self.assertIn("context", action_dict)
+        self.assertNotIn("res_model", action_dict)
+        self.assertEqual(action_dict["context"].count(UPDATE_KEY), 1)
+
+    def test_some_fields(self):
+        """Test action to open a partner view and read fields, including context."""
+        action_dict = self._read_model_action(
+            "res.partner", fields=["view_mode", "context"]
+        )
+        self.assertIn("context", action_dict)
+        self.assertNotIn("res_model", action_dict)
+        self.assertIn(UPDATE_KEY, action_dict["context"])
+
+    def test_no_context(self):
+        """Test action to open a partner view and read fields, but not context."""
+        action_dict = self._read_model_action(
+            "res.partner", fields=["view_mode", "target"]
+        )
+        self.assertIn("view_mode", action_dict)
+        self.assertNotIn("context", action_dict)
+        self.assertNotIn("res_model", action_dict)
+
+    def _read_model_action(self, model_name, fields=None):
+        """Read a single action for a model and return a dict."""
+        action_model = self.env["ir.actions.act_window"]
+        action = action_model.search([("res_model", "=", model_name)], limit=1)
+        self.assertTrue(bool(action))
+        action_dicts = action.read(fields=fields)
+        self.assertEqual(len(action_dicts), 1)
+        return action_dicts[0]

--- a/partner_multi_relation_tabs/views/menu.xml
+++ b/partner_multi_relation_tabs/views/menu.xml
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-        <record id="contacts.action_contacts" model="ir.actions.act_window">
-            <field name="context">{'update_relation_tab': 1}</field>
-        </record>
 
-        <act_window
-            id="action_res_partner_tab"
-            res_model="res.partner.tab"
-            view_mode="tree,form"
-            name="Relation Tabs"
+    <act_window
+        id="action_res_partner_tab"
+        res_model="res.partner.tab"
+        view_mode="tree,form"
+        name="Relation Tabs"
         />
 
-        <menuitem
-            id="menu_res_partner_tab"
-            parent="partner_multi_relation.menu_res_partner_relation"
-            action="action_res_partner_tab"
-            sequence="80"
+    <menuitem
+        id="menu_res_partner_tab"
+        parent="partner_multi_relation.menu_res_partner_relation"
+        action="action_res_partner_tab"
+        sequence="80"
         />
 
 </odoo>


### PR DESCRIPTION
Existing code only adds tab to partner form, when this is reached through the main Contacts action. But in practice there are many more views that lead to the partner form.