### PR TITLE
[FIX] 14.0 address_default: return ids on address_get

### DIFF
--- a/partner_contact_address_default/models/res_partner.py
+++ b/partner_contact_address_default/models/res_partner.py
@@ -26,5 +26,5 @@ class ResPartner(models.Model):
             for addr_type in default_address_type_list:
                 default_address_id = partner["partner_{}_id".format(addr_type)]
                 if default_address_id:
-                    res[addr_type] = default_address_id
+                    res[addr_type] = default_address_id.id
         return res

--- a/partner_contact_address_default/tests/test_partner_contact_address_default.py
+++ b/partner_contact_address_default/tests/test_partner_contact_address_default.py
@@ -31,11 +31,11 @@ class TestPartnerContactAddressDefault(common.TransactionCase):
         self.partner.partner_delivery_id = self.partner
         self.partner.partner_invoice_id = self.partner
         res = self.partner.address_get()
-        self.assertEqual(res["delivery"], self.partner)
-        self.assertEqual(res["invoice"], self.partner)
+        self.assertEqual(res["delivery"], self.partner.id)
+        self.assertEqual(res["invoice"], self.partner.id)
 
         self.partner_child_delivery2.partner_delivery_id = self.partner_child_delivery2
         self.partner_child_delivery2.partner_invoice_id = self.partner_child_delivery2
         res = self.partner_child_delivery2.address_get()
-        self.assertEqual(res["delivery"], self.partner_child_delivery2)
-        self.assertEqual(res["invoice"], self.partner_child_delivery2)
+        self.assertEqual(res["delivery"], self.partner_child_delivery2.id)
+        self.assertEqual(res["invoice"], self.partner_child_delivery2.id)


### PR DESCRIPTION
The Odoo function returns ids so this function should too: https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/models/res_partner.py#L882 

It made me run into issues with this: https://github.com/odoo/odoo/blob/14.0/addons/sale/models/sale.py#L508