### PR TITLE
[16.0][IMP] partner_identification: use odoo_test_helper in tests

### DIFF
--- a/partner_identification/tests/fake_models.py
+++ b/partner_identification/tests/fake_models.py
@@ -6,32 +6,10 @@
 from odoo import fields, models
 
 
-def setup_test_model(env, model_cls):
-    """Pass a test model class and initialize it.
-
-    Courtesy of SBidoul from https://github.com/OCA/mis-builder :)
-    """
-    model_cls._build_model(env.registry, env.cr)
-    env.registry.setup_models(env.cr)
-    env.registry.init_models(
-        env.cr, [model_cls._name], dict(env.context, update_custom_fields=True)
-    )
-
-
-def teardown_test_model(env, model_cls):
-    """Pass a test model class and deinitialize it.
-
-    Courtesy of SBidoul from https://github.com/OCA/mis-builder :)
-    """
-    if not getattr(model_cls, "_teardown_no_delete", False):
-        del env.registry.models[model_cls._name]
-    env.registry.setup_models(env.cr)
-
-
 class ResPartner(models.Model):
     _name = "res.partner"
     _inherit = "res.partner"
-    _teardown_no_delete = True
+    _description = "Fake Model"
 
     social_security = fields.Char(
         compute=lambda s: s._compute_identification("social_security", "SSN"),

--- a/partner_identification/tests/test_res_partner.py
+++ b/partner_identification/tests/test_res_partner.py
@@ -1,17 +1,23 @@
 # Copyright 2017 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo_test_helper import FakeModelLoader
+
 from odoo.exceptions import ValidationError
 from odoo.tests import common
-
-from .fake_models import ResPartner, setup_test_model, teardown_test_model
 
 
 class TestResPartner(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        setup_test_model(cls.env, ResPartner)
+
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .fake_models import ResPartner
+
+        cls.loader.update_registry((ResPartner,))
+
         bad_cat = cls.env["res.partner.id_category"].create(
             {"code": "another_code", "name": "another_name"}
         )
@@ -36,7 +42,7 @@ class TestResPartner(common.TransactionCase):
 
     @classmethod
     def tearDownClass(cls):
-        teardown_test_model(cls.env, ResPartner)
+        cls.loader.restore_registry()
         super().tearDownClass()
 
     def test_compute_identification(self):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo-test-helper


### PR DESCRIPTION
Make use of odoo-test-helper to correctly import fake model ResPartner in tests
See https://github.com/OCA/odoo-test-helper