### PR TITLE
[Fix] Opening Deduplicate Contacts when clicking on main Contacts men…

### DIFF
--- a/partner_deduplicate_acl/README.rst
+++ b/partner_deduplicate_acl/README.rst
@@ -66,7 +66,7 @@ Usage
 To use this module, you need to:
 
 #. Ask your admin to give you the new rights.
-#. Go to *CRM > Tools > Deduplicate Contacts* as usual.
+#. Go to *Contacts > Tools > Deduplicate Contacts* as usual.
 
 Bug Tracker
 ===========

--- a/partner_deduplicate_acl/readme/USAGE.rst
+++ b/partner_deduplicate_acl/readme/USAGE.rst
@@ -1,4 +1,4 @@
 To use this module, you need to:
 
 #. Ask your admin to give you the new rights.
-#. Go to *CRM > Tools > Deduplicate Contacts* as usual.
+#. Go to *Contacts > Tools > Deduplicate Contacts* as usual.

--- a/partner_deduplicate_acl/views/base_partner_merge_view.xml
+++ b/partner_deduplicate_acl/views/base_partner_merge_view.xml
@@ -9,7 +9,7 @@
         id='base_tools'
         name='Tools'
         parent='contacts.menu_contacts'
-        sequence="1"
+        sequence="2"
     />
     <menuitem
         id='partner_merge_automatic_menu'


### PR DESCRIPTION
[FIX] partner_deduplicate_acl: Put menu on lower sequence

So that when clicking on Contacts main menu, it doesn't open the
wizard by default.

![Bildschirmfoto_vom_2022-09-01_16-28-13](https://user-images.githubusercontent.com/10541765/189487240-e19349fb-7029-4fd4-b09c-d77bbc4b5288.png)
