### PR TITLE
[13.0][FIX] base_location: Force saving city_id

### DIFF
--- a/base_location/models/res_partner.py
+++ b/base_location/models/res_partner.py
@@ -1,6 +1,8 @@
 # Copyright 2016 Nicolas Bessi, Camptocamp SA
-# Copyright 2018 Tecnativa - Pedro M. Baeza
+# Copyright 2018-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from lxml import etree
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -83,3 +85,15 @@ class ResPartner(models.Model):
     @api.model
     def _address_fields(self):
         return super()._address_fields() + ["zip_id"]
+
+    @api.model
+    def _fields_view_get_address(self, arch):
+        """Force the save of the city_id field, as we set it through the onchanges
+        and we need consistency (there's a constraint for that).
+        """
+        arch = super()._fields_view_get_address(arch)
+        doc = etree.fromstring(arch)
+        for node in doc.xpath("//field[@name='city_id']"):
+            node.attrib["force_save"] = "1"
+        arch = etree.tostring(doc, encoding="unicode")
+        return arch


### PR DESCRIPTION
Steps to reproduce the problem:

- Create a parent contact with a full location with city.
- Create a child contact of type "Contact".
- Try to save.

You get the error "The city of partner ... differs from that in location ...".

That's because the field `city_id` is readonly when type = 'contact' and no force_save is indicated.

We therefore include the force_save flag for avoiding the problem.

@Tecnativa TT41570