### PR TITLE
[14.0][FIX] base_location: security - all users should be able to read

### DIFF
--- a/base_location/security/ir.model.access.csv
+++ b/base_location/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"ir_model_access_cityzip_all","res_city_zip all users","model_res_city_zip",,1,0,0,0
 "ir_model_access_cityzip0","res_city_zip group_user","model_res_city_zip","base.group_partner_manager",1,1,1,1


### PR DESCRIPTION
For some reason, this access was removed during the migration to 12.0 (67baf9196).
But this security is perfectly valid and aligned to Odoo core's security for `res.city`[^1].

Without this, you might get bitten while trying to implement website features that
require reading or setting partner's zip_id, for example.

[^1]: https://github.com/odoo/odoo/blob/f5a5d9616/addons/base_address_city/security/ir.model.access.csv