### PR TITLE
[16.0] [FIX] partner_identification partner form view: partner_id field on res.partner.id_number inside res.partner view

### DIFF
--- a/partner_identification/views/res_partner_view.xml
+++ b/partner_identification/views/res_partner_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <!-- Modification of Partner - Adding Tab for Idenification Numbers -->
+    <!-- Modification of Partner - Adding Tab for Identification Numbers -->
     <record model="ir.ui.view" id="view_partner_form">
         <field name="name">res.partner.form.id_number</field>
         <field name="model">res.partner</field>
@@ -14,8 +14,31 @@
                         colspan="4"
                         nolabel="1"
                         widget="one2many_list"
-                        context="{'default_partner_id': active_id}"
-                    />
+                    >
+                        <tree>
+                            <field name="category_id" />
+                            <field name="name" />
+                            <field name="partner_issued_id" />
+                            <field name="date_issued" />
+                            <field name="valid_from" />
+                            <field name="valid_until" />
+                            <field name="status" />
+                        </tree>
+                        <form>
+                            <group>
+                                <field name="category_id" />
+                                <field name="name" />
+                                <field name="partner_issued_id" />
+                                <field name="date_issued" />
+                                <field name="place_issuance" />
+                                <field name="valid_from" />
+                                <field name="valid_until" />
+                                <field name="status" />
+                            </group>
+                            <separator colspan="4" string="Notes" />
+                            <field name="comment" colspan="4" nolabel="1" />
+                        </form>
+                    </field>
                 </page>
             </page>
         </field>


### PR DESCRIPTION
`partner_id` field is currently visible in ID numbers form and tree view, even in the views of the o2m field id_numbers on res.partner. It is filled with active_id. 

The problem is that when creating a new partner from the interface and directly creating new ID numbers before saving (and thus creating the partner in DB), the active ID doesn't exist yet and the partner_id couldn't be filled. This is now necessary to save to create the partner before adding the ID numbers. 