### PR TITLE
[ADD] module partner_child_ids_confirm_remove

### DIFF
--- a/partner_child_ids_confirm_remove/README.rst
+++ b/partner_child_ids_confirm_remove/README.rst
@@ -1,0 +1,1 @@
+Add a confirmation dialog when you click 'Remove' on related contacts.

--- a/partner_child_ids_confirm_remove/__init__.py
+++ b/partner_child_ids_confirm_remove/__init__.py
@@ -1,0 +1,1 @@
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/partner_child_ids_confirm_remove/__manifest__.py
+++ b/partner_child_ids_confirm_remove/__manifest__.py
@@ -1,0 +1,21 @@
+#  Copyright 2022 Francesco Ballerini
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Confirm Removal of Related Partners",
+    "summary": """
+        Ask for confirmation before removal of a partner from child form view,
+    """,
+    "version": "14.0.0.0.1",
+    "depends": ["base", "web"],
+    "license": "AGPL-3",
+    "author": "Francesco Ballerini, Odoo Community Association (OCA)",
+    "support": "francescobl.lavoro@gmail.com",
+    "category": "Tools",
+    "development_status": "Beta",
+    "maintainers": ["Francesco Ballerini"],
+    "website": "https://github.com/OCA/partner-contact",
+    "data": ["views/assets.xml"],
+    "installable": True,
+    "application": True,
+    "auto_install": False,
+}

--- a/partner_child_ids_confirm_remove/readme/CONTRIBUTORS.rst
+++ b/partner_child_ids_confirm_remove/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Francesco Ballerini <francescobl.lavoro@gmail.com>

--- a/partner_child_ids_confirm_remove/readme/DESCRIPTION.rst
+++ b/partner_child_ids_confirm_remove/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Add a confirmation dialog when you click 'Remove' on related contacts.

--- a/partner_child_ids_confirm_remove/readme/USAGE.rst
+++ b/partner_child_ids_confirm_remove/readme/USAGE.rst
@@ -1,0 +1,2 @@
+Install the module will automatically enable the warning pop-up.
+Uninstall the module to disable the warning.

--- a/partner_child_ids_confirm_remove/static/src/js/view_dialogs.js
+++ b/partner_child_ids_confirm_remove/static/src/js/view_dialogs.js
@@ -1,0 +1,36 @@
+odoo.define("partner_child_ids_confirm_remove.partner_child_dialog_remove", function (
+    require
+) {
+    "use strict";
+
+    var core = require("web.core");
+    var Dialog = require("web.Dialog");
+    var ViewDialogs = require("web.view_dialogs");
+
+    var _t = core._t;
+
+    ViewDialogs.FormViewDialog.include({
+        _remove: function () {
+            if (this.res_model === "res.partner") {
+                var self = this;
+
+                var def = new Promise(function (resolve, reject) {
+                    var message = _t(
+                        "Confirming this will delete child contact from database. Do you still want to proceed?"
+                    );
+                    Dialog.confirm(self, message, {
+                        title: _t("Warning"),
+                        confirm_callback: function () {
+                            resolve(self.on_remove());
+                            self.close();
+                        },
+                        cancel_callback: reject,
+                    }).on("closed", self, reject);
+                });
+                return def;
+            }
+            // Classic workflow if model is not res.partner
+            return Promise.resolve(this.on_remove());
+        },
+    });
+});

--- a/partner_child_ids_confirm_remove/static/src/js/view_dialogs.js
+++ b/partner_child_ids_confirm_remove/static/src/js/view_dialogs.js
@@ -6,14 +6,14 @@ odoo.define("partner_child_ids_confirm_remove.partner_child_dialog_remove", func
     var core = require("web.core");
     var Dialog = require("web.Dialog");
     var ViewDialogs = require("web.view_dialogs");
-
     var _t = core._t;
 
     ViewDialogs.FormViewDialog.include({
         _remove: function () {
             if (this.res_model === "res.partner") {
                 var self = this;
-
+                var args = arguments;
+                var _super = this._super;
                 var def = new Promise(function (resolve, reject) {
                     var message = _t(
                         "Confirming this will delete child contact from database. Do you still want to proceed?"
@@ -21,16 +21,14 @@ odoo.define("partner_child_ids_confirm_remove.partner_child_dialog_remove", func
                     Dialog.confirm(self, message, {
                         title: _t("Warning"),
                         confirm_callback: function () {
-                            resolve(self.on_remove());
-                            self.close();
+                            resolve(_super.apply(self, args));
                         },
                         cancel_callback: reject,
                     }).on("closed", self, reject);
                 });
                 return def;
             }
-            // Classic workflow if model is not res.partner
-            return Promise.resolve(this.on_remove());
+            return this._super.apply(this, arguments);
         },
     });
 });

--- a/partner_child_ids_confirm_remove/views/assets.xml
+++ b/partner_child_ids_confirm_remove/views/assets.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="assets_backend"
+        inherit_id="web.assets_backend"
+        name="Partner Child Remove Dialog"
+    >
+        <xpath expr="//script[last()]" position="after">
+            <script
+                type="text/javascript"
+                src="/partner_child_ids_confirm_remove/static/src/js/view_dialogs.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/setup/partner_child_ids_confirm_remove/odoo/addons/partner_child_ids_confirm_remove
+++ b/setup/partner_child_ids_confirm_remove/odoo/addons/partner_child_ids_confirm_remove
@@ -1,0 +1,1 @@
+../../../../partner_child_ids_confirm_remove

--- a/setup/partner_child_ids_confirm_remove/setup.py
+++ b/setup/partner_child_ids_confirm_remove/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module add a simple confirm dialog before the child id partner deletion. 

Without an explicit warning on delete button it could be possible to click it without even notice that partner is going to be deleted. Saving the record would then lead to unintentional loss of data.