### PR TITLE
[UPD]partner_fax:set field position after mobile

### DIFF
--- a/partner_fax/views/res_partner.xml
+++ b/partner_fax/views/res_partner.xml
@@ -6,7 +6,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_simple_form"/>
         <field name="arch" type="xml">
-            <field name="function" position="after">
+            <field name="mobile" position="after">
                 <field name="fax" placeholder="Fax..."/>
             </field>
         </field>
@@ -17,7 +17,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_short_form"/>
         <field name="arch" type="xml">
-            <field name="function" position="after">
+            <field name="mobile" position="after">
                 <field name="fax" placeholder="Fax..." widget="phone"/>
             </field>
         </field>
@@ -28,10 +28,10 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <field name="function" position="after">
+            <field name="mobile" position="after">
                 <field name="fax" placeholder="Fax..." widget="phone"/>
             </field>
-            <xpath expr="//field[@name='child_ids']/form//field[@name='function']" position="after">
+            <xpath expr="//field[@name='child_ids']/form//field[@name='mobile']" position="after">
                 <field name="fax" placeholder="Fax..." widget="phone"/>
             </xpath>
         </field>


### PR DESCRIPTION
Having fax as the first field of communication data is confusing and
not as it was back when it was in core Odoo.
This changes the fax position to be right after mobile