### PR TITLE
[17.0] [IMP] partner_affiliate: add button in kanban to open form

### DIFF
--- a/partner_affiliate/README.rst
+++ b/partner_affiliate/README.rst
@@ -84,6 +84,7 @@ Contributors
 -  Dennis Sluijk <d.sluijk@onestein.nl>
 -  Stephan Rozendaal <stephan.rozendaal@neobis.net>
 -  Achraf Mhadhbi <machraf@bloopark.de>
+-  Alberto Martínez <alberto.martinez@sygel.es>
 -  `Binhex Systems Solutions <https://binhex.cloud/>`__:
 
    -  Deriman Alonso <d.alonso@binhex.cloud>

--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -22,3 +22,13 @@ class ResPartner(models.Model):
         string="Affiliates",
         domain=[("active", "=", True), ("is_company", "=", True)],
     )
+
+    def open_affiliate_form(self):
+        """Open affiliate contact form from the parent partner form view"""
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "res.partner",
+            "res_id": self.id,
+            "view_mode": "form",
+            "target": "current",
+        }

--- a/partner_affiliate/readme/CONTRIBUTORS.md
+++ b/partner_affiliate/readme/CONTRIBUTORS.md
@@ -5,5 +5,6 @@
 - Dennis Sluijk \<<d.sluijk@onestein.nl>\>
 - Stephan Rozendaal \<<stephan.rozendaal@neobis.net>\>
 - Achraf Mhadhbi \<<machraf@bloopark.de>\>
+- Alberto Martínez \<<alberto.martinez@sygel.es>\>
 - [Binhex Systems Solutions](https://binhex.cloud/):
   - Deriman Alonso \<<d.alonso@binhex.cloud>\>

--- a/partner_affiliate/static/description/index.html
+++ b/partner_affiliate/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -432,6 +433,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Dennis Sluijk &lt;<a class="reference external" href="mailto:d.sluijk&#64;onestein.nl">d.sluijk&#64;onestein.nl</a>&gt;</li>
 <li>Stephan Rozendaal &lt;<a class="reference external" href="mailto:stephan.rozendaal&#64;neobis.net">stephan.rozendaal&#64;neobis.net</a>&gt;</li>
 <li>Achraf Mhadhbi &lt;<a class="reference external" href="mailto:machraf&#64;bloopark.de">machraf&#64;bloopark.de</a>&gt;</li>
+<li>Alberto Martínez &lt;<a class="reference external" href="mailto:alberto.martinez&#64;sygel.es">alberto.martinez&#64;sygel.es</a>&gt;</li>
 <li><a class="reference external" href="https://binhex.cloud/">Binhex Systems Solutions</a>:<ul>
 <li>Deriman Alonso &lt;<a class="reference external" href="mailto:d.alonso&#64;binhex.cloud">d.alonso&#64;binhex.cloud</a>&gt;</li>
 </ul>
@@ -451,7 +453,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/partner_affiliate/tests/__init__.py
+++ b/partner_affiliate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_partner_affiliate

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Sygel Technology - Alberto Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import TransactionCase
+
+
+class TestPartnerAffiliate(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner_model = self.env["res.partner"]
+        self.company = self.partner_model.create(
+            {"name": "Test Company", "company_type": "company"}
+        )
+        self.affiliate = self.partner_model.create(
+            {
+                "name": "Test Affiliate",
+                "company_type": "company",
+                "parent_id": self.company.id,
+            }
+        )
+
+    def test_partner_affiliate_access_link(self):
+        res = self.affiliate.open_affiliate_form()
+        self.assertEqual(res["type"], "ir.actions.act_window")
+        self.assertEqual(res["res_model"], "res.partner")
+        self.assertEqual(res["res_id"], self.affiliate.id)
+        self.assertEqual(res["view_mode"], "form")
+        self.assertEqual(res["target"], "current")

--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -85,6 +85,17 @@
                                         </div>
                                         <div class="oe_kanban_details">
                                             <field name="name" />
+                                            <button
+                                                class="btn btn-link"
+                                                type="object"
+                                                name="open_affiliate_form"
+                                                title="Open full form"
+                                            >
+                                                <i
+                                                    class="fa fa-caret-right fa-2x"
+                                                    style="position:absolute;top:-4px;right:5px;transform:rotateY(0deg) rotate(-45deg);"
+                                                />
+                                            </button>
                                             <div t-if="record.function.raw_value"><field
                                                     name="function"
                                                 /></div>


### PR DESCRIPTION
This PR adds the functionality of the partner_contact_access_link module of this repo to the kanban view added in the partner_affiliate module, without  altering the dependences

T-6101