### PR TITLE
[FIX] partner_contact_address_default: can't adapt type 'res.partner'

### DIFF
--- a/partner_contact_address_default/models/res_partner.py
+++ b/partner_contact_address_default/models/res_partner.py
@@ -26,5 +26,5 @@ class ResPartner(models.Model):
             for addr_type in default_address_type_list:
                 default_address_id = partner['partner_{}_id'.format(addr_type)]
                 if default_address_id:
-                    res[addr_type] = default_address_id
+                    res[addr_type] = default_address_id.id
         return res

--- a/partner_contact_address_default/tests/test_partner_contact_address_default.py
+++ b/partner_contact_address_default/tests/test_partner_contact_address_default.py
@@ -32,13 +32,13 @@ class TestPartnerContactAddressDefault(common.TransactionCase):
         self.partner.partner_delivery_id = self.partner
         self.partner.partner_invoice_id = self.partner
         res = self.partner.address_get()
-        self.assertEqual(res['delivery'], self.partner)
-        self.assertEqual(res['invoice'], self.partner)
+        self.assertEqual(res['delivery'], self.partner.id)
+        self.assertEqual(res['invoice'], self.partner.id)
 
         self.partner_child_delivery2.partner_delivery_id =\
             self.partner_child_delivery2
         self.partner_child_delivery2.partner_invoice_id =\
             self.partner_child_delivery2
         res = self.partner_child_delivery2.address_get()
-        self.assertEqual(res['delivery'], self.partner_child_delivery2)
-        self.assertEqual(res['invoice'], self.partner_child_delivery2)
+        self.assertEqual(res['delivery'], self.partner_child_delivery2.id)
+        self.assertEqual(res['invoice'], self.partner_child_delivery2.id)


### PR DESCRIPTION
Update with the same type of value as the original function (ID instead of BrowseRecord). As it is now, in runbot it gives an error, and in some of our clients it also fails



**Runbot error: create invoice from a sale order**
![OCA_partner_contact_address_default](https://user-images.githubusercontent.com/29223264/98136579-62339080-1ec1-11eb-9f00-2b8a79b3a8d2.png)
