### PR TITLE
[12.0][FIX] base_location: Keep contacts zip_id and city_id addresses in sync with their parent

### DIFF
--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -5,12 +5,19 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
+ADDRESS_FIELDS = ('zip_id', 'city_id')
+
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     zip_id = fields.Many2one('res.city.zip', 'ZIP Location', index=True)
     city_id = fields.Many2one(index=True)  # add index for performance
+
+    @api.model
+    def _address_fields(self):
+        """Returns the list of address fields that are synced from the parent."""
+        return super()._address_fields() + list(ADDRESS_FIELDS)
 
     @api.onchange('city_id')
     def _onchange_city_id(self):


### PR DESCRIPTION
Use the  `res.partner` built-in method `_address_fields()` to include `zip_id` and `city_id` in the list of fields that must stay in sync with the object's parent.