### PR TITLE
[12.0][IMP] base_location: pre-fill zip code with current city

### DIFF
--- a/base_location/views/res_city_view.xml
+++ b/base_location/views/res_city_view.xml
@@ -28,7 +28,7 @@
                 </group>
                 <notebook>
                     <page name="zips" string="Zips">
-                        <field name="zip_ids"/>
+                        <field name="zip_ids" context="{'default_city_id': active_id}"/>
                     </page>
                 </notebook>
             </form>


### PR DESCRIPTION
Set city from current form when creating a new zip code.
![image](https://user-images.githubusercontent.com/22446243/118491208-08890a00-b71f-11eb-93ca-449c65a0cb6e.png)

Note that in the initial implementation the domain is not locked to the current city, and that's a good point when you need to move a zip code from a city to another one.