### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/partner_company_group/__manifest__.py
+++ b/partner_company_group/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": "Adds the possibility to add a company group to a company",
     "version": "14.0.1.1.1",
     "category": "Sales",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["base", "account", "crm", "sale"],
     "website": "https://github.com/OCA/partner-contact",

--- a/partner_identification_unique_by_category/__manifest__.py
+++ b/partner_identification_unique_by_category/__manifest__.py
@@ -5,7 +5,7 @@
     "license": "AGPL-3",
     "depends": ["partner_identification"],
     "data": ["views/res_partner_id_category_view.xml"],
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/partner-contact",
     "development_status": "Production/Stable",
 }


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.