### PR TITLE
[15.0][UPD] partner_deduplicate_acl. Set bigger value of a sequence menu

### DIFF
--- a/partner_deduplicate_acl/views/base_partner_merge_view.xml
+++ b/partner_deduplicate_acl/views/base_partner_merge_view.xml
@@ -9,7 +9,7 @@
         id='base_tools'
         name='Tools'
         parent='contacts.menu_contacts'
-        sequence="1"
+        sequence="10"
     />
     <menuitem
         id='partner_merge_automatic_menu'


### PR DESCRIPTION
In order to prevent that the wizard "Deduplicate Contacts" is automatically launched by just clicking on "Contacts", the sequence of this menu is increased.

@Tecnativa TT37296

