### PR TITLE
[REF] partner_firstname,partner_second_lastname: Avoid _inverse_name when recalculating names

### DIFF
--- a/partner_firstname/models/base_config_settings.py
+++ b/partner_firstname/models/base_config_settings.py
@@ -61,7 +61,10 @@ class ResConfigSettings(models.TransientModel):
         )
         partners = self._partners_for_recalculating()
         _logger.info("Recalculating names for %d partners.", len(partners))
-        partners._compute_name()
+        # Use add_to_compute instead of _compute_name to avoid triggering
+        # _inverse_name_after_cleaning_whitespace, which can
+        # modify a partner's firstname, lastname and lastname2
+        self.env.add_to_compute(self.env["res.partner"]._fields["name"], partners)
         self.partner_names_order_changed = False
         self.execute()
         _logger.info("%d partners updated.", len(partners))

--- a/partner_second_lastname/tests/test_name.py
+++ b/partner_second_lastname/tests/test_name.py
@@ -197,3 +197,33 @@ class UserCase(PersonCase, MailInstalled):
         # Skip if ``mail`` is installed
         if not self.mail_installed():
             super(UserCase, self).tearDown()
+
+
+class TestRecalculateNames(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.config_settings = self.env["res.config.settings"].create({})
+
+    def test_recalculate_names(self):
+        firstname = "Xavier De Jesús"
+        lastname = "Payen"
+        lastname2 = "Sandoval"
+        correct_names = {
+            "first_last": f"{firstname} {lastname} {lastname2}",
+            "last_first": f"{lastname} {lastname2} {firstname}",
+            "last_first_comma": f"{lastname} {lastname2}, {firstname}",
+        }
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": firstname,
+                "lastname": lastname,
+                "lastname2": lastname2,
+            }
+        )
+        for order in correct_names:
+            self.config_settings.partner_names_order = order
+            self.config_settings.action_recalculate_partners_name()
+            self.assertEqual(partner.name, correct_names[order])
+            self.assertEqual(partner.firstname, firstname)
+            self.assertEqual(partner.lastname, lastname)
+            self.assertEqual(partner.lastname2, lastname2)


### PR DESCRIPTION
Currently, pressing the Recalculate Names button in the 'Partner Names Order' setting
triggers the _inverse_name method which can modify the firstname, lastname and lastname2
of a partner depending on the 'partner_names_order' setting and the number of names
in each field.

The modification to action_recalculate_partners_name prevents the _inverse_name method from 
triggering when pressing Recalculate Names, leaving the firstname, lastname and lastname2 fields intact.

Demo video (left window is before fix; right window is after applying fix): https://www.youtube.com/watch?v=5yAVLBajTbo

Additionally, added related unittest to ensure names are computed correctly without
modifying firstname, lastname or lastname2.