### PR TITLE
[16.0][IMP] partner_category_security: Add Contact Tags menu from Managers

### DIFF
--- a/partner_category_security/README.rst
+++ b/partner_category_security/README.rst
@@ -40,7 +40,7 @@ Usage
 
 #. *Contact Tags > Publisher* permission allows you to modify the tags assigned to contacts.
 #. *Contact Tags > Manager* permission also allows you to manage such tag (create, modify or remove them).
-#. *Contacts > Configuration > Contact Tags* menu will only be visible if you "Contact Tags > Manager" permission.
+#. *Contacts > Contact Tags* menu will only be visible if you "Contact Tags > Manager" permission.
 #. *Extra Rights / Contact Creation* and "Internal users" permissions only allows reading the tags assigned to contacts.
 
 Bug Tracker

--- a/partner_category_security/models/__init__.py
+++ b/partner_category_security/models/__init__.py
@@ -1,1 +1,2 @@
+from . import ir_ui_menu
 from . import res_partner

--- a/partner_category_security/models/ir_ui_menu.py
+++ b/partner_category_security/models/ir_ui_menu.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, models, tools
+
+
+class IrUiMenu(models.Model):
+    _inherit = "ir.ui.menu"
+
+    @api.model
+    @tools.ormcache("frozenset(self.env.user.groups_id.ids)", "debug")
+    def _visible_menu_ids(self, debug=False):
+        """It is not possible to set !groups in menu items, we do not return the record
+        if the user has base.group_system (to avoid the 'duplicate' menu)."""
+        visible = super()._visible_menu_ids(debug=debug)
+        user = self.env.user
+        if (
+            self.env.su
+            or user.has_group("base.group_system")
+            or user.has_group("sales_team.group_sale_manager")
+        ):
+            menu_partner_category_custom = self.env.ref(
+                "partner_category_security.menu_partner_category_custom"
+            )
+            if menu_partner_category_custom.id in visible:
+                visible.remove(menu_partner_category_custom.id)
+        return visible

--- a/partner_category_security/readme/USAGE.rst
+++ b/partner_category_security/readme/USAGE.rst
@@ -1,4 +1,4 @@
 #. *Contact Tags > Publisher* permission allows you to modify the tags assigned to contacts.
 #. *Contact Tags > Manager* permission also allows you to manage such tag (create, modify or remove them).
-#. *Contacts > Configuration > Contact Tags* menu will only be visible if you "Contact Tags > Manager" permission.
+#. *Contacts > Contact Tags* menu will only be visible if you "Contact Tags > Manager" permission.
 #. *Extra Rights / Contact Creation* and "Internal users" permissions only allows reading the tags assigned to contacts.

--- a/partner_category_security/static/description/index.html
+++ b/partner_category_security/static/description/index.html
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -388,7 +389,7 @@ ul.auto-toc {
 <ol class="arabic simple">
 <li><em>Contact Tags &gt; Publisher</em> permission allows you to modify the tags assigned to contacts.</li>
 <li><em>Contact Tags &gt; Manager</em> permission also allows you to manage such tag (create, modify or remove them).</li>
-<li><em>Contacts &gt; Configuration &gt; Contact Tags</em> menu will only be visible if you “Contact Tags &gt; Manager” permission.</li>
+<li><em>Contacts &gt; Contact Tags</em> menu will only be visible if you “Contact Tags &gt; Manager” permission.</li>
 <li><em>Extra Rights / Contact Creation</em> and “Internal users” permissions only allows reading the tags assigned to contacts.</li>
 </ol>
 </div>

--- a/partner_category_security/tests/test_partner_category_security.py
+++ b/partner_category_security/tests/test_partner_category_security.py
@@ -75,3 +75,34 @@ class TestPartnerCategorySecurity(BaseCommon):
         modifiers = json.loads(node.get("modifiers")) if node.get("modifiers") else {}
         self.assertTrue("readonly" not in modifiers or not modifiers["readonly"])
         self.assertFalse(node.get("force_save"))
+
+    def test_ir_ui_menu(self):
+        menu_partner_category_custom = self.env.ref(
+            "partner_category_security.menu_partner_category_custom"
+        )
+        visible_ids = (
+            self.env["ir.ui.menu"].with_user(self.basic_user)._visible_menu_ids()
+        )
+        self.assertNotIn(menu_partner_category_custom.id, visible_ids)
+        visible_ids = (
+            self.env["ir.ui.menu"]
+            .with_user(self.partner_category_user)
+            ._visible_menu_ids()
+        )
+        self.assertNotIn(menu_partner_category_custom.id, visible_ids)
+        visible_ids = (
+            self.env["ir.ui.menu"]
+            .with_user(self.partner_category_manager)
+            ._visible_menu_ids()
+        )
+        self.assertIn(menu_partner_category_custom.id, visible_ids)
+        # Add system to partner_category_manager user
+        self.partner_category_manager.write(
+            {"groups_id": [(4, self.env.ref("base.group_system").id)]}
+        )
+        visible_ids = (
+            self.env["ir.ui.menu"]
+            .with_user(self.partner_category_manager)
+            ._visible_menu_ids()
+        )
+        self.assertNotIn(menu_partner_category_custom.id, visible_ids)

--- a/partner_category_security/views/menu.xml
+++ b/partner_category_security/views/menu.xml
@@ -6,4 +6,14 @@
             eval="[(4, ref('partner_category_security.group_partner_category_manager'))]"
         />
     </record>
+    <!-- Custom menu for accessing Contact Tags if the user does not have the
+        group.group_system group.-->
+    <menuitem
+        id="menu_partner_category_custom"
+        name="Contact Tags"
+        parent="contacts.menu_contacts"
+        action="base.action_partner_category_form"
+        groups="partner_category_security.group_partner_category_manager"
+        sequence="90"
+    />
 </odoo>


### PR DESCRIPTION
Add Contact Tags menu from Managers

Add a menu to be able to access Contact Tags. The menu will not be displayed if the user has the base.group_system permission.

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT48639