### PR TITLE
Change connection to ec.europa.eu from http to https

### DIFF
--- a/base_location_nuts/tests/test_base_location_nuts.py
+++ b/base_location_nuts/tests/test_base_location_nuts.py
@@ -82,7 +82,7 @@ class TestBaseLocationNuts(common.SavepointCase):
         with self.assertRaises(UserError):
             self.importer._download_nuts(url_base='htttt://test.com')
         with self.assertRaises(UserError):
-            self.importer._download_nuts(url_base='http://ec.europa.eu/_404')
+            self.importer._download_nuts(url_base='https://ec.europa.eu/_404')
 
     def create_new_parent(self, orig_parent):
         new_parent = self.nuts_model.create({

--- a/base_location_nuts/wizard/nuts_import.py
+++ b/base_location_nuts/wizard/nuts_import.py
@@ -15,7 +15,7 @@ from collections import OrderedDict
 logger = logging.getLogger(__name__)
 
 # Default server values
-URL_BASE = 'http://ec.europa.eu'
+URL_BASE = 'https://ec.europa.eu'
 URL_PATH = '/eurostat/ramon/nomenclatures/index.cfm'
 URL_PARAMS = {'TargetUrl': 'ACT_OTH_CLS_DLD',
               'StrNom': 'NUTS_2013',


### PR DESCRIPTION
ec.europa.eu site has enabled the https protocol by default.

This commit is for update base_location_nuts to use this URL with https.

