### PR TITLE
[14.0][FIX] base_location: address field sync zip_id

### DIFF
--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -146,3 +146,7 @@ class ResPartner(models.Model):
         for node in doc.xpath("//field[@name='zip_id']"):
             node.attrib["domain"] = self._zip_id_domain()
         return etree.tostring(doc, encoding="unicode")
+
+    @api.model
+    def _address_fields(self):
+        return super()._address_fields() + ["zip_id"]

--- a/base_location/tests/test_base_location.py
+++ b/base_location/tests/test_base_location.py
@@ -204,6 +204,29 @@ class TestBaseLocation(common.SavepointCase):
         self.company._onchange_state_id()
         self.assertEqual(self.company.country_id, self.company.state_id.country_id)
 
+    def test_partner_address_field_sync(self):
+        """Test that zip_id is correctly synced with parent of contact addresses"""
+        parent = self.env["res.partner"].create(
+            {
+                "name": "ACME Inc.",
+                "is_company": True,
+                "street": "123 Fake St.",
+                "city": "Springfield",
+                "state_id": self.barcelona.state_id.id,
+                "country_id": self.barcelona.country_id.id,
+                "zip_id": self.barcelona.id,
+            }
+        )
+        contact = self.env["res.partner"].create(
+            {
+                "name": "John Doe",
+                "type": "contact",
+                "parent_id": parent.id,
+            }
+        )
+        parent.zip_id = self.lausanne
+        self.assertEqual(contact.zip_id, self.lausanne, "Contact should be synced")
+
     def test_display_name(self):
         """Test if the display_name is stored and computed properly"""
         self.assertEqual(


### PR DESCRIPTION
`_address_fields` are used by `update_address` [^1], which is in turn called by `_fields_sync` and `_children_sync`.

This mechanism is in charge of synchronizing parent/children address fields for contacts of type == "contact", as they don't really have an address of their own. They simply copy the address of their parent.

Without this fix, not only the zip_id is not sync'ed, but also in some cases an exception may be raised by `_check_zip_id`, due to only some fields being sync'ed but not all, creating inconsistencies between zip_id and other address fields.

[^1]: https://github.com/odoo/odoo/blob/20648ef21/odoo/addons/base/models/res_partner.py#L429