### PR TITLE
[16.0][FIX] base_location_nuts: Modified field definition

### DIFF
--- a/base_location_nuts/models/res_partner_nuts.py
+++ b/base_location_nuts/models/res_partner_nuts.py
@@ -21,7 +21,7 @@ class ResPartnerNuts(models.Model):
     not_updatable = fields.Boolean()
     # Parent hierarchy
     parent_id = fields.Many2one(comodel_name="res.partner.nuts", ondelete="restrict")
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     child_ids = fields.One2many(
         comodel_name="res.partner.nuts", inverse_name="parent_id", string="Children"
     )


### PR DESCRIPTION
   In field parent_path, unaccent is assigned as False in order to avoid below warning message during installation:
   
Warning during installation


2024-07-15 12:47:08,142 1 WARNING devel odoo.models: parent_path field on model 'res.partner.nuts' should have unaccent disabled. Add `unaccent=False` to the field definition. 