### PR TITLE
[FIX] partner_firstname: Multiple creation with "name"

### DIFF
--- a/partner_firstname/README.rst
+++ b/partner_firstname/README.rst
@@ -124,6 +124,9 @@ Contributors
 * Graeme Gellatly <graeme@o4sb.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Bjorn Billen <bjorn.billen@dynapps.be>
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -1,6 +1,7 @@
 # Copyright 2013 Nicolas Bessi (Camptocamp SA)
 # Copyright 2014 Agile Business Group (<http://www.agilebg.com>)
 # Copyright 2015 Grupo ESOC (<http://www.grupoesoc.es>)
+# Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import logging
 
@@ -73,7 +74,7 @@ class ResPartner(models.Model):
             # pylint: disable=W8121
             created_partners |= super(
                 ResPartner, self.with_context(partner_context)
-            ).create(vals_list)
+            ).create([vals])
         return created_partners
 
     def get_extra_default_copy_values(self, order):

--- a/partner_firstname/readme/CONTRIBUTORS.rst
+++ b/partner_firstname/readme/CONTRIBUTORS.rst
@@ -18,3 +18,6 @@
 * Graeme Gellatly <graeme@o4sb.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Bjorn Billen <bjorn.billen@dynapps.be>
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>

--- a/partner_firstname/static/description/index.html
+++ b/partner_firstname/static/description/index.html
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -466,6 +467,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Graeme Gellatly &lt;<a class="reference external" href="mailto:graeme&#64;o4sb.com">graeme&#64;o4sb.com</a>&gt;</li>
 <li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</li>
 <li>Bjorn Billen &lt;<a class="reference external" href="mailto:bjorn.billen&#64;dynapps.be">bjorn.billen&#64;dynapps.be</a>&gt;</li>
+<li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/partner_firstname/tests/test_name.py
+++ b/partner_firstname/tests/test_name.py
@@ -23,6 +23,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
+# Copyright 2024 Simone Rubino - Aion Tech
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 """Test naming logic.
 
 To have more accurate results, remove the ``mail`` module before testing.
@@ -49,6 +52,32 @@ class PartnerContactCase(BaseCase):
 
         # Need this to refresh the ``name`` field
         self.original.invalidate_recordset(["name"])
+
+    def test_multiple_name_creation(self):
+        """Create multiple partners at once, only with "name"."""
+        partners = self.env["res.partner"].create(
+            [
+                {
+                    "name": "Test partner1",
+                },
+                {
+                    "name": "Test partner2",
+                },
+            ]
+        )
+        self.assertRecordValues(
+            partners,
+            [
+                {
+                    "firstname": "Test",
+                    "lastname": "partner1",
+                },
+                {
+                    "firstname": "Test",
+                    "lastname": "partner2",
+                },
+            ],
+        )
 
 
 class PartnerCompanyCase(BaseCase):


### PR DESCRIPTION
This happens after https://github.com/OCA/partner-contact/pull/1647.

**Steps**:
1. Create 2 partners in one `create`, only assigning their `name` (also see added test):
   ```
   self.env["res.partner"].create(
       [
           {
               "name": "Test partner1",
           },
           {
               "name": "Test partner2",
           },
       ]
   )
   ```

**Actual behavior**:
Exception raised:
> odoo.addons.partner_firstname.exceptions.EmptyNamesError: ("Error(s) with partner 1425's name.", 'No name is set.')

**Expected behavior**:
2 partners created

