### PR TITLE
[14.0][FIX] base_location: address field sync city_id

### DIFF
--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -149,4 +149,4 @@ class ResPartner(models.Model):
 
     @api.model
     def _address_fields(self):
-        return super()._address_fields() + ["zip_id"]
+        return super()._address_fields() + ["zip_id", "city_id"]


### PR DESCRIPTION
Partial FWP from 13.0: https://github.com/OCA/partner-contact/pull/1180

Address field sync `city_id`.

Please @pedrobaeza @joao-p-marques can you review it?

@Tecnativa TT33047