### PR TITLE
[14.0][FIX] partner_firstname: byte encoded string from ldap

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -127,6 +127,11 @@ class ResPartner(models.Model):
 
         Removes leading, trailing and duplicated whitespace.
         """
+        if isinstance(name, bytes):
+            # With users coming from LDAP, name can be a byte encoded string.
+            # This happens with FreeIPA for instance.
+            name = name.decode("utf-8")
+
         try:
             name = " ".join(name.split()) if name else name
         except UnicodeDecodeError:


### PR DESCRIPTION
Forward port of https://github.com/OCA/partner-contact/pull/1017.

This PR fixes the following error:

```
  File "/path_to/partner_firstname/models/res_partner.py", line 38, in create
    self._get_whitespace_cleaned_name(name),
  File "/path_to/partner_firstname/models/res_partner.py", line 131, in _get_whitespace_cleaned_name
    name = " ".join(name.split()) if name else name
TypeError: sequence item 0: expected str instance, bytes found - - -
```

The error occurs when the user name coming from LDAP (eg.: FreeIPA) is a byte encoded string.