### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/partner_company_group/__manifest__.py
+++ b/partner_company_group/__manifest__.py
@@ -5,7 +5,7 @@
     'summary': 'Adds the possibility to add a company group to a company',
     'version': '12.0.1.2.1',
     'category': 'Sales',
-    'author': 'Camptocamp SA, Odoo Community Association (OCA)',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'depends': [
         'base',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 12.0.