### PR TITLE
[16.0][FIX] partner_company_default

### DIFF
--- a/partner_company_default/models/res_partner.py
+++ b/partner_company_default/models/res_partner.py
@@ -2,16 +2,22 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.tools import config
 
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    company_id = fields.Many2one(default=lambda self: self.env.company)
+    company_id = fields.Many2one(default=lambda self: self._default_company_id())
 
     @api.model
-    def create(self, vals):
-        # The context value is set in the create method of res.company
-        if self.env.context.get("creating_from_company"):
-            vals["company_id"] = False
-        return super(ResPartner, self).create(vals)
+    def _default_company_id(self):
+        """Return False for other tests or if creating a company."""
+        context = self.env.context
+        if (
+            context.get("creating_from_company")
+            or config["test_enable"]
+            and not context.get("test_partner_company_default")
+        ):
+            return False
+        return self.env.company

--- a/partner_company_default/tests/test_partner_company_default.py
+++ b/partner_company_default/tests/test_partner_company_default.py
@@ -15,6 +15,7 @@ class TestPartnerCompanyDefault(common.TransactionCase):
         partner = (
             self.env["res.partner"]
             .with_user(self.user.id)
+            .with_context(test_partner_company_default=True)
             .create({"name": "Test Partner 1"})
         )
         self.assertEqual(partner.company_id, self.user.company_id)
@@ -39,6 +40,7 @@ class TestPartnerCompanyDefault(common.TransactionCase):
         partner = (
             self.env["res.partner"]
             .with_user(self.user.id)
+            .with_context(test_partner_company_default=True)
             .create({"name": "Test Partner 2"})
         )
         self.assertEqual(partner.company_id, company_fr)


### PR DESCRIPTION
Before this PR, multi-record creation is not awared and not ways correct depending on when the create override in the stack is executed.

With current PR, this will be solved.

@qrtl