### PR TITLE
[14.0][FIX] base_location_geonames_import : old_zip id may be removed more than once

### DIFF
--- a/base_location_geonames_import/wizard/geonames_import.py
+++ b/base_location_geonames_import/wizard/geonames_import.py
@@ -224,7 +224,7 @@ class CityZipGeonamesImport(models.TransientModel):
                 if zip_vals not in zip_vals_list:
                     zip_vals_list.append(zip_vals)
             else:
-                old_zips.remove(zip_code.id)
+                old_zips.discard(zip_code.id)
         self.env["res.city.zip"].create(zip_vals_list)
         if not max_import:
             if old_zips:


### PR DESCRIPTION
In that case, using remove would raise a KeyError.
On the other hand, discard fails silently.

I got this issue when re-importing France geonames.
Two rows pointed to the same zip_code:

|-|-|-|-|-|-|-|-|-|-|-|-|
|-|-|-|-|-|-|-|-|-|-|-|-|
|FR|62760|Thièvres|Hauts-de-France|32|Pas-de-Calais|62|Arrondissement d’Arras|621|50.1306|2.4552|5| 
|FR|62760|Thièvres|Hauts-de-France|32|Somme|80|Arrondissement de Péronne|804|50.1268|2.454|5| 

(Note: there may be other cases like this, this is the first one that raised the exception)
