### PR TITLE
[10.0]Correct the email validator version on requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ python-stdnum
 suds
 requests
 unicodecsv
-email_validator
+email_validator==1.2.1


### PR DESCRIPTION
Hi, 

The latest version of email-validator is not compatible with the V10, we added a specification of the version to use.

Regards,