### PR TITLE
[FIX] partner_vat_unique: VAT uniqueness constraint for XMLRPC contact creation

### DIFF
--- a/partner_vat_unique/README.rst
+++ b/partner_vat_unique/README.rst
@@ -45,7 +45,6 @@ isn't any duplicated VAT before installation.
 Known issues / Roadmap
 ======================
 
-* Creation of the partner from XML-RPC.
 * Partner creation by importing a CSV file, in those cases you miss the notice.
 
 Bug Tracker
@@ -72,6 +71,7 @@ Contributors
 * Ismael Calvo <ismael.calvo@es.gt.com>
 * Michael Michot <michotm@gmail.com>
 * Koen Loodts <koen.loodts@dynapps.be>
+* Randall Castro <randall@vauxoo.com>
 
 * `Tecnativa <https://www.tecnativa.com>`__:
     * Vicent Cubells <vicent.cubells@tecnativa.com>

--- a/partner_vat_unique/models/res_partner.py
+++ b/partner_vat_unique/models/res_partner.py
@@ -26,3 +26,11 @@ class ResPartner(models.Model):
                 raise ValidationError(
                     _("The VAT %s already exists in another partner.") % record.vat
                 )
+
+    @api.model
+    def create(self, vals_list):
+        new_records = super(ResPartner, self).create(vals_list)
+        if "xmlrpc" in self.env.context:
+            for record in new_records:
+                record._check_vat_unique()
+        return new_records

--- a/partner_vat_unique/tests/test_vat_unique.py
+++ b/partner_vat_unique/tests/test_vat_unique.py
@@ -1,8 +1,12 @@
 # Copyright 2017 Grant Thornton Spain - Ismael Calvo <ismael.calvo@es.gt.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from unittest.mock import patch
+
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
+
+from odoo.addons.partner_vat_unique.models.res_partner import ResPartner
 
 
 class TestVatUnique(TransactionCase):
@@ -16,10 +20,23 @@ class TestVatUnique(TransactionCase):
 
     def test_duplicated_vat_creation(self):
         with self.assertRaises(ValidationError):
-            self.partner_model.with_context(test_vat=True).create(
+            self.partner_model.with_context(test_vat=True, xmlrpc=True).create(
                 {"name": "Second partner", "vat": "ESA12345674"}
             )
 
     def test_duplicate_partner(self):
         partner_copied = self.partner.copy()
         self.assertFalse(partner_copied.vat)
+
+    @patch.object(ResPartner, "_check_vat_unique")
+    def test_check_vat_unique_called_with_xmlrpc(self, _check_vat_unique_mock):
+        self.partner_model.with_context(xmlrpc=True).create(
+            {"name": "Third partner", "vat": "BE0477472701"}
+        )
+        self.partner_model.with_context(xmlrpc=True).create(
+            {"name": "Multiple partner 01", "vat": "BE0477472722"}
+        )
+        self.partner_model.with_context(xmlrpc=True).create(
+            {"name": "Third partner copy", "vat": "BE0477472701"}
+        )
+        _check_vat_unique_mock.assert_called_once()


### PR DESCRIPTION
Modifies the `res.partner` model in Odoo to apply the VAT uniqueness constraint specifically when a contact is created via XMLRPC.