### PR TITLE
[14.0][FIX] base_location: City/locations completion object display_name is not updated when changing the city name

### DIFF
--- a/base_location/models/res_city_zip.py
+++ b/base_location/models/res_city_zip.py
@@ -37,7 +37,15 @@ class ResCityZip(models.Model):
         )
     ]
 
-    @api.depends("name", "city_id", "city_id.state_id", "city_id.country_id")
+    @api.depends(
+        "name",
+        "city_id",
+        "city_id.name",
+        "city_id.state_id",
+        "city_id.state_id.name",
+        "city_id.country_id",
+        "city_id.country_id.name",
+    )
     def _compute_new_display_name(self):
         for rec in self:
             name = [rec.name, rec.city_id.name]

--- a/base_location/readme/CONTRIBUTORS.rst
+++ b/base_location/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Francesco Apruzzese <f.apruzzese@apuliasoftware.it>
 * Dave Lasley <dave@laslabs.com>
 * Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+* Eric Antones <eantones@nuobit.com>


### PR DESCRIPTION
After changing a city name (adding an accent for instance), the display_name of res.city.zip is not updated and the address on the company form keeps displaying the old wrong value.