### PR TITLE
[13.0][IMP] partner_identification duplicate

### DIFF
--- a/partner_identification/models/res_partner_id_number.py
+++ b/partner_identification/models/res_partner_id_number.py
@@ -68,3 +68,11 @@ class ResPartnerIdNumber(models.Model):
         ]
     )
     active = fields.Boolean(string="Active", default=True)
+
+    _sql_constraints = [
+        (
+            "unique_number_and_category",
+            "UNIQUE(category_id, name)",
+            "The combo category and ID number must be unique",
+        )
+    ]

--- a/partner_identification/tests/test_res_partner.py
+++ b/partner_identification/tests/test_res_partner.py
@@ -1,6 +1,8 @@
 # Copyright 2017 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from psycopg2 import IntegrityError
+
 from odoo.exceptions import ValidationError
 from odoo.tests import common
 
@@ -85,3 +87,22 @@ class TestResPartner(common.SavepointCase):
         self.partner.social_security = "Test"
         partner = self.env["res.partner"].search([("social_security", "=", "Test")])
         self.assertEqual(partner, self.partner)
+
+    def test_raise_duplicate_category_and_id(self):
+        """Check no duplicate allowed for combo (category, number)."""
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "Duplicate ID",
+                "category_id": self.partner_id_category.id,
+                "partner_id": self.partner.id,
+            }
+        )
+
+        with self.assertRaises(IntegrityError):
+            self.env["res.partner.id_number"].create(
+                {
+                    "name": "Duplicate ID",
+                    "category_id": self.partner_id_category.id,
+                    "partner_id": self.partner.id,
+                }
+            )


### PR DESCRIPTION
At the moment, it is possible to create duplicate of number ID
for the same category.
Which not something that make sense.

So this change adds a constraint on the combo (category, id_number).