### PR TITLE
[FIX][13.0] partner_identification: Add menu for Partner ID Numbers

### DIFF
--- a/partner_identification/__manifest__.py
+++ b/partner_identification/__manifest__.py
@@ -9,7 +9,7 @@
 {
     "name": "Partner Identification Numbers",
     "category": "Customer Relationship Management",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.0.2",
     "license": "AGPL-3",
     "depends": ["contacts"],
     "data": [

--- a/partner_identification/views/res_partner_id_number_view.xml
+++ b/partner_identification/views/res_partner_id_number_view.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <form string="Partner ID Numbers">
                 <group>
+                    <field name="partner_id" />
                     <field name="category_id" />
                     <field name="name" />
                     <field name="partner_issued_id" />
@@ -42,4 +43,9 @@
         <field name="res_model">res.partner.id_number</field>
         <field name="view_mode">tree,form</field>
     </record>
+    <menuitem
+        action="action_partner_id_numbers_form"
+        id="menu_partner_id_numbers"
+        parent="contacts.res_partner_menu_config"
+    />
 </odoo>


### PR DESCRIPTION
PR to add missing menu item for Partner ID Numbers and field partner_id inside form view.
New menu will add the possibility to import/export records.