### PR TITLE
[16.0][IMP] partner_fax: reformat fax numbers

### DIFF
--- a/partner_fax/__manifest__.py
+++ b/partner_fax/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/partner-contact",
-    "depends": ["base_setup"],
+    "depends": ["phone_validation"],
     "data": ["views/res_partner.xml"],
     "installable": True,
 }

--- a/partner_fax/models/res_partner.py
+++ b/partner_fax/models/res_partner.py
@@ -1,10 +1,20 @@
 # Copyright 2018 Apruzzese Francesco <f.apruzzese@apuliasoftware.it>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    fax = fields.Char()
+    fax = fields.Char(unaccent=False)
+
+    def _phone_get_number_fields(self):
+        res = super()._phone_get_number_fields()
+        res.append("fax")
+        return res
+
+    @api.onchange("fax", "country_id", "company_id")
+    def _onchange_fax_validation(self):
+        if self.fax:
+            self.fax = self._phone_format(self.fax, force_format="INTERNATIONAL")

--- a/partner_fax/static/description/index.html
+++ b/partner_fax/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/partner_fax/views/res_partner.xml
+++ b/partner_fax/views/res_partner.xml
@@ -5,8 +5,8 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_simple_form" />
         <field name="arch" type="xml">
-            <field name="function" position="after">
-                <field name="fax" placeholder="Fax..." />
+            <field name="mobile" position="after">
+                <field name="fax" widget="phone" />
             </field>
         </field>
     </record>
@@ -15,15 +15,26 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <field name="function" position="after">
-                <field name="fax" placeholder="Fax..." widget="phone" />
+            <field name="mobile" position="after">
+                <field name="fax" widget="phone" />
             </field>
             <xpath
                 expr="//field[@name='child_ids']/form//field[@name='mobile']"
                 position="after"
             >
-                <field name="fax" placeholder="Fax..." widget="phone" />
+                <field name="fax" widget="phone" />
             </xpath>
         </field>
-    </record>
+</record>
+<record id="view_partner_tree" model="ir.ui.view">
+        <field name="name">Add fax on partner tree view</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree" />
+        <field name="arch" type="xml">
+            <field name="phone" position="after">
+                    <field name="fax" optional="hide" widget="phone" />
+            </field>
+        </field>
+</record>
+
 </odoo>


### PR DESCRIPTION
Remove placeholder='Fax ...' on partner form view
Add fax as optional="hide" in partner tree view
Add unaccent=False on fax field definition, as for mobile and phone in v16 On partner form view, position the fax field after the mobile field (it was its position until odoo remove the fax field in v11)