### PR TITLE
[16.0][IMP] partner_contact_address_default: set default contact

### DIFF
--- a/partner_contact_address_default/README.rst
+++ b/partner_contact_address_default/README.rst
@@ -29,7 +29,7 @@ Partner Contact address default
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module extends the functionality of base partner module to allow to set a
-default delivery and invoice address for contacts.
+default delivery and invoice address and a default contact for contacts.
 
 **Table of contents**
 
@@ -40,7 +40,7 @@ Usage
 =====
 
 #. Go to *Contacts*.
-#. Select default delivery address or invoice address for partner.
+#. Select default delivery address, invoice address or contact for partner.
 
 Bug Tracker
 ===========
@@ -75,6 +75,10 @@ Contributors
 * `Studio73 <https://www.studio73.es>`_:
 
   * Carlos Reyes
+
+* `ForgeFlow <https://www.forgeflow.com>`_:
+
+  * Laura Cazorla
 
 Maintainers
 ~~~~~~~~~~~

--- a/partner_contact_address_default/__manifest__.py
+++ b/partner_contact_address_default/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Partner Contact address default",
-    "summary": "Set a default delivery and invoice address for contacts",
+    "summary": "Set a default delivery address, invoice address and contact for contacts",
     "version": "16.0.1.0.0",
     "development_status": "Beta",
     "category": "Generic Modules/Base",

--- a/partner_contact_address_default/i18n/es.po
+++ b/partner_contact_address_default/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-11 10:32+0000\n"
-"PO-Revision-Date: 2023-01-11 10:32+0000\n"
+"POT-Creation-Date: 2024-03-11 07:35+0000\n"
+"PO-Revision-Date: 2024-03-11 07:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: \n"
@@ -20,6 +20,12 @@ msgstr ""
 #: model:ir.model,name:partner_contact_address_default.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
+
+#. module: partner_contact_address_default
+#: model:ir.model.fields,field_description:partner_contact_address_default.field_res_partner__partner_contact_id
+#: model:ir.model.fields,field_description:partner_contact_address_default.field_res_users__partner_contact_id
+msgid "Default contact"
+msgstr "Contacto predeterminado"
 
 #. module: partner_contact_address_default
 #: model_terms:ir.ui.view,arch_db:partner_contact_address_default.view_partner_form
@@ -45,5 +51,5 @@ msgstr "Dirección de envío"
 
 #. module: partner_contact_address_default
 #: model_terms:ir.ui.view,arch_db:partner_contact_address_default.view_partner_form
-msgid "You can force and delivery and invoice address for this contacts."
-msgstr "Puede forzar las dirección de envío y facturación para estos contactos"
+msgid "You can force contact, delivery and invoice address for this contacts."
+msgstr "Puede forzar el contacto y las direcciones de envío y facturación para estos contactos."

--- a/partner_contact_address_default/i18n/partner_contact_address_default.pot
+++ b/partner_contact_address_default/i18n/partner_contact_address_default.pot
@@ -19,6 +19,12 @@ msgid "Contact"
 msgstr ""
 
 #. module: partner_contact_address_default
+#: model:ir.model.fields,field_description:partner_contact_address_default.field_res_partner__partner_contact_id
+#: model:ir.model.fields,field_description:partner_contact_address_default.field_res_users__partner_contact_id
+msgid "Default contact"
+msgstr ""
+
+#. module: partner_contact_address_default
 #: model_terms:ir.ui.view,arch_db:partner_contact_address_default.view_partner_form
 msgid "Force addresses"
 msgstr ""
@@ -42,5 +48,5 @@ msgstr ""
 
 #. module: partner_contact_address_default
 #: model_terms:ir.ui.view,arch_db:partner_contact_address_default.view_partner_form
-msgid "You can force and delivery and invoice address for this contacts."
+msgid "You can force contact, delivery and invoice address for this contacts."
 msgstr ""

--- a/partner_contact_address_default/models/res_partner.py
+++ b/partner_contact_address_default/models/res_partner.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Tecnativa - Carlos Dauden
 # Copyright 2020 Tecnativa - Sergio Teruel
+# Copyright 2024 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
@@ -15,14 +16,18 @@ class ResPartner(models.Model):
         comodel_name="res.partner",
         string="Invoice address",
     )
+    partner_contact_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Default contact",
+    )
 
     def get_address_default_type(self):
         """This will be the extension method for other contact types"""
-        return ["delivery", "invoice"]
+        return ["delivery", "invoice", "contact"]
 
     def address_get(self, adr_pref=None):
-        """Force the delivery or invoice addresses. It will try to default
-        to the one set in the commercial partner if any"""
+        """Force the contact, delivery or invoice addresses. It will
+        try to default to the one set in the commercial partner if any"""
         res = super().address_get(adr_pref)
         adr_pref = adr_pref or []
         default_address_type_list = {
@@ -46,5 +51,8 @@ class ResPartner(models.Model):
             )
             self.search([("partner_invoice_id", "in", self.ids)]).write(
                 {"partner_invoice_id": False}
+            )
+            self.search([("partner_contact_id", "in", self.ids)]).write(
+                {"partner_contact_id": False}
             )
         return super().write(vals)

--- a/partner_contact_address_default/readme/CONTRIBUTORS.rst
+++ b/partner_contact_address_default/readme/CONTRIBUTORS.rst
@@ -10,3 +10,7 @@
 * `Studio73 <https://www.studio73.es>`_:
 
   * Carlos Reyes
+
+* `ForgeFlow <https://www.forgeflow.com>`_:
+
+  * Laura Cazorla

--- a/partner_contact_address_default/readme/DESCRIPTION.rst
+++ b/partner_contact_address_default/readme/DESCRIPTION.rst
@@ -1,2 +1,2 @@
 This module extends the functionality of base partner module to allow to set a
-default delivery and invoice address for contacts.
+default delivery and invoice address and a default contact for contacts.

--- a/partner_contact_address_default/readme/USAGE.rst
+++ b/partner_contact_address_default/readme/USAGE.rst
@@ -1,2 +1,2 @@
 #. Go to *Contacts*.
-#. Select default delivery address or invoice address for partner.
+#. Select default delivery address, invoice address or contact for partner.

--- a/partner_contact_address_default/static/description/index.html
+++ b/partner_contact_address_default/static/description/index.html
@@ -371,7 +371,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/partner-contact/tree/16.0/partner_contact_address_default"><img alt="OCA/partner-contact" src="https://img.shields.io/badge/github-OCA%2Fpartner--contact-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/partner-contact-16-0/partner-contact-16-0-partner_contact_address_default"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/partner-contact&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module extends the functionality of base partner module to allow to set a
-default delivery and invoice address for contacts.</p>
+default delivery and invoice address and a default contact for contacts.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -389,7 +389,7 @@ default delivery and invoice address for contacts.</p>
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
 <ol class="arabic simple">
 <li>Go to <em>Contacts</em>.</li>
-<li>Select default delivery address or invoice address for partner.</li>
+<li>Select default delivery address, invoice address or contact for partner.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -422,6 +422,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.studio73.es">Studio73</a>:<ul>
 <li>Carlos Reyes</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.forgeflow.com">ForgeFlow</a>:<ul>
+<li>Laura Cazorla</li>
 </ul>
 </li>
 </ul>

--- a/partner_contact_address_default/tests/test_partner_contact_address_default.py
+++ b/partner_contact_address_default/tests/test_partner_contact_address_default.py
@@ -27,27 +27,39 @@ class TestPartnerContactAddressDefault(common.TransactionCase):
         cls.partner_child_invoice = cls.Partner.create(
             {"name": "Child invoice", "type": "invoice", "parent_id": cls.partner.id}
         )
+        cls.partner_child_contact = cls.Partner.create(
+            {"name": "Child contact", "type": "contact", "parent_id": cls.partner.id}
+        )
 
     def test_contact_address_default(self):
         self.partner.partner_delivery_id = self.partner
         self.partner.partner_invoice_id = self.partner
-        res = self.partner.address_get(["delivery", "invoice"])
+        self.partner.partner_contact_id = self.partner
+        res = self.partner.address_get(["delivery", "invoice", "contact"])
         self.assertEqual(res["delivery"], self.partner.id)
         self.assertEqual(res["invoice"], self.partner.id)
+        self.assertEqual(res["contact"], self.partner.id)
 
         self.partner_child_delivery2.partner_delivery_id = self.partner_child_delivery2
         self.partner_child_delivery2.partner_invoice_id = self.partner_child_delivery2
-        res = self.partner_child_delivery2.address_get(["delivery", "invoice"])
+        self.partner_child_delivery2.partner_contact_id = self.partner_child_delivery2
+        res = self.partner_child_delivery2.address_get(
+            ["delivery", "invoice", "contact"]
+        )
         self.assertEqual(res["delivery"], self.partner_child_delivery2.id)
         self.assertEqual(res["invoice"], self.partner_child_delivery2.id)
+        self.assertEqual(res["contact"], self.partner_child_delivery2.id)
 
     def test_contact_address_archived(self):
         self.partner.partner_delivery_id = self.partner_child_delivery2
         self.partner.partner_invoice_id = self.partner_child_invoice
+        self.partner.partner_contact_id = self.partner_child_contact
+        self.partner_child_contact.write({"active": False})
         self.partner_child_invoice.write({"active": False})
         self.partner_child_delivery2.write({"active": False})
-        res = self.partner.address_get(["delivery", "invoice"])
+        res = self.partner.address_get(["delivery", "invoice", "contact"])
         # As partner_child_delivery2 is archived, even though it is set as
         # partner_delivery_id it should fall back to partner_child_delivery1 here:
         self.assertEqual(res["delivery"], self.partner_child_delivery1.id)
         self.assertEqual(res["invoice"], self.partner.id)
+        self.assertEqual(res["contact"], self.partner.id)

--- a/partner_contact_address_default/views/res_partner_views.xml
+++ b/partner_contact_address_default/views/res_partner_views.xml
@@ -12,11 +12,16 @@
                             domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'delivery')]"
                             widget="selection"
                         />
-                    </group>
-                    <group>
                         <field
                             name="partner_invoice_id"
                             domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'invoice')]"
+                            widget="selection"
+                        />
+                    </group>
+                    <group>
+                        <field
+                            name="partner_contact_id"
+                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'contact')]"
                             widget="selection"
                         />
                     </group>
@@ -31,7 +36,7 @@
                         <field name="commercial_partner_id" invisible="1" />
                         <div class="oe_grey">
                             <div
-                            >You can force and delivery and invoice address for this contacts.</div>
+                            >You can force contact, delivery and invoice address for this contacts.</div>
                             <div
                             >If you keep empty this fields the Odoo's behavior will be normal</div>
                         </div>
@@ -46,6 +51,12 @@
                         <field
                             name="partner_invoice_id"
                             domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'invoice')]"
+                        />
+                    </group>
+                    <group colspan="4">
+                        <field
+                            name="partner_contact_id"
+                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'contact')]"
                         />
                     </group>
                 </group>


### PR DESCRIPTION
Implement the possibility to add a default contact along with the delivery and invoice addresses for partners.