### PR TITLE
[16.0] [IMP] partner_industry_secondary: add unaccent=False on parent_path field

### DIFF
--- a/partner_industry_secondary/models/res_partner_industry.py
+++ b/partner_industry_secondary/models/res_partner_industry.py
@@ -21,7 +21,7 @@ class ResPartnerIndustry(models.Model):
     child_ids = fields.One2many(
         comodel_name="res.partner.industry", inverse_name="parent_id", string="Children"
     )
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
 
     def name_get(self):
         def get_names(cat):


### PR DESCRIPTION
As asked by Odoo in a warning in `_check_parent_path` method.

See https://github.com/odoo/odoo/blob/16.0/odoo/models.py#L2615