### PR TITLE
[10.0][FIX]: Requirement email_validator >= 1.3 fail in partner_email_check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ python-stdnum
 suds
 requests
 unicodecsv
-email_validator
+email_validator<1.3


### PR DESCRIPTION
https://github.com/OCA/partner-contact/issues/1358