### PR TITLE
[16.0][FIX] base_partner_sequence: consider written values in _needs_ref check

### DIFF
--- a/base_partner_sequence/models/partner.py
+++ b/base_partner_sequence/models/partner.py
@@ -53,9 +53,17 @@ class ResPartner(models.Model):
                 _("Either field values or an id must be provided.")
             )
         # only assign a 'ref' to commercial partners
+        fields_for_check = ["is_company", "parent_id"]
+        # Copy original vals to prevent modifying them
+        if vals:
+            vals_for_check = vals.copy()
+        else:
+            vals_for_check = {}
         if self:
-            vals = {"is_company": self.is_company, "parent_id": self.parent_id}
-        return vals.get("is_company") or not vals.get("parent_id")
+            for field in fields_for_check:
+                if field not in vals_for_check:
+                    vals_for_check[field] = self[field]
+        return vals_for_check.get("is_company") or not vals_for_check.get("parent_id")
 
     @api.model
     def _commercial_fields(self):

--- a/base_partner_sequence/tests/test_base_partner_sequence.py
+++ b/base_partner_sequence/tests/test_base_partner_sequence.py
@@ -48,3 +48,20 @@ class TestBasePartnerSequence(common.TransactionCase):
         self.assertFalse(partners[0].ref)
         partners.write({})
         self.assertFalse(partners[0].ref == partners[1].ref)
+
+    def test_ref_change_convert_child_to_parent(self):
+        """Test that a ref is assigned to a child contact when it is
+        converted to a commercial partner."""
+        # Remove the ref from the parent so child does not have one initially
+        self.partner.write({"ref": False})
+        contact = self.res_partner.create(
+            {
+                "name": "contact1",
+                "email": "contact@contact.com",
+                "parent_id": self.partner.id,
+            }
+        )
+        self.assertEqual(self.partner.ref, contact.ref)
+        contact.write({"parent_id": False})
+        self.assertTrue(contact.ref)
+        self.assertFalse(contact.ref == self.partner.ref)


### PR DESCRIPTION
When evaluating the `_needs_ref` on a partner write, the method is not taking into consideration the values that are going to be written.

For example, imagine a scenario where you are converting a child partner into a parent partner by removing the parent_id. When the evaluation is done, it is done before the write, so the method considers that the partner is having a parent (although the write will remove it).

The fix is aimed at making sure the written values are considered in the evaluation. Due to having to modify the passed argument `vals` we need to make a copy in order to not mess up with the dict that is being passed from the write method.