### PR TITLE
[16.0][IMP] base_partner_sequence: add setting to mark reference as readonly

### DIFF
--- a/base_partner_sequence/__manifest__.py
+++ b/base_partner_sequence/__manifest__.py
@@ -16,9 +16,13 @@
     "development_status": "Production/Stable",
     "category": "Generic Modules/Base",
     "website": "https://github.com/OCA/partner-contact",
-    "depends": ["base"],
+    "depends": ["base", "base_setup"],
     "summary": "Sets customer's code from a sequence",
-    "data": ["data/partner_sequence.xml", "views/partner_view.xml"],
+    "data": [
+        "data/partner_sequence.xml",
+        "views/partner_view.xml",
+        "views/res_config_view.xml",
+    ],
     "installable": True,
     "license": "AGPL-3",
 }

--- a/base_partner_sequence/models/__init__.py
+++ b/base_partner_sequence/models/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import partner
+from . import res_company
+from . import res_config_settings

--- a/base_partner_sequence/models/partner.py
+++ b/base_partner_sequence/models/partner.py
@@ -14,12 +14,18 @@ class ResPartner(models.Model):
 
     ref_readonly = fields.Boolean(compute="_compute_ref_readonly")
 
-    @api.depends("company_id")
+    @api.depends("company_id", "is_company", "parent_id")
     @api.depends_context("company")
     def _compute_ref_readonly(self):
         for rec in self:
-            company = rec.company_id or self.env.company
-            rec.ref_readonly = company.partner_ref_readonly
+            ref_readonly = False
+            if not rec.is_company and rec.parent_id:
+                ref_readonly = True
+            elif (
+                rec.company_id and rec.company_id.partner_ref_readonly
+            ) or self.env.company.partner_ref_readonly:
+                ref_readonly = True
+            rec.ref_readonly = ref_readonly
 
     def _get_next_ref(self, vals=None):
         return self.env["ir.sequence"].next_by_code("res.partner")

--- a/base_partner_sequence/models/partner.py
+++ b/base_partner_sequence/models/partner.py
@@ -4,13 +4,22 @@
 # Copyright 2016 Camptocamp - Akim Juillerat (<https://www.camptocamp.com>).
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, exceptions, models
+from odoo import _, api, exceptions, fields, models
 
 
 class ResPartner(models.Model):
     """Assigns 'ref' from a sequence on creation and copying"""
 
     _inherit = "res.partner"
+
+    ref_readonly = fields.Boolean(compute="_compute_ref_readonly")
+
+    @api.depends("company_id")
+    @api.depends_context("company")
+    def _compute_ref_readonly(self):
+        for rec in self:
+            company = rec.company_id or self.env.company
+            rec.ref_readonly = company.partner_ref_readonly
 
     def _get_next_ref(self, vals=None):
         return self.env["ir.sequence"].next_by_code("res.partner")

--- a/base_partner_sequence/models/res_company.py
+++ b/base_partner_sequence/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright 2023 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    partner_ref_readonly = fields.Boolean(
+        string="Partner Reference Readonly",
+        help="If marked, the Reference in partners will not be editable.",
+    )

--- a/base_partner_sequence/models/res_config_settings.py
+++ b/base_partner_sequence/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2023 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    partner_ref_readonly = fields.Boolean(
+        related="company_id.partner_ref_readonly", readonly=False
+    )

--- a/base_partner_sequence/views/partner_view.xml
+++ b/base_partner_sequence/views/partner_view.xml
@@ -5,10 +5,13 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
+            <field name="ref" position="before">
+                <field name="ref_readonly" invisible="1" />
+            </field>
             <field name="ref" position="attributes">
                 <attribute
                     name="attrs"
-                >{'readonly': [('is_company', '=', False), ('parent_id', '!=', False)]}</attribute>
+                >{'readonly': ['|', ('ref_readonly', '=', True), '&amp;', ('is_company', '=', False), ('parent_id', '!=', False)]}</attribute>
             </field>
         </field>
     </record>

--- a/base_partner_sequence/views/partner_view.xml
+++ b/base_partner_sequence/views/partner_view.xml
@@ -11,7 +11,7 @@
             <field name="ref" position="attributes">
                 <attribute
                     name="attrs"
-                >{'readonly': ['|', ('ref_readonly', '=', True), '&amp;', ('is_company', '=', False), ('parent_id', '!=', False)]}</attribute>
+                >{'readonly': [('ref_readonly', '=', True)]}</attribute>
             </field>
         </field>
     </record>

--- a/base_partner_sequence/views/res_config_view.xml
+++ b/base_partner_sequence/views/res_config_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 ForgeFlow S.L.
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field
+            name="name"
+        >res.config.settings.view.form - base_partner_sequence</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="base.res_config_settings_view_form" />
+            <field name="arch" type="xml">
+                <xpath
+                expr="//div[@name='contacts_setting_container']"
+                position='inside'
+            >
+                    <div class="rcol-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="partner_ref_readonly" />
+                        </div>
+                        <div class="o_setting_right_pane" id="partner_ddghe_settings">
+                            <label for="partner_ref_readonly" />
+                            <div class="text-muted">
+                                Set Partner Reference field as read-only
+                            </div>
+                        </div>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </odoo>


### PR DESCRIPTION
New company setting to allow marking the reference as readonly. Useful if you want to rely 100% on the partner sequence, not allowing users to modify it.