### PR TITLE
[CHG] partner_address_version: revamp functionality

### DIFF
--- a/partner_address_version/models/res_partner.py
+++ b/partner_address_version/models/res_partner.py
@@ -44,6 +44,23 @@ class ResPartner(models.Model):
         version_hash = hashlib.md5(str(version).encode("utf-8")).hexdigest()
         return version_hash
 
+    def _version_impacted_tables(self):
+        """
+        :return:
+            - list of tables to update in case of address versioning
+        """
+        return []
+
+    def _version_exclude_keys(self):
+        """
+        :return:
+            - dict:
+                key = table name
+                value = list of columns to ignore in case of address
+                        versioning
+        """
+        return {}
+
     def _version_impacted_columns(self):
         """
         :return: list of tuples of format:

--- a/partner_address_version/models/res_partner.py
+++ b/partner_address_version/models/res_partner.py
@@ -86,8 +86,6 @@ class ResPartner(models.Model):
                 "base.partner.merge.automatic.wizard"
             ].with_context(address_version=True)
             partner_wizard._update_foreign_keys(self, version_p)
-            return version_p
-        return self
 
     def write(self, vals):
         version_fields = self._version_fields()
@@ -121,7 +119,7 @@ class ResPartner(models.Model):
         return self.copy(default=default)
 
     def _version_exists(self):
-        return bool(
+        return (
             self.env["res.partner"]
             .with_context(active_test=False)
             .search([("version_hash", "=", self._version_hash())])

--- a/partner_address_version/models/res_partner.py
+++ b/partner_address_version/models/res_partner.py
@@ -86,7 +86,8 @@ class ResPartner(models.Model):
                 "base.partner.merge.automatic.wizard"
             ].with_context(address_version=True)
             partner_wizard._update_foreign_keys(self, version_p)
-        return False
+            return version_p
+        return self
 
     def write(self, vals):
         version_fields = self._version_fields()

--- a/partner_address_version/models/res_partner.py
+++ b/partner_address_version/models/res_partner.py
@@ -44,22 +44,12 @@ class ResPartner(models.Model):
         version_hash = hashlib.md5(str(version).encode("utf-8")).hexdigest()
         return version_hash
 
-    def _version_impacted_tables(self):
+    def _version_impacted_columns(self):
         """
-        :return:
-            - list of tables to update in case of address versioning
+        :return: list of tuples of format:
+            (table_name, column_name)
         """
         return []
-
-    def _version_exclude_keys(self):
-        """
-        :return:
-            - dict:
-                key = table name
-                value = list of columns to ignore in case of address
-                        versioning
-        """
-        return {}
 
     def _version_need(self):
         """

--- a/partner_address_version/models/res_partner.py
+++ b/partner_address_version/models/res_partner.py
@@ -118,3 +118,10 @@ class ResPartner(models.Model):
             "date_version": fields.Datetime.now(),
         }
         return self.copy(default=default)
+
+    def _version_exists(self):
+        return bool(
+            self.env["res.partner"]
+            .with_context(active_test=False)
+            .search([("version_hash", "=", self._version_hash())])
+        )

--- a/partner_address_version/tests/test_address_version.py
+++ b/partner_address_version/tests/test_address_version.py
@@ -3,12 +3,44 @@
 
 import hashlib
 from collections import OrderedDict
+from contextlib import contextmanager
 
-from odoo.exceptions import UserError
+from mock import patch
+
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import SavepointCase
+
+MOCK_PATH_RES_PARTNER = (
+    "odoo.addons.partner_address_version" ".models.res_partner" ".ResPartner."
+)
 
 
 class TestAddressVersion(SavepointCase):
+    @classmethod
+    def _get_created_partners(cls):
+        return (
+            cls.env["res.partner"]
+            .with_context(active_test=False)
+            .search([("id", ">", cls.last_partner_id)], order="id desc")
+        )
+
+    @contextmanager
+    def patch_fn(self, to_patch):
+        """
+        :param to_patch: dict of format function_name: return_value
+        SavepointCase doesn't reset patched methods inbetween tests;
+        we take care to clean them up
+        """
+        cleanup = []
+        for path, return_value in to_patch.items():
+            patcher = patch(MOCK_PATH_RES_PARTNER + path)
+            mock_fn = patcher.start()
+            mock_fn.return_value = return_value
+            cleanup.append(patcher.stop)
+        yield
+        for stop_mock in cleanup:
+            stop_mock()
+
     @classmethod
     def setUpClass(cls):
         super(TestAddressVersion, cls).setUpClass()
@@ -28,6 +60,13 @@ class TestAddressVersion(SavepointCase):
         cls.partner = cls.env["res.partner"].create(create_vals)
         cls.partner_2 = cls.env["res.partner"].create(create_vals_2)
         cls.partner_vals.update({"parent_id": cls.partner.id})
+        cls.last_partner_id = (
+            cls.env["res.partner"]
+            .with_context(active_test=False)
+            .search([], order="id desc")[0]
+            .id
+            or 0
+        )
 
     def test_hash(self):
         test_hash = hashlib.md5(str(self.partner_vals).encode("utf-8")).hexdigest()
@@ -53,3 +92,87 @@ class TestAddressVersion(SavepointCase):
             self.assertEqual(new_partner[field], new_partner_2[field])
         self.assertNotEqual(new_partner.id, new_partner_2.id)
         self.assertNotEqual(new_partner.version_hash, new_partner_2.version_hash)
+
+    def test_version_exists(self):
+        self.assertFalse(self.partner._version_exists())
+        self.partner._version_create()
+        self.assertTrue(self.partner._version_exists())
+
+    def test_write_nonversioned_partner(self):
+        """
+        * Implement _version_need
+        * Write on the partner
+        -> We should get a new versioned partner
+        """
+        with self.patch_fn({"_version_need": True}):
+            self.partner.street = "New Street"
+        self.assertTrue(self._get_created_partners())
+
+    def test_impacted_tables(self):
+        """
+        * Implement impacted_tables on res.users
+        * Trigger partner versioning
+        -> Check res.users are impacted
+        """
+        user = self.env.ref("base.user_demo")
+        user.partner_id = self.partner
+        with self.patch_fn(
+            {
+                "_version_need": True,
+                "_version_impacted_tables": ["res_users"],
+            }
+        ):
+            self.partner.street = "New Street"
+        self.assertEqual(user.partner_id, self._get_created_partners())
+
+    def test_impacted_tables_excluded_keys(self):
+        """
+        * Implement impacted_tables + excluded keys
+        * Trigger partner versioning
+        -> Check excluded keys are not affected
+        """
+        user = self.env.ref("base.user_demo")
+        user.partner_id = self.partner
+        with self.patch_fn(
+            {
+                "_version_need": True,
+                "_version_impacted_tables": ["res_users"],
+                "_version_exclude_keys": {"res_users": "partner_id"},
+            }
+        ):
+            self.partner.street = "New Street"
+        self.assertEqual(user.partner_id, self.partner)
+
+    def test_impacted_columns(self):
+        """
+        * Implement impacted_columns
+        * Trigger partner versioning
+        -> Check res.users are impacted
+        """
+        user = self.env.ref("base.user_demo")
+        user.partner_id = self.partner
+        with self.patch_fn(
+            {
+                "_version_need": True,
+                "_version_impacted_columns": [("res_users", "partner_id")],
+            }
+        ):
+            self.partner.street = "New Street"
+        self.assertEqual(user.partner_id, self._get_created_partners())
+
+    def test_nonsense_implementation(self):
+        """
+        * Implement impacted_columns + Impacted_tables
+        * Trigger partner versioning
+        -> Error should occur
+        """
+        with self.patch_fn(
+            {
+                "_version_need": True,
+                "_version_impacted_tables": ["res_users"],
+                "_version_exclude_keys": {"res_users": "partner_id"},
+                "_version_impacted_columns": [("res_users", "partner_id")],
+            }
+        ):
+            with self.assertRaises(ValidationError):
+                self.partner.street = "New Street"

--- a/partner_address_version/wizards/base_partner_merge.py
+++ b/partner_address_version/wizards/base_partner_merge.py
@@ -1,14 +1,40 @@
 # Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import _, models
+from odoo.exceptions import ValidationError
 
 
 class MergePartnerAutomatic(models.TransientModel):
     _inherit = "base.partner.merge.automatic.wizard"
 
+    def _get_fk_on_address_version(self, foreign_keys):
+        impacted_tables = self.env["res.partner"]._version_impacted_tables()
+        excluded_keys = self.env["res.partner"]._version_exclude_keys()
+        impacted_columns = self.env["res.partner"]._version_impacted_columns()
+        if (impacted_tables or excluded_keys) and impacted_columns:
+            raise ValidationError(
+                _(
+                    "Address versioning error, you must "
+                    "exclusively do ONE of the following:"
+                    "\n- specify impacted tables and/or excluded keys"
+                    "\n- specify impacted columns"
+                )
+            )
+        if impacted_tables or excluded_keys:
+            limited_fk = []
+            for fk in foreign_keys:
+                if fk[0] in impacted_tables:
+                    ignore_col = excluded_keys.get(fk[0], False)
+                    if ignore_col and fk[1] in ignore_col:
+                        continue
+                    limited_fk.append(fk)
+            return limited_fk
+        else:
+            return self.env["res.partner"]._version_impacted_columns()
+
     def _get_fk_on(self, table):
         foreign_keys = super(MergePartnerAutomatic, self)._get_fk_on(table)
         if table == "res_partner" and self.env.context.get("address_version"):
-            return self.env["res.partner"]._version_impacted_columns()
+            return self._get_fk_on_address_version(foreign_keys)
         return foreign_keys

--- a/partner_address_version/wizards/base_partner_merge.py
+++ b/partner_address_version/wizards/base_partner_merge.py
@@ -10,14 +10,5 @@ class MergePartnerAutomatic(models.TransientModel):
     def _get_fk_on(self, table):
         foreign_keys = super(MergePartnerAutomatic, self)._get_fk_on(table)
         if table == "res_partner" and self.env.context.get("address_version"):
-            models = self.env["res.partner"]._version_impacted_tables()
-            limited_fk = []
-            for fk in foreign_keys:
-                if fk[0] in models:
-                    ignore_col_dict = self.env["res.partner"]._version_exclude_keys()
-                    ignore_col = ignore_col_dict.get(fk[0], False)
-                    if ignore_col and fk[1] in ignore_col:
-                        continue
-                    limited_fk.append(fk)
-            return limited_fk
+            return self.env["res.partner"]._version_impacted_columns()
         return foreign_keys


### PR DESCRIPTION
This changes the functionality of https://github.com/OCA/partner-contact/commit/3ee4689fe00be63dc8a8d53c1a7600d33533a31c

Previously, we would specify table names and excluded column names (keys): it seems very easy to have side-effects from it, because we anytime we add a new res.partner M2O, then it will be automatically impacted by this module. It seems less error-prone instead of specifying excluded columns, to specify instead which columns to use.

For instance we will have problems if we also use this: 
https://github.com/OCA/sale-workflow/tree/14.0/sale_commercial_partner
The above module adds a new field on sale orders "commercial_partner_id" that checks for the parent company of the partner_id. This allows us to do charts and reports (e.g Mr. X and Ms. Y work at Agrolait, I don't care about Mr. X and Mr. Y, on my report I want to quickly see which sales were made to Agrolait and its children contact)

This PR proposes that we explicitly state which models, on which fields, we want to version.

This would make it much harder to get side effects.

@Cedric-Pigeon 