### PR TITLE
[IMP] partner_contact_address_default ux

### DIFF
--- a/partner_contact_address_default/models/res_partner.py
+++ b/partner_contact_address_default/models/res_partner.py
@@ -17,14 +17,40 @@ class ResPartner(models.Model):
     )
 
     def get_address_default_type(self):
+        """This will be the extension method for other contact types"""
         return ['delivery', 'invoice']
 
     def address_get(self, adr_pref=None):
+        """Force the delivery or invoice addresses. It will try to default
+        to the one set in the commercial partner if any"""
         res = super().address_get(adr_pref)
-        default_address_type_list = self.get_address_default_type()
+        adr_pref = adr_pref or []
+        default_address_type_list = set([
+            x for x in adr_pref if x in self.get_address_default_type()
+        ])
         for partner in self:
             for addr_type in default_address_type_list:
-                default_address_id = partner['partner_{}_id'.format(addr_type)]
+                default_address_id = (
+                    partner['partner_{}_id'.format(addr_type)] or
+                    partner.commercial_partner_id[
+                        'partner_{}_id'.format(addr_type)
+                    ]
+                )
                 if default_address_id:
                     res[addr_type] = default_address_id.id
         return res
+
+    def write(self, vals):
+        """We want to prevent archived contacts as default addresses"""
+        if vals.get("active") is False:
+            self.search([
+                ("partner_delivery_id", "in", self.ids)
+            ]).write({
+                "partner_delivery_id": False,
+            })
+            self.search([
+                ("partner_invoice_id", "in", self.ids)
+            ]).write({
+                "partner_invoice_id": False,
+            })
+        return super().write(vals)

--- a/partner_contact_address_default/tests/test_partner_contact_address_default.py
+++ b/partner_contact_address_default/tests/test_partner_contact_address_default.py
@@ -31,7 +31,7 @@ class TestPartnerContactAddressDefault(common.TransactionCase):
     def test_contact_address_default(self):
         self.partner.partner_delivery_id = self.partner
         self.partner.partner_invoice_id = self.partner
-        res = self.partner.address_get()
+        res = self.partner.address_get(['delivery', 'invoice'])
         self.assertEqual(res['delivery'], self.partner.id)
         self.assertEqual(res['invoice'], self.partner.id)
 
@@ -39,6 +39,6 @@ class TestPartnerContactAddressDefault(common.TransactionCase):
             self.partner_child_delivery2
         self.partner_child_delivery2.partner_invoice_id =\
             self.partner_child_delivery2
-        res = self.partner_child_delivery2.address_get()
+        res = self.partner_child_delivery2.address_get(['delivery', 'invoice'])
         self.assertEqual(res['delivery'], self.partner_child_delivery2.id)
         self.assertEqual(res['invoice'], self.partner_child_delivery2.id)

--- a/partner_contact_address_default/views/res_partner_views.xml
+++ b/partner_contact_address_default/views/res_partner_views.xml
@@ -8,15 +8,23 @@
             <xpath expr="//field[@name='child_ids']" position="before">
                 <group>
                     <group>
-                        <field name="partner_delivery_id" domain="[('id', 'child_of', commercial_partner_id)]"/>
+                        <field
+                            name="partner_delivery_id"
+                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'delivery')]"
+                            widget="selection"
+                        />
                     </group>
                     <group>
-                        <field name="partner_invoice_id" domain="[('id', 'child_of', commercial_partner_id)]"/>
+                        <field
+                            name="partner_invoice_id"
+                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'invoice')]"
+                            widget="selection"
+                        />
                     </group>
                 </group>
             </xpath>
             <xpath expr="//field[@name='child_ids']//form//group" position="after">
-                <group string="Force addresses" attrs="{'invisible': [('type', '=', 'private')]}">
+                <group string="Force addresses" attrs="{'invisible': [('type', '!=', 'contact')]}">
                     <group colspan="4">
                         <field name="commercial_partner_id" invisible="1"/>
                         <div class="oe_grey">
@@ -25,12 +33,16 @@
                         </div>
                     </group>
                     <group colspan="4">
-                        <group>
-                            <field name="partner_delivery_id" domain="[('id', 'child_of', commercial_partner_id)]"/>
-                        </group>
-                        <group>
-                            <field name="partner_invoice_id" domain="[('id', 'child_of', commercial_partner_id)]"/>
-                        </group>
+                        <field
+                            name="partner_delivery_id"
+                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'delivery')]"
+                        />
+                    </group>
+                    <group colspan="4">
+                        <field
+                            name="partner_invoice_id"
+                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'invoice')]"
+                        />
                     </group>
                 </group>
             </xpath>


### PR DESCRIPTION
- Filter delivery and invoice addreses properly
- Show it only in contact addresses
- Default to the address the addreses set in the commercial partner if any.

cc @Tecnativa TT30351

please review @sergio-teruel @pedrobaeza 