### PR TITLE
[14.0][IMP][partner_identification] Allow attachments and chatter for res_partner_id_number model

### DIFF
--- a/partner_identification/models/res_partner_id_number.py
+++ b/partner_identification/models/res_partner_id_number.py
@@ -13,6 +13,7 @@ from odoo import api, fields, models
 class ResPartnerIdNumber(models.Model):
     _name = "res.partner.id_number"
     _description = "Partner ID Number"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "name"
 
     @api.constrains("name", "category_id")

--- a/partner_identification/views/res_partner_id_number_view.xml
+++ b/partner_identification/views/res_partner_id_number_view.xml
@@ -6,19 +6,26 @@
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Partner ID Numbers">
-                <group>
-                    <field name="partner_id" />
-                    <field name="category_id" />
-                    <field name="name" />
-                    <field name="partner_issued_id" />
-                    <field name="date_issued" />
-                    <field name="place_issuance" />
-                    <field name="valid_from" />
-                    <field name="valid_until" />
-                    <field name="status" />
-                </group>
-                <separator colspan="4" string="Notes" />
-                <field name="comment" colspan="4" nolabel="1" />
+                <sheet>
+                    <group>
+                        <field name="partner_id" />
+                        <field name="category_id" />
+                        <field name="name" />
+                        <field name="partner_issued_id" />
+                        <field name="date_issued" />
+                        <field name="place_issuance" />
+                        <field name="valid_from" />
+                        <field name="valid_until" />
+                        <field name="status" />
+                    </group>
+                    <separator colspan="4" string="Notes" />
+                    <field name="comment" colspan="4" nolabel="1" />
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
With this commit, one can attach documents in chatter and plan activities in res_partner_id_number model