### PR TITLE
[FIX] partner_multi_relation: Translation string couldn't be parsed correctly using str.format KeyError('kategori') issue

### DIFF
--- a/partner_multi_relation/i18n/sv.po
+++ b/partner_multi_relation/i18n/sv.po
@@ -499,7 +499,7 @@ msgstr "Startdatumet kan inte vara efter slutdatumet."
 #: code:addons/partner_multi_relation/models/res_partner_relation.py:0
 #, python-format
 msgid "The {partner} partner does not have category {category}."
-msgstr "Partnern {partner} har inte kategori {kategori}."
+msgstr "Partnern {partner} har inte kategori {category}."
 
 #. module: partner_multi_relation
 #. odoo-python


### PR DESCRIPTION
This fix is needed to stop having `pre-commit` failing on other PR's.
- [ ] https://github.com/OCA/partner-contact/pull/1774