### PR TITLE
[16.0] [FIX] base_location search by display_name as in older versions

### DIFF
--- a/base_location/migrations/16.0.1.0.1/post-migration.py
+++ b/base_location/migrations/16.0.1.0.1/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Recompute display name for entries inserted by SQL
+    env["res.city.zip"].search([])._compute_display_name()

--- a/base_location/models/res_city_zip.py
+++ b/base_location/models/res_city_zip.py
@@ -2,7 +2,7 @@
 # Copyright 2018 Aitor Bouzas <aitor.bouzas@adaptivecity.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResCityZip(models.Model):
@@ -11,7 +11,7 @@ class ResCityZip(models.Model):
     _name = "res.city.zip"
     _description = __doc__
     _order = "name asc"
-    _rec_names_search = ["name", "city_id", "state_id", "country_id"]
+    _rec_name = "display_name"
 
     name = fields.Char("ZIP", required=True)
     city_id = fields.Many2one(
@@ -24,6 +24,7 @@ class ResCityZip(models.Model):
     )
     state_id = fields.Many2one(related="city_id.state_id")
     country_id = fields.Many2one(related="city_id.country_id")
+    display_name = fields.Char(compute="_compute_display_name", store=True, index=True)
 
     _sql_constraints = [
         (
@@ -34,14 +35,13 @@ class ResCityZip(models.Model):
         )
     ]
 
-    def name_get(self):
+    @api.depends("name", "city_id", "city_id.state_id", "city_id.country_id")
+    def _compute_display_name(self):
         """Get the proper display name formatted as 'ZIP, name, state, country'."""
-        res = []
         for rec in self:
             name = [rec.name, rec.city_id.name]
             if rec.city_id.state_id:
                 name.append(rec.city_id.state_id.name)
             if rec.city_id.country_id:
                 name.append(rec.city_id.country_id.name)
-            res.append((rec.id, ", ".join(name)))
-        return res
+            rec.display_name = ", ".join(name)


### PR DESCRIPTION
I'd propose this PR to fix this issue: https://github.com/OCA/partner-contact/issues/1578

I restored the old behaviour searching by `display_name` instead of separated fields.