### PR TITLE
[14.0][FIX] partner_tier_validation: create does not need custom code, restart validation on controlled field changes

### DIFF
--- a/partner_tier_validation/readme/CONFIGURATION.rst
+++ b/partner_tier_validation/readme/CONFIGURATION.rst
@@ -3,8 +3,22 @@ A default validation rule is provided out of the box,
 that can be used as a starting point fot this configuration.
 
 This configuration is done at
-*Settings > Technical > Tier Validations > Tier Definition*.
+*Settings / Technical / Tier Validations / Tier Definition*.
 
-Note that, since Contacts start as archived records,
-the *Definition Domain* must include ``"|",["active","=",True],["active","=",False]``.
-Otherwise the validation rule won't apply correctly in new records.
+Also relevant is the configuration on the default Stage
+for new Contacts/Partners.
+This can be set at *Contacts / Configuration / Contact Stage*,
+setting the "Default Sate" field on the appropriate Stage record.
+
+Changing some fields will trigger a new request for validation.
+This list of fields can be customized extending ``_partner_tier_revalidation_fields``.
+By default these fields are:
+
+- Company Type (Individual or Company)
+- Parent Company
+- Tax ID
+- State
+- Country
+- Fiscal Position
+- Account Receivable
+- Account Payable

--- a/partner_tier_validation/readme/USAGE.rst
+++ b/partner_tier_validation/readme/USAGE.rst
@@ -1,3 +1,8 @@
+Before using, check Contact Stages configuration,
+to ensure that the default stage has the "Related State" field
+set to "To Approve".
+For example, having the "Draft" stage the default ensures this.
+
 A regular user creates a new Contact and sends it for approval:
 
 #. Create a Contact triggering at least one "Tier Definition".


### PR DESCRIPTION
- [FIX] partner_tier_validation: create does not need custom code, restart validation on controlled field changes
