### PR TITLE
[FIX] Rename group name

### DIFF
--- a/partner_stage/views/res_partner_views.xml
+++ b/partner_stage/views/res_partner_views.xml
@@ -23,7 +23,7 @@
         <field name="arch" type="xml">
             <filter name="group_country" position="after">
                 <filter
-                    name="group_country"
+                    name="group_stage"
                     string="Stage"
                     context="{'group_by': 'stage_id'}"
                 />


### PR DESCRIPTION
Hello, 
The name of the group "group_country" is already in-use. 
Thanks