### PR TITLE
Disable sms on Fax-fields

### DIFF
--- a/partner_fax/views/res_partner.xml
+++ b/partner_fax/views/res_partner.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-	<record id="view_partner_simple_form_fax" model="ir.ui.view">
-		<field name="name">Add fax on partner</field>
-		<field name="model">res.partner</field>
-		<field name="inherit_id" ref="base.view_partner_simple_form" />
-		<field name="arch" type="xml">
-			<field name="function" position="after">
-				<field 
-					name="fax" 
-					placeholder="Fax..." 
-					options="{'enable_sms': False}"
-				/>
-			</field>
-		</field>
-	</record>
-	<record id="view_partner_form_fax" model="ir.ui.view">
-		<field name="name">Add fax on partner</field>
-		<field name="model">res.partner</field>
-		<field name="inherit_id" ref="base.view_partner_form" />
-		<field name="arch" type="xml">
-			<field name="function" position="after">
-				<field 
-					name="fax" 
-					placeholder="Fax..." 
-					widget="phone" 
-					options="{'enable_sms': False}"
-				/>
-			</field>
-			<xpath
+    <record id="view_partner_simple_form_fax" model="ir.ui.view">
+        <field name="name">Add fax on partner</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_simple_form" />
+        <field name="arch" type="xml">
+            <field name="function" position="after">
+                <field 
+                    name="fax" 
+                    placeholder="Fax..." 
+                    options="{'enable_sms': False}"
+                />
+            </field>
+        </field>
+    </record>
+    <record id="view_partner_form_fax" model="ir.ui.view">
+        <field name="name">Add fax on partner</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <field name="function" position="after">
+                <field 
+                    name="fax" 
+                    placeholder="Fax..." 
+                    widget="phone" 
+                    options="{'enable_sms': False}"
+                />
+            </field>
+            <xpath
                 expr="//field[@name='child_ids']/form//field[@name='mobile']"
                 position="after"
             >
-				<field 
-					name="fax" 
-					placeholder="Fax..." 
-					widget="phone" 
-					options="{'enable_sms': False}"
-				/>
-			</xpath>
-		</field>
-	</record>
+                <field 
+                    name="fax" 
+                    placeholder="Fax..." 
+                    widget="phone" 
+                    options="{'enable_sms': False}"
+                />
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/partner_fax/views/res_partner.xml
+++ b/partner_fax/views/res_partner.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base.view_partner_simple_form" />
         <field name="arch" type="xml">
             <field name="function" position="after">
-                <field name="fax" placeholder="Fax..." />
+                <field name="fax" placeholder="Fax..." options="{'enable_sms': False}"/>
             </field>
         </field>
     </record>
@@ -16,13 +16,13 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
             <field name="function" position="after">
-                <field name="fax" placeholder="Fax..." widget="phone" />
+                <field name="fax" placeholder="Fax..." widget="phone" options="{'enable_sms': False}" />
             </field>
             <xpath
                 expr="//field[@name='child_ids']/form//field[@name='mobile']"
                 position="after"
             >
-                <field name="fax" placeholder="Fax..." widget="phone" />
+                <field name="fax" placeholder="Fax..." widget="phone" options="{'enable_sms': False}" />
             </xpath>
         </field>
     </record>

--- a/partner_fax/views/res_partner.xml
+++ b/partner_fax/views/res_partner.xml
@@ -1,29 +1,43 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="view_partner_simple_form_fax" model="ir.ui.view">
-        <field name="name">Add fax on partner</field>
-        <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_simple_form" />
-        <field name="arch" type="xml">
-            <field name="function" position="after">
-                <field name="fax" placeholder="Fax..." options="{'enable_sms': False}"/>
-            </field>
-        </field>
-    </record>
-    <record id="view_partner_form_fax" model="ir.ui.view">
-        <field name="name">Add fax on partner</field>
-        <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form" />
-        <field name="arch" type="xml">
-            <field name="function" position="after">
-                <field name="fax" placeholder="Fax..." widget="phone" options="{'enable_sms': False}" />
-            </field>
-            <xpath
+	<record id="view_partner_simple_form_fax" model="ir.ui.view">
+		<field name="name">Add fax on partner</field>
+		<field name="model">res.partner</field>
+		<field name="inherit_id" ref="base.view_partner_simple_form" />
+		<field name="arch" type="xml">
+			<field name="function" position="after">
+				<field 
+					name="fax" 
+					placeholder="Fax..." 
+					options="{'enable_sms': False}"
+				/>
+			</field>
+		</field>
+	</record>
+	<record id="view_partner_form_fax" model="ir.ui.view">
+		<field name="name">Add fax on partner</field>
+		<field name="model">res.partner</field>
+		<field name="inherit_id" ref="base.view_partner_form" />
+		<field name="arch" type="xml">
+			<field name="function" position="after">
+				<field 
+					name="fax" 
+					placeholder="Fax..." 
+					widget="phone" 
+					options="{'enable_sms': False}"
+				/>
+			</field>
+			<xpath
                 expr="//field[@name='child_ids']/form//field[@name='mobile']"
                 position="after"
             >
-                <field name="fax" placeholder="Fax..." widget="phone" options="{'enable_sms': False}" />
-            </xpath>
-        </field>
-    </record>
+				<field 
+					name="fax" 
+					placeholder="Fax..." 
+					widget="phone" 
+					options="{'enable_sms': False}"
+				/>
+			</xpath>
+		</field>
+	</record>
 </odoo>


### PR DESCRIPTION
Fax-numbers are not used for SMS, so showing the sms-button ahead of it is a bit confusing for end-users.