### PR TITLE
Revert "[IMP] partner_(ref,vat)_unique: enable name search by the VAT Identification Number and Reference"

### DIFF
--- a/partner_ref_unique/models/res_partner.py
+++ b/partner_ref_unique/models/res_partner.py
@@ -4,7 +4,6 @@
 
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
-from odoo.osv import expression
 
 
 class ResPartner(models.Model):
@@ -30,12 +29,3 @@ class ResPartner(models.Model):
                         _("This reference is equal to partner '%s'")
                         % other[0].display_name
                     )
-
-    @api.model
-    def _name_search(self, name="", args=None, operator="ilike", limit=100):
-        """Allow searching by ref by default."""
-        if name and operator in {"=", "ilike", "=ilike", "like", "=like"}:
-            args = expression.OR([[("ref", operator, name)], args])
-        return super()._name_search(
-            name=name, args=args, operator=operator, limit=limit
-        )

--- a/partner_ref_unique/tests/test_res_partner_ref.py
+++ b/partner_ref_unique/tests/test_res_partner_ref.py
@@ -105,17 +105,3 @@ class TestResPartnerRefUnique(TransactionCase):
         )
         # this shouldn't raise error
         wizard.action_merge()
-
-    def test_name_search(self):
-        self.company.partner_ref_unique = "all"
-        partner = self.partner1
-        partner.ref = "ref"
-        result = partner.name_search(name=partner.ref)
-        self.assertEqual(result[0][0], partner.id)
-
-    def test_name_search_args_none(self):
-        self.company.partner_ref_unique = "all"
-        partner = self.partner1
-        partner.ref = "ref"
-        result = partner.name_search(name=partner.ref, args=None)
-        self.assertEqual(result[0][0], partner.id)

--- a/partner_vat_unique/models/res_partner.py
+++ b/partner_vat_unique/models/res_partner.py
@@ -4,7 +4,6 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.osv import expression
 from odoo.tools import config
 
 
@@ -27,12 +26,3 @@ class ResPartner(models.Model):
                 raise ValidationError(
                     _("The VAT %s already exists in another partner.") % record.vat
                 )
-
-    @api.model
-    def _name_search(self, name="", args=None, operator="ilike", limit=100):
-        """Allow searching by vat by default."""
-        if name and operator in {"=", "ilike", "=ilike", "like", "=like"}:
-            args = expression.OR([[("vat", operator, name)], args])
-        return super()._name_search(
-            name=name, args=args, operator=operator, limit=limit
-        )

--- a/partner_vat_unique/tests/test_vat_unique.py
+++ b/partner_vat_unique/tests/test_vat_unique.py
@@ -33,13 +33,3 @@ class TestVatUnique(TransactionCase):
     def test_duplicate_partner(self):
         partner_copied = self.partner.copy()
         self.assertFalse(partner_copied.vat)
-
-    def test_name_search(self):
-        partner = self.partner
-        result = partner.name_search(name=partner.vat)
-        self.assertEqual(result[0][0], partner.id)
-
-    def test_name_search_args_none(self):
-        partner = self.partner
-        result = partner.name_search(name=partner.vat, args=None)
-        self.assertEqual(result[0][0], partner.id)


### PR DESCRIPTION
Revert commits 569f43b9 and ef13b589. This is because more research has to be done in order to account for all possible cases where the search is involved. For example, when a domain needs to be considered with an AND operator.