### PR TITLE
[13.0][FIX] partner_multi_relation:  Fixing problems with migration of computed fields with search f…

### DIFF
--- a/partner_multi_relation/models/res_partner.py
+++ b/partner_multi_relation/models/res_partner.py
@@ -29,24 +29,24 @@ class ResPartner(models.Model):
     )
     search_relation_type_id = fields.Many2one(
         comodel_name="res.partner.relation.type.selection",
-        compute=lambda self: None,
+        compute=lambda self: self.update({"search_relation_type_id": None}),
         search="_search_relation_type_id",
         string="Has relation of type",
     )
     search_relation_partner_id = fields.Many2one(
         comodel_name="res.partner",
-        compute=lambda self: None,
+        compute=lambda self: self.update({"search_relation_partner_id": None}),
         search="_search_related_partner_id",
         string="Has relation with",
     )
     search_relation_date = fields.Date(
-        compute=lambda self: None,
+        compute=lambda self: self.update({"search_relation_date": None}),
         search="_search_relation_date",
         string="Relation valid",
     )
     search_relation_partner_category_id = fields.Many2one(
         comodel_name="res.partner.category",
-        compute=lambda self: None,
+        compute=lambda self: self.update({"search_relation_partner_category_id": None}),
         search="_search_related_partner_category_id",
         string="Has relation with a partner in category",
     )

--- a/partner_multi_relation/models/res_partner_relation_all.py
+++ b/partner_multi_relation/models/res_partner_relation_all.py
@@ -97,7 +97,7 @@ class ResPartnerRelationAll(models.Model):
     any_partner_id = fields.Many2many(
         comodel_name="res.partner",
         string="Partner",
-        compute=lambda self: None,
+        compute=lambda self: self.update({"any_partner_id": None}),
         search="_search_any_partner_id",
     )
 


### PR DESCRIPTION
…unction and no computed function defined

Since v13 all computed functions have to assign a value in all cases to the received self records. 
Before, when defined a computed field just in order to have the search function, it was enough with defining the computed function as compute=lambda self: None, but this is not longer allowed since v13. 
This PR is to fix that error in several fields of the partner_multi_relation module in v13

@NL66278 @gurneyalex @pedrobaeza @dufresnedavid 