### PR TITLE
[12.0] base_location: allow to correctly save company form

### DIFF
--- a/base_location/models/res_company.py
+++ b/base_location/models/res_company.py
@@ -47,21 +47,11 @@ class ResCompany(models.Model):
 
     def _inverse_city_id(self):
         for company in self:
-            company.with_context(
-                skip_check_zip=True).partner_id.city_id = company.city_id
+            company.partner_id.city_id = company.city_id
 
     def _inverse_zip_id(self):
         for company in self:
-            company.with_context(
-                skip_check_zip=True).partner_id.zip_id = company.zip_id
-
-    def _inverse_state(self):
-        return super(ResCompany, self.with_context(
-            skip_check_zip=True))._inverse_state()
-
-    def _inverse_country(self):
-        return super(ResCompany, self.with_context(
-            skip_check_zip=True))._inverse_country()
+            company.partner_id.zip_id = company.zip_id
 
     @api.onchange('zip_id')
     def _onchange_zip_id(self):

--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -70,8 +70,6 @@ class ResPartner(models.Model):
 
     @api.constrains('zip_id', 'country_id', 'city_id', 'state_id')
     def _check_zip(self):
-        if self.env.context.get('skip_check_zip'):
-            return
         for rec in self:
             if not rec.zip_id:
                 continue

--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -2,8 +2,7 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -67,24 +66,6 @@ class ResPartner(models.Model):
             self.update(vals)
         elif not self.country_enforce_cities:
             self.city_id = False
-
-    @api.constrains('zip_id', 'country_id', 'city_id', 'state_id')
-    def _check_zip(self):
-        for rec in self:
-            if not rec.zip_id:
-                continue
-            if rec.zip_id.city_id.state_id != rec.state_id:
-                raise ValidationError(_(
-                    "The state of the partner %s differs from that in "
-                    "location %s") % (rec.name, rec.zip_id.name))
-            if rec.zip_id.city_id.country_id != rec.country_id:
-                raise ValidationError(_(
-                    "The country of the partner %s differs from that in "
-                    "location %s") % (rec.name, rec.zip_id.name))
-            if rec.city_id and rec.zip_id.city_id != rec.city_id:
-                raise ValidationError(_(
-                    "The city of partner %s differs from that in "
-                    "location %s") % (rec.name, rec.zip_id.name))
 
     @api.onchange('state_id')
     def _onchange_state_id(self):

--- a/base_location/tests/test_base_location.py
+++ b/base_location/tests/test_base_location.py
@@ -135,9 +135,6 @@ class TestBaseLocation(common.SavepointCase):
                 'zip_id': self.barcelona.id,
             })
 
-    def test_writing_company(self):
-        self.company.zip_id = self.barcelona
-
     def test_constrains_partner_country(self):
         """Test partner country constraints"""
         partner = self.partner_obj.create({

--- a/base_location/tests/test_base_location.py
+++ b/base_location/tests/test_base_location.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Yannick Vaucher, Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.exceptions import ValidationError
 from odoo.tests import tagged, common
 from odoo.tools.misc import mute_logger
 import psycopg2
@@ -127,52 +126,38 @@ class TestBaseLocation(common.SavepointCase):
         company._onchange_zip_id()
         self.assertEqual(company.city_id, self.barcelona.city_id)
 
-    def test_constrains_partner_01(self):
-        """Test partner 1 constraints"""
-        with self.assertRaises(ValidationError):
-            self.partner_obj.create({
-                'name': 'P1',
-                'zip_id': self.barcelona.id,
-            })
+    def test_writing_company(self):
+        self.company.zip_id = self.barcelona
 
     def test_constrains_partner_country(self):
         """Test partner country constraints"""
-        partner = self.partner_obj.create({
+        self.partner_obj.create({
             'name': 'P1',
             'zip_id': self.barcelona.id,
             'country_id': self.barcelona.city_id.country_id.id,
             'state_id': self.barcelona.city_id.state_id.id,
             'city_id': self.barcelona.city_id.id,
         })
-
-        with self.assertRaises(ValidationError):
-            partner.country_id = self.ref('base.ch')
 
     def test_constrains_partner_state(self):
         """Test partner state constraints"""
-        partner = self.partner_obj.create({
+        self.partner_obj.create({
             'name': 'P1',
             'zip_id': self.barcelona.id,
             'country_id': self.barcelona.city_id.country_id.id,
             'state_id': self.barcelona.city_id.state_id.id,
             'city_id': self.barcelona.city_id.id,
         })
-
-        with self.assertRaises(ValidationError):
-            partner.state_id = self.state_vd.id
 
     def test_constrains_partner_city(self):
         """Test partner city constraints"""
-        partner = self.partner_obj.create({
+        self.partner_obj.create({
             'name': 'P1',
             'zip_id': self.barcelona.id,
             'country_id': self.barcelona.city_id.country_id.id,
             'state_id': self.barcelona.city_id.state_id.id,
             'city_id': self.barcelona.city_id.id,
         })
-
-        with self.assertRaises(ValidationError):
-            partner.city_id = self.city_lausanne
 
     def test_partner_onchange_country(self):
         """Test partner onchange country_id"""


### PR DESCRIPTION
From https://github.com/OCA/partner-contact/pull/733

Reverting 70fc4395740e9df4c8056adc877ab784c1c6c21c and removing _check_zip as preventing to correctly save company data.

FIX the following case

 - open company form
 - set state_id
 - save
 - state_id is not saved

![base_location](https://user-images.githubusercontent.com/1033131/102221710-c004c080-3ee2-11eb-82c0-2eb05df4a9c0.gif)
