### PR TITLE
[13.0][partner_affiliate][imp] modify partner views to allow you to edit the address and vat of an affiliate.

### DIFF
--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -2,7 +2,7 @@
 # Copyright 2018 brain-tec AG - Raul Martin
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -22,3 +22,10 @@ class ResPartner(models.Model):
         string="Affiliates",
         domain=[("active", "=", True), ("is_company", "=", True)],
     )
+
+    @api.onchange("parent_id")
+    def onchange_parent_id(self):
+        # If it is a company and it has a parent, do not change the address.
+        if self.parent_id and self.is_company:
+            return {}
+        return super(ResPartner, self).onchange_parent_id()

--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -6,6 +6,35 @@
         <field eval="1" name="priority" />
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
+            <field name="street" position='attributes'>
+                <attribute name="attrs">{'readonly': [('type', '=',
+                    'contact'),('parent_id', '!=', False),('is_company', '=',False)]}</attribute>
+            </field>
+            <field name="street2" position='attributes'>
+                <attribute name="attrs">{'readonly': [('type', '=',
+                    'contact'),('parent_id', '!=', False),('is_company', '=',False)]}</attribute>
+            </field>
+            <field name="city" position='attributes'>
+                <attribute name="attrs">{'readonly': [('type', '=',
+                    'contact'),('parent_id', '!=', False),('is_company', '=',False)]}</attribute>
+            </field>
+            <field name="state_id" position='attributes'>
+                <attribute name="attrs">{'readonly': [('type', '=',
+                    'contact'),('parent_id', '!=', False),('is_company', '=',False)]}</attribute>
+            </field>
+            <field name="zip" position='attributes'>
+                <attribute name="attrs">{'readonly': [('type', '=',
+                    'contact'),('parent_id', '!=', False),('is_company', '=',False)]}</attribute>
+            </field>
+            <field name="country_id" position='attributes'>
+                <attribute name="attrs">{'readonly': [('type', '=',
+                    'contact'),('parent_id', '!=', False),('is_company', '=',False)]}</attribute>
+            </field>
+            <field name="vat" position='attributes'>
+                <attribute
+                    name="attrs"
+                >{'readonly': [('parent_id','!=',False),('is_company', '=',False)]}</attribute>
+            </field>
             <xpath
                 expr="/form/sheet//div[hasclass('o_row')]/field[@name='parent_id']"
                 position="attributes"


### PR DESCRIPTION
Currently the address and VAT fields are read-only by the time you choose a parent. That makes sense when you are linking a contact to a parent company, but not when you are linking a company to a parent company.

@ForgeFlow