### PR TITLE
[15.0][IMP] partner_ref_unique: improve corporative partners

### DIFF
--- a/partner_ref_unique/models/res_company.py
+++ b/partner_ref_unique/models/res_company.py
@@ -12,6 +12,7 @@ class ResCompany(models.Model):
         selection=[
             ("none", "None"),
             ("companies", "Only companies"),
+            ("exclude_corporative", "All, except contacts of a partner"),
             ("all", "All partners"),
         ],
         string="Unique partner reference for",

--- a/partner_ref_unique/models/res_partner.py
+++ b/partner_ref_unique/models/res_partner.py
@@ -9,23 +9,32 @@ from odoo.exceptions import ValidationError
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    @api.constrains("ref", "is_company", "company_id")
+    @api.constrains("ref", "is_company", "company_id", "parent_id")
     def _check_ref(self):
         for partner in self.filtered("ref"):
             # If the company is not defined in the partner, take current user company
             company = partner.company_id or self.env.company
             mode = company.partner_ref_unique
-            if mode == "all" or (mode == "companies" and partner.is_company):
-                domain = [
-                    ("id", "!=", partner.id),
-                    ("ref", "=", partner.ref),
-                ]
-                if mode == "companies":
+            if mode == "none":
+                continue
+            domain = [
+                ("id", "!=", partner.id),
+                ("ref", "=", partner.ref),
+            ]
+            if mode == "exclude_corporative":
+                if partner.parent_id:
+                    # if reference same as the main on the company skip the check
+                    # reference will be checked on company level
+                    if partner.ref == partner.parent_id.ref:
+                        continue
+            if mode == "companies":
+                if partner.is_company:
                     domain.append(("is_company", "=", True))
-                other = self.search(domain)
-                # Don't raise when coming from contact merge wizard or no duplicates
-                if other and not self.env.context.get("partner_ref_unique_merging"):
-                    raise ValidationError(
-                        _("This reference is equal to partner '%s'")
-                        % other[0].display_name
-                    )
+                else:
+                    domain.append(("is_company", "=", False))
+            other = self.search(domain)
+            # Don't raise when coming from contact merge wizard or no duplicates
+            if other and not self.env.context.get("partner_ref_unique_merging"):
+                raise ValidationError(
+                    _("This reference is equal to partner '%s'") % other[0].display_name
+                )

--- a/partner_ref_unique/models/res_partner.py
+++ b/partner_ref_unique/models/res_partner.py
@@ -29,8 +29,6 @@ class ResPartner(models.Model):
                         continue
             if mode == "companies":
                 domain.append(("is_company", "=", partner.is_company))
-                else:
-                    domain.append(("is_company", "=", False))
             other = self.search(domain)
             # Don't raise when coming from contact merge wizard or no duplicates
             if other and not self.env.context.get("partner_ref_unique_merging"):

--- a/partner_ref_unique/models/res_partner.py
+++ b/partner_ref_unique/models/res_partner.py
@@ -28,8 +28,7 @@ class ResPartner(models.Model):
                     if partner.ref == partner.parent_id.ref:
                         continue
             if mode == "companies":
-                if partner.is_company:
-                    domain.append(("is_company", "=", True))
+                domain.append(("is_company", "=", partner.is_company))
                 else:
                     domain.append(("is_company", "=", False))
             other = self.search(domain)

--- a/partner_ref_unique/readme/USAGE.rst
+++ b/partner_ref_unique/readme/USAGE.rst
@@ -3,4 +3,6 @@
 
    * If you selected the option 'All partners', you can't create two partners with the same ref.
    * If you selected the option 'Only companies', you can't create two companies with the same ref.
+   * If you selected the option 'All, except contacts of a partner', you can't create two partners with 
+   the same ref, except the case, if partner has a parent, thus partners in a group can share the same reference.
    * If you selected the option 'None', you can create two partners with the same ref.

--- a/partner_ref_unique/readme/USAGE.rst
+++ b/partner_ref_unique/readme/USAGE.rst
@@ -3,6 +3,6 @@
 
    * If you selected the option 'All partners', you can't create two partners with the same ref.
    * If you selected the option 'Only companies', you can't create two companies with the same ref.
-   * If you selected the option 'All, except contacts of a partner', you can't create two partners with 
-   the same ref, except the case, if partner has a parent, thus partners in a group can share the same reference.
+   * If you selected the option 'All, except contacts of a partner', you can't create two partners with
+     the same ref, except the case, if partner has a parent, thus partners in a group can share the same reference.
    * If you selected the option 'None', you can create two partners with the same ref.


### PR DESCRIPTION
allow non unique references for partners under one company

customer request: partners under the company should operate under the same reference they propagate it to documents so it is possible to select them just by reference
we add one more option which should provide expected behaviour 