### PR TITLE
[16.0][FIX] partner_firstname: fix installation w/ missing names

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -259,7 +259,9 @@ class ResPartner(models.Model):
         correctly into the database. This can be called later too if needed.
         """
         # Find records with empty firstname and lastname
-        records = self.search([("firstname", "=", False), ("lastname", "=", False)])
+        records = self.search(
+            [("firstname", "=", False), ("lastname", "=", False), ("name", "!=", "")]
+        )
 
         # Force calculations there
         records._inverse_name()

--- a/partner_firstname/tests/test_create.py
+++ b/partner_firstname/tests/test_create.py
@@ -33,6 +33,18 @@ class PersonCase(TransactionCase):
 
         super(PersonCase, self).tearDown()
 
+    def test_module_installation(self):
+        model = self.env[self.model].with_context(**self.context)
+        unnamed = model.create(
+            {"name": "", "email": "anon@ymous.org", "type": "invoice"}
+        )
+        named = model.create(
+            {"name": "firstname lastname", "email": "firstname@lastname.org"}
+        )
+        model._install_partner_firstname()
+        self.assertEqual(unnamed.name, "")
+        self.assertEqual((named.firstname, named.lastname), ("firstname", "lastname"))
+
     def test_no_name(self):
         """Name is calculated."""
         del self.values["name"]


### PR DESCRIPTION
This change fixes this bug: https://github.com/OCA/partner-contact/issues/1677

With that the module can be installed as only partners with names will be processed