### PR TITLE
[16.0][FIX] partner_interest_group: solution to correlation problems with multi-company

### DIFF
--- a/partner_interest_group/__manifest__.py
+++ b/partner_interest_group/__manifest__.py
@@ -19,6 +19,7 @@
         "views/res_partner_interest_group_view.xml",
         "views/res_partner_view.xml",
         "security/ir.model.access.csv",
+        "security/interest_group_rules.xml",
     ],
     "demo": [],
     "qweb": [],

--- a/partner_interest_group/i18n/es.po
+++ b/partner_interest_group/i18n/es.po
@@ -6,20 +6,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2023-08-31 08:13+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
-"Language-Team: none\n"
-"Language: es\n"
+"POT-Creation-Date: 2024-01-30 14:22+0000\n"
+"PO-Revision-Date: 2024-01-30 14:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Plural-Forms: \n"
 
 #. module: partner_interest_group
 #: model:ir.model.fields,field_description:partner_interest_group.field_res_partner_interest_group__active
 msgid "Active"
 msgstr "Activo"
+
+#. module: partner_interest_group
+#: model:ir.model.fields,field_description:partner_interest_group.field_res_partner_interest_group__company_id
+msgid "Company"
+msgstr "Compañía"
 
 #. module: partner_interest_group
 #: model:ir.model,name:partner_interest_group.model_res_partner_interest_group
@@ -59,7 +63,7 @@ msgstr "ID (identificación)"
 #: model:ir.ui.menu,name:partner_interest_group.menu_res_partner_interest_group
 #: model_terms:ir.ui.view,arch_db:partner_interest_group.res_partner_interest_group_form_view
 msgid "Interest Group"
-msgstr "Grupo de interés"
+msgstr "Grupos de interés"
 
 #. module: partner_interest_group
 #: model:ir.model.fields,field_description:partner_interest_group.field_res_partner_interest_group____last_update

--- a/partner_interest_group/models/res_partner_interest_group.py
+++ b/partner_interest_group/models/res_partner_interest_group.py
@@ -8,3 +8,9 @@ class ResPartnerInterestGroup(models.Model):
     name = fields.Char(string="Interest Group")
     active = fields.Boolean(default=True)
     partner_id = fields.Many2many("res.partner")
+    company_id = fields.Many2one(
+        "res.company",
+        required=False,
+        domain=lambda self: [("id", "=", self.env.company.id)],
+        string="Company",
+    )

--- a/partner_interest_group/security/interest_group_rules.xml
+++ b/partner_interest_group/security/interest_group_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record model="ir.rule" id="partner_interest_group_rule">
+        <field name="name">Partner interest group: multi-company</field>
+        <field name="model_id" ref="model_res_partner_interest_group" />
+        <field name="global" eval="True" />
+        <field name="domain_force">
+            ['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]
+        </field>
+    </record>
+</odoo>

--- a/partner_interest_group/views/res_partner_interest_group_view.xml
+++ b/partner_interest_group/views/res_partner_interest_group_view.xml
@@ -11,6 +11,7 @@
         <field name="arch" type="xml">
             <tree editable="top">
                 <field name="name" />
+                <field name="company_id" />
             </tree>
         </field>
     </record>
@@ -21,6 +22,7 @@
             <form string="Interest Group">
                 <group>
                     <field name="name" />
+                    <field name="company_id" />
                 </group>
             </form>
         </field>


### PR DESCRIPTION
Solution to correlation problems with multi-company that makes every interest group appear in all companies. This makes all interest groups configurable, avoiding then to appear in other companies if you have one company selected. Besides, if you don't specify a company for the interest group, it will be available for all companies.

FL-556-2219