### PR TITLE
[IMP] partner_(ref,vat)_unique: enable name search by the VAT Identification Number and Reference

### DIFF
--- a/partner_ref_unique/__manifest__.py
+++ b/partner_ref_unique/__manifest__.py
@@ -11,6 +11,7 @@
     "website": "https://github.com/OCA/partner-contact",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
+    "maintainers": ["luisg123v"],
     "application": False,
     "installable": True,
     "depends": ["base"],

--- a/partner_ref_unique/models/res_partner.py
+++ b/partner_ref_unique/models/res_partner.py
@@ -4,6 +4,7 @@
 
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+from odoo.osv import expression
 
 
 class ResPartner(models.Model):
@@ -29,3 +30,12 @@ class ResPartner(models.Model):
                         _("This reference is equal to partner '%s'")
                         % other[0].display_name
                     )
+
+    @api.model
+    def _name_search(self, name="", args=None, operator="ilike", limit=100):
+        """Allow searching by ref by default."""
+        if name and operator in {"=", "ilike", "=ilike", "like", "=like"}:
+            args = expression.OR([[("ref", operator, name)], args])
+        return super()._name_search(
+            name=name, args=args, operator=operator, limit=limit
+        )

--- a/partner_ref_unique/tests/test_res_partner_ref.py
+++ b/partner_ref_unique/tests/test_res_partner_ref.py
@@ -4,10 +4,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import ValidationError
-from odoo.tests import common
+from odoo.tests import TransactionCase
 
 
-class TestResPartnerRefUnique(common.SavepointCase):
+class TestResPartnerRefUnique(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestResPartnerRefUnique, cls).setUpClass()

--- a/partner_ref_unique/tests/test_res_partner_ref.py
+++ b/partner_ref_unique/tests/test_res_partner_ref.py
@@ -105,3 +105,17 @@ class TestResPartnerRefUnique(common.SavepointCase):
         )
         # this shouldn't raise error
         wizard.action_merge()
+
+    def test_name_search(self):
+        self.company.partner_ref_unique = "all"
+        partner = self.partner1
+        partner.ref = "ref"
+        result = partner.name_search(name=partner.ref)
+        self.assertEqual(result[0][0], partner.id)
+
+    def test_name_search_args_none(self):
+        self.company.partner_ref_unique = "all"
+        partner = self.partner1
+        partner.ref = "ref"
+        result = partner.name_search(name=partner.ref, args=None)
+        self.assertEqual(result[0][0], partner.id)

--- a/partner_vat_unique/__manifest__.py
+++ b/partner_vat_unique/__manifest__.py
@@ -9,6 +9,7 @@
     "website": "https://github.com/OCA/partner-contact",
     "author": "Grant Thornton S.L.P, Odoo Community Association (OCA)",
     "license": "AGPL-3",
+    "maintainers": ["luisg123v"],
     "application": True,
     "installable": True,
     "depends": ["base"],

--- a/partner_vat_unique/models/res_partner.py
+++ b/partner_vat_unique/models/res_partner.py
@@ -4,6 +4,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.osv import expression
 from odoo.tools import config
 
 
@@ -26,3 +27,12 @@ class ResPartner(models.Model):
                 raise ValidationError(
                     _("The VAT %s already exists in another partner.") % record.vat
                 )
+
+    @api.model
+    def _name_search(self, name="", args=None, operator="ilike", limit=100):
+        """Allow searching by vat by default."""
+        if name and operator in {"=", "ilike", "=ilike", "like", "=like"}:
+            args = expression.OR([[("vat", operator, name)], args])
+        return super()._name_search(
+            name=name, args=args, operator=operator, limit=limit
+        )

--- a/partner_vat_unique/tests/test_vat_unique.py
+++ b/partner_vat_unique/tests/test_vat_unique.py
@@ -33,3 +33,13 @@ class TestVatUnique(TransactionCase):
     def test_duplicate_partner(self):
         partner_copied = self.partner.copy()
         self.assertFalse(partner_copied.vat)
+
+    def test_name_search(self):
+        partner = self.partner
+        result = partner.name_search(name=partner.vat)
+        self.assertEqual(result[0][0], partner.id)
+
+    def test_name_search_args_none(self):
+        partner = self.partner
+        result = partner.name_search(name=partner.vat, args=None)
+        self.assertEqual(result[0][0], partner.id)


### PR DESCRIPTION
The search functionality has been improved to include the VAT
Identification Number and Partner Reference. This enhancement
is achieved by inheriting the _name_search method to include
the VAT Identification Number and Partner Reference in the
search domain.

Additionally, tests have been added for this new inheritance.