### PR TITLE
[13.0][IMP] Add missing field to ID Numbers tree view

### DIFF
--- a/partner_identification/views/res_partner_id_number_view.xml
+++ b/partner_identification/views/res_partner_id_number_view.xml
@@ -28,6 +28,7 @@
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree string="Partner ID Numbers">
+                <field name="partner_id" />
                 <field name="category_id" />
                 <field name="name" />
                 <field name="partner_issued_id" />

--- a/partner_identification/views/res_partner_view.xml
+++ b/partner_identification/views/res_partner_view.xml
@@ -14,6 +14,7 @@
                         colspan="4"
                         nolabel="1"
                         widget="one2many_list"
+                        context="{'default_partner_id': active_id}"
                     />
                 </page>
             </page>


### PR DESCRIPTION
Aim of this PR is to add missing partner_id field to ID numbers tree view and pre-fill partner_id with current partner name in tab on partner form. 