### PR TITLE
[14.0] [IMP] partner_company_group: Change field position

### DIFF
--- a/partner_company_group/views/contact_view.xml
+++ b/partner_company_group/views/contact_view.xml
@@ -5,10 +5,11 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <field name="vat" position="before">
+            <field name="parent_id" position="after">
                 <field
                     name="company_group_id"
                     attrs="{'invisible': [('is_company','=', False)]}"
+                    placeholder="Company Group"
                 />
             </field>
         </field>


### PR DESCRIPTION
This PR changes the field position of the company_group_id to be after the name of the company.

I think that having the field between address fields and vat is a bit rare, i think the user would not expect to find it there. I propose to move it after the "name" when the parent_id field appears when the partner is not a company. So, if the partner is a company we show company_group there, and if not, original partner_id is shown. 

If you think we should move it to other place, please suggest it. 