### PR TITLE
[13.0][FIX] base_location: address field sync zip_id

### DIFF
--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -79,3 +79,7 @@ class ResPartner(models.Model):
         if self.zip_id and self.state_id != self.zip_id.city_id.state_id:
             vals.update({"zip_id": False, "zip": False, "city": False})
         self.update(vals)
+
+    @api.model
+    def _address_fields(self):
+        return super()._address_fields() + ["zip_id", "city_id"]

--- a/base_location/tests/test_base_location.py
+++ b/base_location/tests/test_base_location.py
@@ -4,7 +4,7 @@
 import psycopg2
 
 from odoo.exceptions import ValidationError
-from odoo.tests import common, tagged
+from odoo.tests import Form, common, tagged
 from odoo.tools.misc import mute_logger
 
 
@@ -246,3 +246,25 @@ class TestBaseLocation(common.SavepointCase):
                     "country_id": self.ref("base.es"),
                 }
             )
+
+    def test_partner_address_field_sync(self):
+        """Test that zip_id is correctly synced with parent of contact addresses"""
+        parent = self.env["res.partner"].create(
+            {
+                "name": "ACME Inc.",
+                "is_company": True,
+                "street": "123 Fake St.",
+                "city": "Springfield",
+                "city_id": self.barcelona.city_id.id,
+                "state_id": self.barcelona.city_id.state_id.id,
+                "country_id": self.barcelona.city_id.country_id.id,
+                "zip_id": self.barcelona.id,
+            }
+        )
+        contact = self.env["res.partner"].create(
+            {"name": "John Doe", "type": "contact", "parent_id": parent.id}
+        )
+        parent = Form(parent)
+        parent.zip_id = self.lausanne
+        parent.save()
+        self.assertEqual(contact.zip_id, self.lausanne, "Contact should be synced")


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/partner-contact/pull/1150

`_address_fields` are used by `update_address` [1], which is in turn
called by `_fields_sync` and `_children_sync`.

This mechanism is in charge of synchronizing parent/children address fields
for contacts of type == "contact", as they don't really have an address of
their own. They simply copy the address of their parent.

Without this fix, not only the zip_id is not sync'ed, but also in some cases
an exception may be raised by `_check_zip_id`, due to only some fields being
sync'ed but not all, creating inconsistencies between zip_id and other address
fields.

Please @pedrobaeza @joao-p-marques can you review it?

@Tecnativa TT33047


[1]: https://github.com/odoo/odoo/blob/20648ef21/odoo/addons/base/models/res_partner.py#L429