### PR TITLE
[14.0][IMP] partner_manual_rank 

### DIFF
--- a/partner_manual_rank/models/res_partner.py
+++ b/partner_manual_rank/models/res_partner.py
@@ -25,12 +25,14 @@ class ResPartner(models.Model):
     @api.depends("customer_rank")
     def _compute_is_customer(self):
         for partner in self:
-            partner.is_customer = bool(partner.customer_rank)
+            if not partner.is_customer:
+                partner.is_customer = bool(partner.customer_rank)
 
     @api.depends("supplier_rank")
     def _compute_is_supplier(self):
         for partner in self:
-            partner.is_supplier = bool(partner.supplier_rank)
+            if not partner.is_supplier:
+                partner.is_supplier = bool(partner.supplier_rank)
 
     def _inverse_is_customer(self):
         for partner in self:


### PR DESCRIPTION
Don't disable automatically customer or supplier flags if already settled. This behavior has no sense in a real case. Now if a customer or a supplier is settled, when computing it will leave at it is. This is causing problems because adding a delivery address for example clears the customer/supplier rank. It should be fixed in later versions but this is the easiest fix in 14.0. 

@ForgeFlow