### PR TITLE
[17.0][FIX] partner_firstname: fix error when creating a user from an employee

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -65,6 +65,8 @@ class ResPartner(models.Model):
     @api.model
     def default_get(self, fields_list):
         """Invert name when getting default values."""
+        if "firstname" in fields_list or "lastname" in fields_list:
+            fields_list.append("name")
         result = super().default_get(fields_list)
 
         inverted = self._get_inverse_name(


### PR DESCRIPTION
Steps to reproduce:
- Install `hr` and `partner_firstname`
- Go to Employees > any employee > action menu > Create User > Save
- 💥 Traceback

Suspected cause: in `defaul_get()`, the field `name` is not present in `fields_list` (probably because it's computed). So `result.get("name", "")` will always return `""` and `firstname` and `lastname` are not computed.