### PR TITLE
[17.0][FIX] partner_manual_rank: Compatibility with Odoo default

### DIFF
--- a/partner_manual_rank/models/res_partner.py
+++ b/partner_manual_rank/models/res_partner.py
@@ -72,3 +72,12 @@ class ResPartner(models.Model):
 
     def _default_is_supplier(self):
         return self.env.context.get("res_partner_search_mode") == "supplier"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if "customer_rank" in vals and "is_customer" not in vals:
+                vals["is_customer"] = bool(vals["customer_rank"])
+            if "supplier_rank" in vals and "is_supplier" not in vals:
+                vals["is_supplier"] = bool(vals["supplier_rank"])
+        return super().create(vals_list)

--- a/partner_manual_rank/tests/test_res_partner.py
+++ b/partner_manual_rank/tests/test_res_partner.py
@@ -9,6 +9,30 @@ class TestResPartner(common.TransactionCase):
         self.partner = self.env["res.partner"].create({"name": "Microsoft Corporation"})
         self.partner_2 = self.env["res.partner"].create({"name": "Apple Inc."})
 
+    def test_create_with_rank(self):
+        p = self.env["res.partner"].create({"name": "customer", "customer_rank": 1})
+        self.assertTrue(p.is_customer)
+        self.assertEqual(p.customer_rank, 1)
+        self.assertFalse(p.is_supplier)
+        self.assertEqual(p.supplier_rank, 0)
+        p = self.env["res.partner"].create({"name": "supplier", "supplier_rank": 1})
+        self.assertTrue(p.is_supplier)
+        self.assertEqual(p.supplier_rank, 1)
+        self.assertFalse(p.is_customer)
+        self.assertEqual(p.customer_rank, 0)
+
+    def test_create_without_rank(self):
+        p = self.env["res.partner"].create({"name": "customer", "is_customer": True})
+        self.assertTrue(p.is_customer)
+        self.assertEqual(p.customer_rank, 1)
+        self.assertFalse(p.is_supplier)
+        self.assertEqual(p.supplier_rank, 0)
+        p = self.env["res.partner"].create({"name": "supplier", "is_supplier": True})
+        self.assertTrue(p.is_supplier)
+        self.assertEqual(p.supplier_rank, 1)
+        self.assertFalse(p.is_customer)
+        self.assertEqual(p.customer_rank, 0)
+
     def test_01_is_customer(self):
         partners = self.partner | self.partner_2
         self.assertRecordValues(


### PR DESCRIPTION
The introduction of default values for the fields 'is_customer' and 'is_supplier' breaks the compatibility when the create method on partner is called with once of the fields 'supplier_rank', 'customer_rank'. To restore this compatibility, we ovveride the create method to initialize the 'is_customer' and 'is_supplier' fields into the given dict if 'supplier_rank' or 'customer_rank' are passed to the method.

* [ ] forward port of #1849 