### PR TITLE
[16.0][UPD] partner_interest_group no_create on interest_group_ids

### DIFF
--- a/partner_interest_group/views/res_partner_view.xml
+++ b/partner_interest_group/views/res_partner_view.xml
@@ -9,7 +9,7 @@
                 <field
                     name="interest_group_ids"
                     widget="many2many_tags"
-                    options="{'no_create_edit': True}"
+                    options="{'no_create': True}"
                 />
             </field>
         </field>


### PR DESCRIPTION
no_create_edit only removes create and edit... when we want to avoid that a user creates an interest group, we should use no_create instead