### PR TITLE
[14.0][IMP] partner_manual_rank: Set default value based on `res_partner_search_mode` context

### DIFF
--- a/partner_manual_rank/models/res_partner.py
+++ b/partner_manual_rank/models/res_partner.py
@@ -13,6 +13,7 @@ class ResPartner(models.Model):
         store=True,
         readonly=False,
         string="Is a Customer",
+        default=lambda self: self._default_is_customer(),
     )
     is_supplier = fields.Boolean(
         compute="_compute_is_supplier",
@@ -20,6 +21,7 @@ class ResPartner(models.Model):
         store=True,
         readonly=False,
         string="Is a Supplier",
+        default=lambda self: self._default_is_supplier(),
     )
 
     @api.depends("customer_rank")
@@ -49,3 +51,9 @@ class ResPartner(models.Model):
                 partners._increase_rank("supplier_rank")
             else:
                 partners.supplier_rank = 0
+
+    def _default_is_customer(self):
+        return self.env.context.get("res_partner_search_mode") == "customer"
+
+    def _default_is_supplier(self):
+        return self.env.context.get("res_partner_search_mode") == "supplier"


### PR DESCRIPTION
Use context set by Odoo in most of their views to pre-fill supplier/customer fields.
@MiquelRForgeFlow 