### PR TITLE
[16.0] add partner_no_address_type

### DIFF
--- a/partner_no_address_type/README.rst
+++ b/partner_no_address_type/README.rst
@@ -1,0 +1,1 @@
+Wait for the bot.

--- a/partner_no_address_type/__init__.py
+++ b/partner_no_address_type/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/partner_no_address_type/__manifest__.py
+++ b/partner_no_address_type/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Partner address no type",
+    "version": "16.0.1.0.0",
+    "summary": "The address type is not displayed if the partner doesn't have a defined name",
+    "author": "Camptocamp," "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Partner",
+    "website": "https://github.com/OCA/partner-contact",
+    "depends": ["base"],
+    "installable": True,
+    "auto_install": False,
+}

--- a/partner_no_address_type/models/__init__.py
+++ b/partner_no_address_type/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_report

--- a/partner_no_address_type/models/ir_actions_report.py
+++ b/partner_no_address_type/models/ir_actions_report.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def _get_rendering_context(self, report, docids, data):
+        """Set context key to not display the address type only on reports"""
+        res = super()._get_rendering_context(report, docids, data)
+        docs = res.get("docs")
+        if docs:
+            res["docs"] = docs.with_context(no_address_type=True)
+        return res

--- a/partner_no_address_type/readme/CONTRIBUTORS.rst
+++ b/partner_no_address_type/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>

--- a/partner_no_address_type/readme/DESCRIPTION.rst
+++ b/partner_no_address_type/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module changes the reports layout.
+The address type is not displayed anymore if the partner doesn't have a defined name.

--- a/partner_no_address_type/tests/__init__.py
+++ b/partner_no_address_type/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_partner

--- a/partner_no_address_type/tests/test_res_partner.py
+++ b/partner_no_address_type/tests/test_res_partner.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestBasePartnerTwoLine(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        partner_model = cls.env["res.partner"]
+        partner = partner_model.create(
+            {"name": "Test Company Name", "company_type": "company"}
+        )
+        cls.child_partner_name = partner_model.create(
+            {
+                "name": "Test Partner Name",
+                "type": "invoice",
+                "parent_id": partner.id,
+            }
+        )
+        cls.child_partner_no_name = partner_model.create(
+            {
+                "name": "",
+                "type": "invoice",
+                "parent_id": partner.id,
+            }
+        )
+
+    def test_get_name(self):
+        # Partner with name.
+        name = self.child_partner_name.with_context(no_address_type=True)._get_name()
+        self.assertEqual(name, "Test Company Name, Test Partner Name")
+        # Partner without a name.
+        name = self.child_partner_no_name.with_context(no_address_type=True)._get_name()
+        self.assertEqual(name, "Test Company Name")

--- a/setup/partner_no_address_type/odoo/addons/partner_no_address_type
+++ b/setup/partner_no_address_type/odoo/addons/partner_no_address_type
@@ -1,0 +1,1 @@
+../../../../partner_no_address_type

--- a/setup/partner_no_address_type/setup.py
+++ b/setup/partner_no_address_type/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
New module to remove the address type from the report address in case the partner name is not defined.

NOTE: This PR depends on this other one from Odoo:
- https://github.com/odoo/odoo/pull/126451

Do not merge until that one is merged as well.

