### PR TITLE
[UPD] partner_manual_rank

### DIFF
--- a/partner_manual_rank/models/res_partner.py
+++ b/partner_manual_rank/models/res_partner.py
@@ -37,20 +37,16 @@ class ResPartner(models.Model):
                 partner.is_supplier = bool(partner.supplier_rank)
 
     def _inverse_is_customer(self):
-        for partner in self:
-            partners = partner | partner.commercial_partner_id
-            if partner.is_customer:
-                partners._increase_rank("customer_rank")
-            else:
-                partners.customer_rank = 0
+        self.filtered(lambda p: not p.is_customer).write({"customer_rank": 0})
+        self.filtered(lambda p: p.is_customer and not p.customer_rank).write(
+            {"customer_rank": 1}
+        )
 
     def _inverse_is_supplier(self):
-        for partner in self:
-            partners = partner | partner.commercial_partner_id
-            if partner.is_supplier:
-                partners._increase_rank("supplier_rank")
-            else:
-                partners.supplier_rank = 0
+        self.filtered(lambda p: not p.is_supplier).write({"supplier_rank": 0})
+        self.filtered(lambda p: p.is_supplier and not p.supplier_rank).write(
+            {"supplier_rank": 1}
+        )
 
     def _default_is_customer(self):
         return self.env.context.get("res_partner_search_mode") == "customer"

--- a/partner_manual_rank/tests/__init__.py
+++ b/partner_manual_rank/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_partner

--- a/partner_manual_rank/tests/test_res_partner.py
+++ b/partner_manual_rank/tests/test_res_partner.py
@@ -1,0 +1,81 @@
+from odoo.tests import common, tagged
+
+
+@tagged("res_partner")
+class TestResPartner(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env["res.partner"].create({"name": "Microsoft Corporation"})
+        self.partner_2 = self.env["res.partner"].create({"name": "Apple Inc."})
+
+    def test_01_is_customer(self):
+        partners = self.partner | self.partner_2
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_customer": False, "customer_rank": 0},
+                {"is_customer": False, "customer_rank": 0},
+            ],
+        )
+        self.partner.write({"is_customer": True})
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_customer": True, "customer_rank": 1},
+                {"is_customer": False, "customer_rank": 0},
+            ],
+        )
+        partners_found = self.env["res.partner"].search([("is_customer", "=", True)])
+        self.assertIn(self.partner, partners_found)
+        partners.write({"is_customer": True})
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_customer": True, "customer_rank": 1},
+                {"is_customer": True, "customer_rank": 1},
+            ],
+        )
+        partners.write({"is_customer": False})
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_customer": False, "customer_rank": 0},
+                {"is_customer": False, "customer_rank": 0},
+            ],
+        )
+
+    def test_02_is_supplier(self):
+        partners = self.partner | self.partner_2
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_supplier": False, "supplier_rank": 0},
+                {"is_supplier": False, "supplier_rank": 0},
+            ],
+        )
+        self.partner.write({"is_supplier": True})
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_supplier": True, "supplier_rank": 1},
+                {"is_supplier": False, "supplier_rank": 0},
+            ],
+        )
+        partners_found = self.env["res.partner"].search([("is_supplier", "=", True)])
+        self.assertIn(self.partner, partners_found)
+        partners.write({"is_supplier": True})
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_supplier": True, "supplier_rank": 1},
+                {"is_supplier": True, "supplier_rank": 1},
+            ],
+        )
+        partners.write({"is_supplier": False})
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_supplier": False, "supplier_rank": 0},
+                {"is_supplier": False, "supplier_rank": 0},
+            ],
+        )


### PR DESCRIPTION
- backported supplier and customer calculation from v15.0 - Fixes part when parent partner  is supplier, and if we have child who is not - it turns off supplier boolean for parent, which should not happen

https://github.com/OCA/partner-contact/blob/e7d7e4a53e8788ffe36635b3df0f59c8e08468ff/partner_manual_rank/models/res_partner.py#L46