### PR TITLE
[17.0][IMP] partner_email_check: improve configuration view

### DIFF
--- a/partner_email_check/views/base_config_view.xml
+++ b/partner_email_check/views/base_config_view.xml
@@ -6,63 +6,34 @@
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[@id='companies']" position='after'>
-                <h2>Email validation</h2>
-                <div class="row mt16 o_settings_container" name="partner_email_check">
-                    <div class="col-xs-12 col-md-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="partner_email_check_syntax" />
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="partner_email_check_syntax" />
-                            <span
-                                class="fa fa-lg fa-building-o"
-                                title="Values set here are company-specific."
-                                aria-label="Values set here are company-specific."
-                                groups="base.group_multi_company"
-                                role="img"
-                            />
-                            <div class="text-muted">
-                                Require partner email addresses to have valid syntax
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-xs-12 col-md-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="partner_email_check_filter_duplicates" />
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="partner_email_check_filter_duplicates" />
-                            <span
-                                class="fa fa-lg fa-building-o"
-                                title="Values set here are company-specific."
-                                aria-label="Values set here are company-specific."
-                                groups="base.group_multi_company"
-                                role="img"
-                            />
-                            <div class="text-muted">
-                                Require partner email addresses to be unique
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-xs-12 col-md-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="partner_email_check_check_deliverability" />
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="partner_email_check_check_deliverability" />
-                            <span
-                                class="fa fa-lg fa-building-o"
-                                title="Values set here are company-specific."
-                                aria-label="Values set here are company-specific."
-                                groups="base.group_multi_company"
-                                role="img"
-                            />
-                            <div class="text-muted">
-                                Ensure that partner email addresses can be delivered to
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <block title="Email validation" name="partner_email_check">
+                    <setting
+                        id="partner_email_check_syntax"
+                        title="Values set here are company-specific."
+                        help="Require partner email addresses to have valid syntax"
+                        company_dependent="1"
+                    >
+                        <field name="partner_email_check_syntax" />
+                    </setting>
+
+                    <setting
+                        id="partner_email_check_filter_duplicates"
+                        title="Values set here are company-specific."
+                        help="Require partner email addresses to be unique"
+                        company_dependent="1"
+                    >
+                        <field name="partner_email_check_filter_duplicates" />
+                    </setting>
+
+                    <setting
+                        id="partner_email_check_check_deliverability"
+                        title="Values set here are company-specific."
+                        help="Ensure that partner email addresses can be delivered to"
+                        company_dependent="1"
+                    >
+                        <field name="partner_email_check_check_deliverability" />
+                    </setting>
+                </block>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The `res_config_settings_view_form` in Odoo 17 has changed its xml style, and the `view_general_configuration` in this module was written using Odoo 16 styling. So we need to update it accordingly.