### PR TITLE
[13.0][FIX] partner_manual_rank: call compute when rank is incremented

### DIFF
--- a/partner_manual_rank/models/res_partner.py
+++ b/partner_manual_rank/models/res_partner.py
@@ -47,3 +47,8 @@ class ResPartner(models.Model):
                 partners._increase_rank("supplier_rank")
             else:
                 partners.supplier_rank = 0
+
+    def _increase_rank(self, field):
+        super()._increase_rank(field)
+        if self.ids and field in ["customer_rank", "supplier_rank"]:
+            self.modified([field])


### PR DESCRIPTION
The _increase_rank updates the rank by sql instead of using orm, so api.depends doesn't work.

I have tested the fix.