### PR TITLE
[16.0][FIX] partner_multi_relation: fix name search on relation

### DIFF
--- a/partner_multi_relation/models/res_partner_relation_all.py
+++ b/partner_multi_relation/models/res_partner_relation_all.py
@@ -54,7 +54,7 @@ class ResPartnerRelationAll(models.Model):
     _order = "this_partner_id, type_selection_id, date_end desc, date_start desc"
     _rec_names_search = [
         "this_partner_id.name",
-        "type_selection_id.display_name",
+        "type_selection_id.name",
         "other_partner_id.name",
     ]
 


### PR DESCRIPTION
Before this fix the following exception was logged (and the search not done):
```
2024-04-18 13:13:15,110 320 ERROR vwnvrs-testdatabase odoo.osv.expression: Non-stored field res.partner.relation.type.selection.display_name cannot be searched. 
NoneType: None
```

After fix no more errors in the log and the search works.