### PR TITLE
[15.0][FIX] partner_company_default: multi company creation

### DIFF
--- a/partner_company_default/models/__init__.py
+++ b/partner_company_default/models/__init__.py
@@ -1,1 +1,2 @@
+from . import res_company
 from . import res_partner

--- a/partner_company_default/models/res_company.py
+++ b/partner_company_default/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Quartile Limited
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    @api.model
+    def create(self, vals):
+        self = self.with_context(creating_from_company=True)
+        return super().create(vals)

--- a/partner_company_default/models/res_partner.py
+++ b/partner_company_default/models/res_partner.py
@@ -1,10 +1,23 @@
 # Copyright 2023 Quartile Limited
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.tools import config
 
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    company_id = fields.Many2one(default=lambda self: self.env.company)
+    company_id = fields.Many2one(default=lambda self: self._default_company_id())
+
+    @api.model
+    def _default_company_id(self):
+        """Return False for other tests or if creating a company."""
+        context = self.env.context
+        if (
+            context.get("creating_from_company")
+            or config["test_enable"]
+            and not context.get("test_partner_company_default")
+        ):
+            return False
+        return self.env.company

--- a/partner_company_default/tests/__init__.py
+++ b/partner_company_default/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_partner_company_default

--- a/partner_company_default/tests/test_partner_company_default.py
+++ b/partner_company_default/tests/test_partner_company_default.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Quartile Limited
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import odoo.tests.common as common
+
+
+class TestPartnerCompanyDefault(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = cls.env.ref("base.user_admin")
+
+    def test_partner_company_default(self):
+        # Check company of newly created partner
+        partner = (
+            self.env["res.partner"]
+            .with_user(self.user.id)
+            .with_context(test_partner_company_default=True)
+            .create({"name": "Test Partner 1"})
+        )
+        self.assertEqual(partner.company_id, self.user.company_id)
+
+        # Check company of the partner of newly created company
+        company_fr = (
+            self.env["res.company"]
+            .with_user(self.user.id)
+            .create(
+                {
+                    "name": "French company",
+                    "currency_id": self.env.ref("base.EUR").id,
+                    "country_id": self.env.ref("base.fr").id,
+                }
+            )
+        )
+        self.assertFalse(company_fr.partner_id.company_id)
+
+        # Switch user's company and create a partner
+        self.user.company_ids = [(4, company_fr.id)]
+        self.user.company_id = company_fr.id
+        partner = (
+            self.env["res.partner"]
+            .with_user(self.user.id)
+            .with_context(test_partner_company_default=True)
+            .create({"name": "Test Partner 2"})
+        )
+        self.assertEqual(partner.company_id, company_fr)


### PR DESCRIPTION
Prior to this commit, the system would generate a partner before the creation of a new company and subsequently assign that partner to the company. As per `partner_company_default` module's behavior, the system would automatically assign the current company to the partner during creation, leading to a mismatch between the partner's company_id and its company.

In this Pull Request (PR), when a new company is created, the company_id of the associated partner will no longer be assigned during the partner's creation.
@qrtl