### PR TITLE
[REF] partner_second_lastname: clean firstname and lastname2 when partner is a company

### DIFF
--- a/partner_second_lastname/models/res_partner.py
+++ b/partner_second_lastname/models/res_partner.py
@@ -123,3 +123,12 @@ class ResPartner(models.Model):
             for partner in self:
                 if not partner.lastname2:
                     raise
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "is_company" in vals and vals["is_company"]:
+            for partner in self:
+                partner.lastname = partner.name
+                partner.firstname = None
+                partner.lastname2 = None
+        return res

--- a/partner_second_lastname/tests/test_name.py
+++ b/partner_second_lastname/tests/test_name.py
@@ -68,6 +68,26 @@ class CompanyCase(TransactionCase):
         """Create a company with whitespace everywhere in the name."""
         self.name = "  A  lot  öf    whitespace   "
 
+    def test_clean_fields_partner_company(self):
+        """Check that the fields firstname and lastname2 are
+        cleaned when partner is updated to company type
+        """
+        self.name = "Söme very lóng nâme"
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": "Company",
+                "lastname": "Duck",
+                "lastname2": "Inc",
+            }
+        )
+        self.assertEqual(partner.name, "Company Duck Inc")
+
+        partner.is_company = True
+        self.assertEqual(partner.name, "Company Duck Inc")
+        self.assertEqual(partner.lastname, "Company Duck Inc")
+        self.assertFalse(partner.firstname)
+        self.assertFalse(partner.lastname2)
+
 
 class PersonCase(TransactionCase):
     """Test ``res.partner`` when it is a person."""


### PR DESCRIPTION
When you create a partner type individual and update to company, the field `lastname` is filled-out with the full name but the fields `firstname` and lastname2 are not cleaned,
it's causing when you update the partner name with a different order, the full name is computed based on the
fields `firstname`, `lastname` and lastname2 and it's inconsistent.

This commit is cleaning the fields `firstname` and `lastname2` from the write method.

Fix https://github.com/OCA/partner-contact/issues/1465