### PR TITLE
[14.0] [ADD] Added dependencies repo in oca-dependencies file.

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 # See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
+server-ux


### PR DESCRIPTION
- `partner_tier_validation` module is depend on `base_tier_validation`, that is inside `server-ux` repo.