### PR TITLE
[10.0][IMP] partner_firstname: Improve performances

### DIFF
--- a/partner_firstname/models/base_config_settings.py
+++ b/partner_firstname/models/base_config_settings.py
@@ -71,6 +71,6 @@ class BaseConfigSettings(models.TransientModel):
     def action_recalculate_partners_name(self):
         partners = self._partners_for_recalculating()
         _logger.info("Recalculating names for %d partners.", len(partners))
-        partners._compute_name()
+        partners.with_context(tracking_disable=True)._compute_name()
         _logger.info("%d partners updated.", len(partners))
         return True

--- a/partner_firstname/models/res_users.py
+++ b/partner_firstname/models/res_users.py
@@ -28,9 +28,10 @@ class ResUser(models.Model):
     @api.onchange("firstname", "lastname")
     def _compute_name(self):
         """Write the 'name' field according to splitted data."""
+        order = self.env["res.partner"]._get_names_order()
         for rec in self:
             rec.name = rec.partner_id._get_computed_name(
-                rec.lastname, rec.firstname)
+                rec.lastname, rec.firstname, order=order)
 
     @api.multi
     def copy(self, default=None):


### PR DESCRIPTION
When batch modifications are done, the recomputation can be very
long.

* One query to ir.config.parameter when computing names, useful
when multi recordset.
* On inverse, updating both fields at once and only when needed.