### PR TITLE
[16.0][REM] partner_tier_validation: remove test-requirements.txt 

### DIFF
--- a/partner_tier_validation/test-requirements.txt
+++ b/partner_tier_validation/test-requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/OCA/partner-contact/pull/1339/head#subdirectory=setup/partner_stage


### PR DESCRIPTION
This PR is to remove unnecessary test-requirements.txt data that points to a closer PR
