### PR TITLE
[FIX] partner_multi_relation: Avoid access error on Relations button

### DIFF
--- a/partner_multi_relation/models/res_partner.py
+++ b/partner_multi_relation/models/res_partner.py
@@ -187,9 +187,9 @@ class ResPartner(models.Model):
                     ("other_partner_id", "=", contact.id),
                 ]
             )
-            action = self.env.ref(
+            action = self.env["ir.actions.act_window"]._for_xml_id(
                 "partner_multi_relation.action_res_partner_relation_all"
-            ).read()[0]
+            )
             action["domain"] = [("id", "in", relation_ids.ids)]
             context = action.get("context", "{}").strip()[1:-1]
             elements = context.split(",") if context else []

--- a/partner_multi_relation/tests/__init__.py
+++ b/partner_multi_relation/tests/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import test_partner_relation_common
+from . import test_partner_relation_action
 from . import test_partner_relation
 from . import test_partner_relation_all
 from . import test_partner_search

--- a/partner_multi_relation/tests/test_partner_relation_action.py
+++ b/partner_multi_relation/tests/test_partner_relation_action.py
@@ -1,0 +1,29 @@
+# © 2021 Tobias Zehntner
+# © 2021 Niboo SRL (https://www.niboo.com/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import exceptions
+
+from .test_partner_relation_common import TestPartnerRelationCommon
+
+
+class TestPartnerRelationAction(TestPartnerRelationCommon):
+    def setUp(self):
+        super().setUp()
+        self.user = self.env["res.users"].create(
+            {
+                "login": "test_partner_action_user",
+                "name": "test_partner_action_user",
+                "groups_id": [
+                    (4, self.env.ref("base.group_user").id),
+                ],
+            }
+        )
+
+    def test_call_relation_action(self):
+        """Test calling relations action. Should be possible with simple user rights"""
+        try:
+            self.partner_01_person.with_user(self.user).action_view_relations()
+        except exceptions.AccessError:
+            self.fail("action_view_relations() raised AccessError unexpectedly!")


### PR DESCRIPTION
In Odoo v14, ir.actions.act_window have only access rights for admin while a user had read access in previous versions. Odoo provides now a function (`_for_xml_id`) that returns the action read with sudo.

To reproduce: As standard user that has a relation, click on the "Relations" magic button on the contact form. Without this fix it throws an access error:
```
You are not allowed to access 'Action Window' (ir.actions.act_window) records.
This operation is allowed for the following groups:
	- Administration/Settings
```