### PR TITLE
[FIX] base_location_geonames_import: avoid code duplicates in country states

### DIFF
--- a/base_location_geonames_import/tests/test_base_location_geonames_import.py
+++ b/base_location_geonames_import/tests/test_base_location_geonames_import.py
@@ -177,6 +177,42 @@ class TestBaseLocationGeonamesImport(common.TransactionCase):
                 "Incorrect state for {} {}".format(state_name, zip_code),
             )
 
+    def test_import_duplicated_state_code(self):
+        country = self.env.ref("base.bg")
+        self.wizard.country_ids = [(6, 0, country.ids)]
+        parsed_csv = [
+            [
+                "BG",
+                "8500",
+                "Ajtos",
+                "Burgas",
+                "BGS",
+                "Ajtos",
+                "BGS01",
+                "42.7",
+                "27.25",
+                "4",
+            ],
+            [
+                "BG",
+                "8518",
+                "Ljaskovo",
+                "Burgos",
+                "BGS",
+                "Ajtos",
+                "BGS02",
+                "42.7333",
+                "27.3",
+                "4",
+            ],
+        ]
+        self.wizard._process_csv(parsed_csv, country)
+        self.wizard._process_csv(parsed_csv, country)
+        cities = self.env["res.city"].search([("country_id", "=", country.id)])
+        self.assertEqual(len(cities), 2)
+        states = self.env["res.country.state"].search([("country_id", "=", country.id)])
+        self.assertEqual(len(states), 1)
+
     def test_import_countries(self):
         max_import = 1
         self.wizard_2.with_context(max_import=max_import).run_import()

--- a/base_location_geonames_import/wizard/geonames_import.py
+++ b/base_location_geonames_import/wizard/geonames_import.py
@@ -134,7 +134,7 @@ class CityZipGeonamesImport(models.TransientModel):
                 )
             }
         # States
-        state_vals_set = set()
+        state_vals_dict = dict()
         state_dict = {}
         for i, row in enumerate(parsed_csv):
             if max_import and i == max_import:
@@ -145,14 +145,18 @@ class CityZipGeonamesImport(models.TransientModel):
                 state = states_map.get(code)
             if not state:
                 state_vals = self.prepare_state(row, country)
-                state_vals_set.add(
-                    (state_vals["name"], state_vals["code"], state_vals["country_id"])
-                )
+                key = (state_vals["code"], state_vals["country_id"])
+                if key not in state_vals_dict:
+                    state_vals_dict[key] = (
+                        state_vals["name"],
+                        state_vals["code"],
+                        state_vals["country_id"],
+                    )
             else:
                 state_dict[state.code] = state
         state_vals_list = [
             {"name": name, "code": code, "country_id": country_id}
-            for name, code, country_id in state_vals_set
+            for name, code, country_id in state_vals_dict.values()
         ]
         logger.info("Importing %d states", len(state_vals_list))
         created_states = self.env["res.country.state"].create(state_vals_list)


### PR DESCRIPTION
Currently, some countries like Bulgaria, Latvia and Sweden can't be imported with this module due to a duplicity in the code of their states on the data files.

With this fix, the states with the same code of another already parsed are discarded, and countries can be imported in spite of having an error of one of their state codes

T-5767
