### PR TITLE
[13.0][FIX] base_location: Remove zip_id field to _address_fields() function

### DIFF
--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -82,4 +82,4 @@ class ResPartner(models.Model):
 
     @api.model
     def _address_fields(self):
-        return super()._address_fields() + ["zip_id", "city_id"]
+        return super()._address_fields() + ["zip_id"]


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/81230 it is not necessary to add the `zip_id` field to `_address_fields()`

Related to https://github.com/OCA/partner-contact/pull/1180, now it is necessary to remove part of the change because odoo has included it in `base_address_city` addon.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT33047