### PR TITLE
[14.0][FIX+IMP] base_location: Remove zip_id field to _address_fields() function

### DIFF
--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -149,4 +149,4 @@ class ResPartner(models.Model):
 
     @api.model
     def _address_fields(self):
-        return super()._address_fields() + ["zip_id", "city_id"]
+        return super()._address_fields() + ["zip_id"]

--- a/base_location/tests/test_base_location.py
+++ b/base_location/tests/test_base_location.py
@@ -212,6 +212,7 @@ class TestBaseLocation(common.SavepointCase):
                 "is_company": True,
                 "street": "123 Fake St.",
                 "city": "Springfield",
+                "city_id": self.barcelona.city_id.id,
                 "state_id": self.barcelona.state_id.id,
                 "country_id": self.barcelona.country_id.id,
                 "zip_id": self.barcelona.id,
@@ -224,7 +225,9 @@ class TestBaseLocation(common.SavepointCase):
                 "parent_id": parent.id,
             }
         )
+        parent = Form(parent)
         parent.zip_id = self.lausanne
+        parent.save()
         self.assertEqual(contact.zip_id, self.lausanne, "Contact should be synced")
 
     def test_display_name(self):


### PR DESCRIPTION
Improve tests according to https://github.com/OCA/partner-contact/pull/1180.
Since https://github.com/odoo/odoo/pull/81239 it is not necessary to add the `zip_id` field to `_address_fields()`

Similar in v13: https://github.com/OCA/partner-contact/pull/1194

Related to https://github.com/OCA/partner-contact/pull/1181, now it is necessary to remove the change because odoo has included it in `base_address_city` addon.

Locked by:
- [x] `base_address_city` https://github.com/odoo/odoo/pull/81239

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT33047