### PR TITLE
[ADD] 14.0 partner_category_unique_per_organization

### DIFF
--- a/partner_category_unique_per_organization/__init__.py
+++ b/partner_category_unique_per_organization/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/partner_category_unique_per_organization/__manifest__.py
+++ b/partner_category_unique_per_organization/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Partner Contact Unique per Organization",
+    "version": "14.0.1.0.0",
+    "category": "Partner",
+    "website": "https://github.com/OCA/partner-contact",
+    "author": "Odoo Community Association (OCA), Akretion",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "base",
+    ],
+    "data": [
+        "views/res_partner_views.xml",
+    ],
+}

--- a/partner_category_unique_per_organization/i18n/fr.po
+++ b/partner_category_unique_per_organization/i18n/fr.po
@@ -1,0 +1,57 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* partner_category_unique_per_organization
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-07 13:52+0000\n"
+"PO-Revision-Date: 2023-02-07 14:54+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model,name:partner_category_unique_per_organization.model_res_partner
+msgid "Contact"
+msgstr "Contact"
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner__display_name
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner_category__display_name
+msgid "Display Name"
+msgstr "Nom d'affichage"
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner__id
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner_category__id
+msgid "ID"
+msgstr "ID"
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner____last_update
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner_category____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model,name:partner_category_unique_per_organization.model_res_partner_category
+msgid "Partner Tags"
+msgstr "Étiquettes de contact"
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner_category__unique_per_organization
+msgid "Unique Per Organization"
+msgstr "Unique par organisation"
+
+#. module: partner_category_unique_per_organization
+#: code:addons/partner_category_unique_per_organization/models/partner.py:0
+#, python-format
+msgid "You can only have 1 contact with the category {} for the organization {} ({})"
+msgstr "Vous ne pouvez avoir qu'1 contact avec la catégorie {} pour l'organisation {} ({})"

--- a/partner_category_unique_per_organization/i18n/partner_category_unique_per_organization.pot
+++ b/partner_category_unique_per_organization/i18n/partner_category_unique_per_organization.pot
@@ -1,0 +1,57 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* partner_category_unique_per_organization
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-07 13:52+0000\n"
+"PO-Revision-Date: 2023-02-07 13:52+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model,name:partner_category_unique_per_organization.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner__display_name
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner_category__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner__id
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner_category__id
+msgid "ID"
+msgstr ""
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner____last_update
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner_category____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model,name:partner_category_unique_per_organization.model_res_partner_category
+msgid "Partner Tags"
+msgstr ""
+
+#. module: partner_category_unique_per_organization
+#: model:ir.model.fields,field_description:partner_category_unique_per_organization.field_res_partner_category__unique_per_organization
+msgid "Unique Per Organization"
+msgstr ""
+
+#. module: partner_category_unique_per_organization
+#: code:addons/partner_category_unique_per_organization/models/partner.py:0
+#, python-format
+msgid ""
+"You can only have 1 contact with the category {} for the organization {} "
+"({})"
+msgstr ""

--- a/partner_category_unique_per_organization/models/__init__.py
+++ b/partner_category_unique_per_organization/models/__init__.py
@@ -1,0 +1,2 @@
+from . import partner_category
+from . import partner

--- a/partner_category_unique_per_organization/models/partner.py
+++ b/partner_category_unique_per_organization/models/partner.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Pierrick Brun <pierrick.brun@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.constrains("category_id")
+    def _check_category_unique_per_organization(self):
+        for record in self:
+            for categ in record.category_id.filtered("unique_per_organization"):
+                already_existing_contacts = (
+                    record.commercial_partner_id.child_ids.filtered(
+                        lambda c: c.id != record.id and categ.id in c.category_id.ids
+                    )
+                )
+                if already_existing_contacts:
+                    raise UserError(
+                        _(
+                            "You can only have 1 contact with the category"
+                            " {} in the organization {} ({})"
+                        ).format(
+                            categ.name,
+                            record.commercial_partner_id.name,
+                            already_existing_contacts[0].name,
+                        )
+                    )

--- a/partner_category_unique_per_organization/models/partner_category.py
+++ b/partner_category_unique_per_organization/models/partner_category.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Pierrick Brun <pierrick.brun@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResPartnerCategory(models.Model):
+    _inherit = "res.partner.category"
+
+    unique_per_organization = fields.Boolean(default=False)

--- a/partner_category_unique_per_organization/readme/DESCRIPTION.rst
+++ b/partner_category_unique_per_organization/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module allows to mark a partner category as "unique per organization".
+
+This means only 1 contact of this organization can have this category
+
+This is useful to make sure the contact for a specific communication is up to date.

--- a/partner_category_unique_per_organization/tests/__init__.py
+++ b/partner_category_unique_per_organization/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_partner_category_unique_per_organization

--- a/partner_category_unique_per_organization/tests/test_partner_category_unique_per_organization.py
+++ b/partner_category_unique_per_organization/tests/test_partner_category_unique_per_organization.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Pierrick Brun <pierrick.brun@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+from odoo.tests import common
+
+
+class TestPartnerCategorySecurity(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_category_main_contact = cls.env["res.partner.category"].create(
+            {
+                "name": "Main Contact",
+                "unique_per_organization": True,
+            }
+        )
+        cls.partner_category_secondary_contact = cls.env["res.partner.category"].create(
+            {
+                "name": "Secondary Contact",
+            }
+        )
+        cls.org = cls.env["res.partner"].create(
+            {
+                "name": "Org",
+                "is_company": True,
+            }
+        )
+        cls.partner_1 = cls.env["res.partner"].create(
+            {
+                "name": "Test 1",
+                "parent_id": cls.org.id,
+            }
+        )
+        cls.partner_2 = cls.env["res.partner"].create(
+            {
+                "name": "Test 2",
+                "parent_id": cls.org.id,
+            }
+        )
+
+    def test_partner_category_main(self):
+        self.partner_1.category_id |= self.partner_category_main_contact
+        with self.assertRaises(UserError):
+            self.partner_2.category_id |= self.partner_category_main_contact
+
+    def test_partner_category_secondary(self):
+        self.partner_1.category_id |= self.partner_category_secondary_contact
+        self.partner_2.category_id |= self.partner_category_secondary_contact

--- a/partner_category_unique_per_organization/views/res_partner_views.xml
+++ b/partner_category_unique_per_organization/views/res_partner_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_partner_category_form" model="ir.ui.view">
+        <field name="model">res.partner.category</field>
+        <field name="inherit_id" ref="base.view_partner_category_form" />
+        <field name="arch" type="xml">
+            <field name="parent_id" position="after">
+                <field name="unique_per_organization" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/partner_category_unique_per_organization/odoo/addons/partner_category_unique_per_organization
+++ b/setup/partner_category_unique_per_organization/odoo/addons/partner_category_unique_per_organization
@@ -1,0 +1,1 @@
+../../../../partner_category_unique_per_organization

--- a/setup/partner_category_unique_per_organization/setup.py
+++ b/setup/partner_category_unique_per_organization/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to mark a partner category as "unique per organization".

This means only 1 contact of this organization can have this category

This is useful to make sure the contact for a specific communication is up to date.