### PR TITLE
[17.0][FIX]partner_industry_secondary: Properly calculate industry's parent name

### DIFF
--- a/partner_industry_secondary/models/res_partner_industry.py
+++ b/partner_industry_secondary/models/res_partner_industry.py
@@ -23,7 +23,7 @@ class ResPartnerIndustry(models.Model):
     )
     parent_path = fields.Char(index=True, unaccent=False)
 
-    @api.depends("name", "parent_id")
+    @api.depends("name", "parent_id", "parent_id.display_name")
     def _compute_display_name(self):
         for rec in self:
             if rec.parent_id:


### PR DESCRIPTION
Before this fix, we noticed that some parents display names of the industries in the tree view were not calculated properly. For example:

![fix_industry-secondary_1](https://github.com/OCA/partner-contact/assets/62256279/da39d443-380e-4b1b-ae56-1e0a9e9f573f)

However, the parent display name was properly displayed in the form view:

![fix_industry_secondary_2](https://github.com/OCA/partner-contact/assets/62256279/eecd046e-87bc-4c7d-98b6-60408055f132)

The reason is that "parent_id.display_name" dependency is missing in the _compute_display_name method in res.partner.industry dependencies list. After the fix, the parent display name is properly shown.

![fix_industry_secondary_3](https://github.com/OCA/partner-contact/assets/62256279/db7a2949-2913-440a-9209-a67df01e33c0)
