### PR TITLE
[13.0][FIX]partner_exception: fix order, use odoo's value as fallback

### DIFF
--- a/partner_exception/models/res_partner.py
+++ b/partner_exception/models/res_partner.py
@@ -14,7 +14,7 @@ class ExceptionRule(models.Model):
 class ResPartner(models.Model):
     _inherit = ["res.partner", "base.exception"]
     _name = "res.partner"
-    _order = "main_exception_id asc, name desc"
+    _order = "main_exception_id asc, display_name"
 
     @api.model
     def _reverse_field(self):


### PR DESCRIPTION
cc @ForgeFlow