### PR TITLE
[FIX] Corrected German Street translation to be uniform with odoo core

### DIFF
--- a/partner_address_street3/i18n/de.po
+++ b/partner_address_street3/i18n/de.po
@@ -60,13 +60,13 @@ msgstr "Layout in Reports"
 #: model:ir.model.fields,field_description:partner_address_street3.field_res_partner__street3
 #: model:ir.model.fields,field_description:partner_address_street3.field_res_users__street3
 msgid "Street 3"
-msgstr "Strasse 3"
+msgstr "Straße 3"
 
 #. module: partner_address_street3
 #: model_terms:ir.ui.view,arch_db:partner_address_street3.add_street3_in_form_view
 #: model_terms:ir.ui.view,arch_db:partner_address_street3.view_partner_address_form
 msgid "Street 3..."
-msgstr "Strasse 3..."
+msgstr "Straße 3..."
 
 #~ msgid "Partner"
 #~ msgstr "Partner"


### PR DESCRIPTION
Don't have the permissions to do it in Weblate myself, the links would be:

https://translation.odoo-community.org/translate/partner-contact-15-0/partner-contact-15-0-partner_address_street3/de/?checksum=3cda62386e1bd105

https://translation.odoo-community.org/translate/partner-contact-15-0/partner-contact-15-0-partner_address_street3/de/?checksum=1e878b4bc77bb9c7