### PR TITLE
[16.0][FIX] partner_firstname,partner_second_lastname: Avoid name fields rewrite

### DIFF
--- a/partner_firstname/models/base_config_settings.py
+++ b/partner_firstname/models/base_config_settings.py
@@ -61,7 +61,10 @@ class ResConfigSettings(models.TransientModel):
         )
         partners = self._partners_for_recalculating()
         _logger.info("Recalculating names for %d partners.", len(partners))
-        partners._compute_name()
+        # Use add_to_compute instead of _compute_name to avoid triggering
+        # _inverse_name_after_cleaning_whitespace, which can
+        # modify a partner's firstname, lastname and lastname2
+        self.env.add_to_compute(self.env["res.partner"]._fields["name"], partners)
         self.partner_names_order_changed = False
         self.execute()
         _logger.info("%d partners updated.", len(partners))

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -99,8 +99,7 @@ class ResPartner(models.Model):
         ignored in :meth:`~.create` because it also copies explicitly firstname
         and lastname fields.
         """
-        if default is None:
-            default = {}
+        default = default or {}
         if not self.is_company:
             order = self._get_names_order()
             extra_default_values = self.get_extra_default_copy_values(order)

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 from .. import exceptions
 
@@ -26,32 +26,71 @@ class ResPartner(models.Model):
         readonly=False,
     )
 
+    @api.model
+    def name_fields_in_vals(self, vals):
+        """Method to check if any name fields are in `vals`."""
+        return vals.get("firstname") or vals.get("lastname")
+
     @api.model_create_multi
     def create(self, vals_list):
-        """Add inverted names at creation if unavailable."""
-        context = dict(self.env.context)
+        """Add inverted names at creation if unavailable. Also, remove the full name
+        from `vals` and context if the partner is an individual and is being created
+        with any name fields, as the name must be computed from the provided name parts;
+        otherwise, the name fields will be computed from the `name` again, when calling
+        its inverse method.
+
+        Note that, to avoid deleting the 'default_name' context for all partners when it's
+        not appropriate, we must call `create` for each partner individually with the correct
+        context.
+        """
+        created_partners = self.browse()
         for vals in vals_list:
-            name = vals.get("name", context.get("default_name"))
+            partner_context = dict(self.env.context)
+            if (
+                not vals.get("is_company")
+                and self.name_fields_in_vals(vals)
+                and "name" in vals
+            ):
+                del vals["name"]
+                partner_context.pop("default_name", None)
+            else:
+                name = vals.get("name", partner_context.get("default_name"))
+                if name is not None:
+                    # Calculate the split fields
+                    inverted = self._get_inverse_name(
+                        self._get_whitespace_cleaned_name(name),
+                        vals.get(
+                            "is_company", self.default_get(["is_company"])["is_company"]
+                        ),
+                    )
+                    for key, value in inverted.items():
+                        if not vals.get(key) or partner_context.get("copy"):
+                            vals[key] = value
 
-            if name is not None:
-                # Calculate the splitted fields
-                inverted = self._get_inverse_name(
-                    self._get_whitespace_cleaned_name(name),
-                    vals.get(
-                        "is_company", self.default_get(["is_company"])["is_company"]
-                    ),
-                )
-                for key, value in inverted.items():
-                    if not vals.get(key) or context.get("copy"):
-                        vals[key] = value
+                    # Remove the combined fields
+                    vals.pop("name", None)
+                    partner_context.pop("default_name", None)
+            # pylint: disable=W8121
+            created_partners |= super(
+                ResPartner, self.with_context(partner_context)
+            ).create(vals_list)
+        return created_partners
 
-                # Remove the combined fields
-                if "name" in vals:
-                    del vals["name"]
-                if "default_name" in context:
-                    del context["default_name"]
-        # pylint: disable=W8121
-        return super(ResPartner, self.with_context(context)).create(vals_list)
+    def get_extra_default_copy_values(self, order):
+        """Method to add '(copy)' suffix to lastname or firstname, depending on name
+        order configuration.
+        """
+        if order == "first_last":
+            return {
+                "lastname": _("%s (copy)", self.lastname)
+                if self.lastname
+                else _("(copy)")
+            }
+        return {
+            "firstname": _("%s (copy)", self.firstname)
+            if self.firstname
+            else _("(copy)")
+        }
 
     def copy(self, default=None):
         """Ensure partners are copied right.
@@ -60,6 +99,12 @@ class ResPartner(models.Model):
         ignored in :meth:`~.create` because it also copies explicitly firstname
         and lastname fields.
         """
+        if default is None:
+            default = {}
+        if not self.is_company:
+            order = self._get_names_order()
+            extra_default_values = self.get_extra_default_copy_values(order)
+            default.update(extra_default_values)
         return super(ResPartner, self.with_context(copy=True)).copy(default)
 
     @api.model

--- a/partner_firstname/tests/test_copy.py
+++ b/partner_firstname/tests/test_copy.py
@@ -11,6 +11,7 @@ class UserCase(TransactionCase, MailInstalled):
     def setUp(self):
         super(UserCase, self).setUp()
         self.create_original()
+        self.create_original_multinames()
 
     def create_original(self):
         self.original = self.env["res.users"].create(
@@ -20,6 +21,20 @@ class UserCase(TransactionCase, MailInstalled):
                 "name": "Firstname Lastname",
                 "login": "firstname.lastname",
             }
+        )
+
+    def create_original_multinames(self):
+        self.original_multinames = (
+            self.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "firstname": "Firstname1 Firstname2",
+                    "lastname": "Lastname1 Lastname2",
+                    "name": "Firstname1 Firstname2 Lastname1 Lastname2 (copy)",
+                    "login": "firstname.multi",
+                }
+            )
         )
 
     def tearDown(self):
@@ -50,3 +65,31 @@ class UserCase(TransactionCase, MailInstalled):
             }
         )
         self.compare(copy)
+
+    def test_copy_multiple_names(self):
+        copy = self.original_multinames.partner_id.copy()
+        self.assertRecordValues(
+            copy,
+            [
+                {
+                    "firstname": "Firstname1 Firstname2",
+                    "lastname": "Lastname1 Lastname2 (copy)",
+                    "name": "Firstname1 Firstname2 Lastname1 Lastname2 (copy)",
+                }
+            ],
+        )
+
+    def test_copy_multiple_names_company(self):
+        partner = self.original_multinames.partner_id
+        partner.is_company = True
+        copy = partner.copy()
+        self.assertRecordValues(
+            copy,
+            [
+                {
+                    "firstname": False,
+                    "lastname": "Firstname1 Firstname2 Lastname1 Lastname2 (copy)",
+                    "name": "Firstname1 Firstname2 Lastname1 Lastname2 (copy)",
+                }
+            ],
+        )

--- a/partner_second_lastname/models/res_partner.py
+++ b/partner_second_lastname/models/res_partner.py
@@ -3,7 +3,7 @@
 # Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 from odoo.addons.partner_firstname import exceptions
 
@@ -16,6 +16,21 @@ class ResPartner(models.Model):
     lastname2 = fields.Char(
         "Second last name",
     )
+
+    @api.model
+    def name_fields_in_vals(self, vals):
+        """Override to check if `lastname2` is in vals."""
+        return super().name_fields_in_vals(vals) or vals.get("lastname2")
+
+    def get_extra_default_copy_values(self, order):
+        """Override to add '(copy)' suffix to lastname2 instead of lastname."""
+        if order == "first_last":
+            return {
+                "lastname2": _("%s (copy)", self.lastname2)
+                if self.lastname2
+                else _("(copy)")
+            }
+        return super().get_extra_default_copy_values(order)
 
     @api.model
     def _get_computed_name(self, lastname, firstname, lastname2=None):

--- a/partner_second_lastname/tests/__init__.py
+++ b/partner_second_lastname/tests/__init__.py
@@ -2,4 +2,5 @@
 
 from . import test_name
 from . import test_config
+from . import test_multiple_names
 from odoo.addons.partner_firstname.tests import test_empty

--- a/partner_second_lastname/tests/test_multiple_names.py
+++ b/partner_second_lastname/tests/test_multiple_names.py
@@ -1,0 +1,41 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestMultipleNames(TransactionCase):
+    def assert_name(self, config_settings, partner, vals, order, expected_name):
+        config_settings.partner_names_order = order
+        config_settings.action_recalculate_partners_name()
+        vals["name"] = expected_name
+        self.assertRecordValues(partner, [vals])
+        copy_partner = partner.copy()
+        self.assertEqual(copy_partner.name, f"{partner.name} (copy)")
+
+    def test_recalculate_names(self):
+        firstname = "Xavier De Jesús"
+        lastname = "Payen"
+        lastname2 = "Sandoval"
+        vals = {"firstname": firstname, "lastname": lastname, "lastname2": lastname2}
+        partner = self.env["res.partner"].create(vals)
+        config_settings = self.env["res.config.settings"].create({})
+
+        self.assert_name(
+            config_settings,
+            partner,
+            vals,
+            "first_last",
+            f"{firstname} {lastname} {lastname2}",
+        )
+        self.assert_name(
+            config_settings,
+            partner,
+            vals,
+            "last_first",
+            f"{lastname} {lastname2} {firstname}",
+        )
+        self.assert_name(
+            config_settings,
+            partner,
+            vals,
+            "last_first_comma",
+            f"{lastname} {lastname2}, {firstname}",
+        )


### PR DESCRIPTION
Previously, creating a non-company partner by passing the `name` field
would trigger the `_inverse_name_after_cleaning_whitespace` which, for
values of `firstname`, `lastname` and `lastname2` with multiple words,
would result in most of those words being set to the `lastname2`, even if the
correct values were explicitly passed to the `create` method. For example,
duplicating a non-company partner with the following field values:
    
firstname = Francisco Javier
lastname = Garcia
lastname2 = Cabeza de Vaca
    
Would result in a partner with these values:
    
firstname = Francisco
lastname = Javier
lastname2 = Garcia Cabeza de Vaca (copy)

because the full name (Francisco Javier Garcia Cabeza de Vaca) is passed to the `create` method, and the `_inverse_name_after_cleaning_whitespace` method is triggered afterwards.
    
This PR solves the issue and also prevents the `_inverse_name_after_cleaning_whitespace`
method from triggering when recomputing names from settings, which causes the same
effect described above.

This PR is a forward port of the following 14.0 PRs:

* https://github.com/OCA/partner-contact/pull/1126
* https://github.com/OCA/partner-contact/pull/1276