### PR TITLE
[17.0][FIX] partner_affiliate: active_id => id

### DIFF
--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -16,7 +16,7 @@
                 <page string="Affiliates" invisible="not is_company">
                     <field
                         name="affiliate_ids"
-                        context="{'default_parent_id': active_id, 'default_is_company': True, 'default_type':'other'}"
+                        context="{'default_parent_id': id, 'default_is_company': True, 'default_type':'other'}"
                         mode="kanban"
                     >
                         <kanban on_create="base.view_partner_form">


### PR DESCRIPTION
For some reason, this was not done as a part of #1741 while being required by https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-17.0