### PR TITLE
[FIX] filter on sector searching in name

### DIFF
--- a/partner_sector/views/res_partner_view.xml
+++ b/partner_sector/views/res_partner_view.xml
@@ -46,7 +46,7 @@
             <field name="category_id" position="after">
                 <field name="sector_id"
                        string="Sector"
-                       filter_domain="['|',('sector_id','ilike',self),
+                       filter_domain="['|',('sector_id.name','ilike',self),
                                            ('secondary_sector_ids.name','ilike',self)]"/>
             </field>
             <filter name="salesperson" position="after">


### PR DESCRIPTION
Old domain would create an error in search. 
By searching in sector_id name we have expected behaviour.