### PR TITLE
[16.0] partner_industry_secondary: fix name_get w/o name

### DIFF
--- a/partner_industry_secondary/models/res_partner_industry.py
+++ b/partner_industry_secondary/models/res_partner_industry.py
@@ -28,8 +28,7 @@ class ResPartnerIndustry(models.Model):
             """Return the list [cat.name, cat.parent_id.name, ...]"""
             res = []
             while cat:
-                res.insert(0, cat.name)
-                cat = cat.parent_id
+                res.insert(0, cat.name or f"#{cat.id}")
             return res
 
         return [(cat.id, " / ".join(get_names(cat))) for cat in self]

--- a/partner_industry_secondary/models/res_partner_industry.py
+++ b/partner_industry_secondary/models/res_partner_industry.py
@@ -29,6 +29,7 @@ class ResPartnerIndustry(models.Model):
             res = []
             while cat:
                 res.insert(0, cat.name or f"#{cat.id}")
+                cat = cat.parent_id
             return res
 
         return [(cat.id, " / ".join(get_names(cat))) for cat in self]

--- a/partner_industry_secondary/tests/test_res_partner_industry.py
+++ b/partner_industry_secondary/tests/test_res_partner_industry.py
@@ -42,6 +42,10 @@ class TestResPartnerIndustry(common.TransactionCase):
 
     def test_04_name(self):
         self.assertEqual(self.industry_child.display_name, "Test / Test child")
+        self.industry_child.name = False
+        self.assertEqual(
+            self.industry_child.display_name, f"Test / #{self.industry_child.id}"
+        )
 
     def test_05_check_partner_industries(self):
         main = self.industry_main


### PR DESCRIPTION
Surprisingly you can have industry records w/o a name. The field is not required in odoo core so...
if by chance you get an empty name, name_get is broken w/o this fix.