### PR TITLE
[13.0][ADD] partner_identification_unique_by_category

### DIFF
--- a/partner_identification_unique_by_category/__init__.py
+++ b/partner_identification_unique_by_category/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/partner_identification_unique_by_category/__manifest__.py
+++ b/partner_identification_unique_by_category/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Partner Identification Numbers Unique By Category",
+    "category": "Customer Relationship Management",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": ["partner_identification"],
+    "data": ["views/res_partner_id_category_view.xml"],
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/partner-contact",
+    "development_status": "Production/Stable",
+}

--- a/partner_identification_unique_by_category/models/__init__.py
+++ b/partner_identification_unique_by_category/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner_id_number
+from . import res_partner_id_category

--- a/partner_identification_unique_by_category/models/res_partner_id_category.py
+++ b/partner_identification_unique_by_category/models/res_partner_id_category.py
@@ -1,0 +1,31 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResPartnerIdCategory(models.Model):
+    _inherit = "res.partner.id_category"
+
+    has_unique_numbers = fields.Boolean(
+        string="Enforce unicity",
+        help="When set, duplicate numbers will not be allowed for this category.",
+    )
+
+    @api.constrains("has_unique_numbers")
+    def validate_must_be_unique(self):
+        for rec in self:
+            if not rec.has_unique_numbers:
+                continue
+            ids = self.env["res.partner.id_number"].search(
+                [("category_id", "in", rec.ids)]
+            )
+            unique_numbers = set(ids.mapped("name"))
+            if len(ids) != len(unique_numbers):
+                raise ValidationError(
+                    _(
+                        "The category {} can not be set to use unique numbers, "
+                        "because it already contains duplicates."
+                    ).format(rec.name)
+                )

--- a/partner_identification_unique_by_category/models/res_partner_id_number.py
+++ b/partner_identification_unique_by_category/models/res_partner_id_number.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class ResPartnerIdNumber(models.Model):
+    _inherit = "res.partner.id_number"
+    _description = "Partner ID Number"
+    _order = "name"
+
+    @api.constrains("name", "category_id")
+    def validate_id_number(self):
+        super().validate_id_number()
+        for rec in self:
+            if not rec.category_id.has_unique_numbers:
+                continue
+            count = self.search_count(
+                [("name", "=", rec.name), ("category_id", "in", rec.category_id.ids)]
+            )
+            if count > 1:
+                raise ValidationError(
+                    _(
+                        "The Id {} in the category {} could not be created because "
+                        "it already exists"
+                    ).format(rec.name, rec.category_id.name)
+                )

--- a/partner_identification_unique_by_category/readme/CONTRIBUTORS.rst
+++ b/partner_identification_unique_by_category/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/partner_identification_unique_by_category/readme/DESCRIPTION.rst
+++ b/partner_identification_unique_by_category/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module extends the module `partner_identification` to enforce having
+unique id numbers by categories.
+This option can be set by category.

--- a/partner_identification_unique_by_category/tests/__init__.py
+++ b/partner_identification_unique_by_category/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_partner_identification_unique_by_category

--- a/partner_identification_unique_by_category/tests/test_partner_identification_unique_by_category.py
+++ b/partner_identification_unique_by_category/tests/test_partner_identification_unique_by_category.py
@@ -1,0 +1,84 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import SavepointCase
+
+
+class TestPartnerIdentificationUniqueByCategory(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.category_1 = cls.env["res.partner.id_category"].create(
+            {"code": "UID", "name": "Group Id"}
+        )
+        cls.category_2 = cls.env["res.partner.id_category"].create(
+            {"code": "GID", "name": "User Id"}
+        )
+        cls.partner_1 = cls.env.ref("base.res_partner_1")
+        cls.partner_2 = cls.env.ref("base.res_partner_2")
+
+    def test_id_creation(self):
+        """Check Id unique (or not) validation."""
+        self.category_1.has_unique_numbers = True
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "123",
+                "category_id": self.category_1.id,
+                "partner_id": self.partner_1.id,
+            }
+        )
+        message = (
+            "The Id 123 in the category Group Id could not be created "
+            "because it already exists"
+        )
+        with self.assertRaisesRegex(ValidationError, message):
+            self.env["res.partner.id_number"].create(
+                {
+                    "name": "123",
+                    "category_id": self.category_1.id,
+                    "partner_id": self.partner_2.id,
+                }
+            )
+        # Allow to create same id in an other category
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "123",
+                "category_id": self.category_2.id,
+                "partner_id": self.partner_2.id,
+            }
+        )
+        self.category_1.has_unique_numbers = False
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "123",
+                "category_id": self.category_1.id,
+                "partner_id": self.partner_2.id,
+            }
+        )
+
+    def test_category_unique_activation(self):
+        """Check there is no duplicate when enabling unicity."""
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "123456",
+                "category_id": self.category_1.id,
+                "partner_id": self.partner_1.id,
+            }
+        )
+        self.category_1.has_unique_numbers = True
+        self.category_1.has_unique_numbers = False
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "123456",
+                "category_id": self.category_1.id,
+                "partner_id": self.partner_2.id,
+            }
+        )
+        message = (
+            "The category Group Id can not be set to use unique numbers, "
+            "because it already contains duplicates."
+        )
+        with self.assertRaisesRegex(ValidationError, message):
+            self.category_1.has_unique_numbers = True

--- a/partner_identification_unique_by_category/views/res_partner_id_category_view.xml
+++ b/partner_identification_unique_by_category/views/res_partner_id_category_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_partner_id_category_form">
+        <field name="name">res.partner.id_category.form</field>
+        <field name="model">res.partner.id_category</field>
+        <field
+            name="inherit_id"
+            ref="partner_identification.view_partner_id_category_form"
+        />
+        <field name="arch" type="xml">
+            <field name="code" position="after">
+                <field name="has_unique_numbers" />
+            </field>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="view_partner_id_category_tree">
+        <field name="name">res.partner.id_category.tree</field>
+        <field name="model">res.partner.id_category</field>
+        <field
+            name="inherit_id"
+            ref="partner_identification.view_partner_id_category_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="code" position="after">
+                <field name="has_unique_numbers" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/partner_identification_unique_by_category/odoo/addons/partner_identification_unique_by_category
+++ b/setup/partner_identification_unique_by_category/odoo/addons/partner_identification_unique_by_category
@@ -1,0 +1,1 @@
+../../../../partner_identification_unique_by_category

--- a/setup/partner_identification_unique_by_category/setup.py
+++ b/setup/partner_identification_unique_by_category/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module extends the module `partner_identification` to enforce having
unique id numbers by categories.
This option can be set by category.