### PR TITLE
[17.0][FIX] partner_display_name_line_break: Do not split with empty name

### DIFF
--- a/partner_display_name_line_break/models/res_partner.py
+++ b/partner_display_name_line_break/models/res_partner.py
@@ -30,6 +30,16 @@ class ResPartner(models.Model):
         super()._compute_display_name()
         if self.env.context.get("_two_lines_partner_address"):
             for partner in self:
+                # Do not split on two lines if name is empty as it would display
+                #  the address type on a new line in the report.
+                # This happens because Odoo splits the display_name on \n character
+                #  and discards the first element to get the address from the
+                #  display_name. In which case, the address type would appear as
+                #  part of the address.
+                if not partner.name and not self.env.context.get(
+                    "_keep_partner_address_type"
+                ):
+                    continue
                 displayed_types = partner._complete_name_displayed_types
                 type_description = dict(
                     partner._fields["type"]._description_selection(partner.env)

--- a/partner_display_name_line_break/models/res_partner.py
+++ b/partner_display_name_line_break/models/res_partner.py
@@ -25,6 +25,7 @@ class ResPartner(models.Model):
         "show_vat",
         "lang",
         "_two_lines_partner_address",
+        "_keep_partner_address_type",
     )
     def _compute_display_name(self):  # pylint: disable=W8110
         super()._compute_display_name()

--- a/partner_display_name_line_break/tests/test_res_partner.py
+++ b/partner_display_name_line_break/tests/test_res_partner.py
@@ -55,5 +55,11 @@ class TestBasePartnerTwoLine(TransactionCase):
         # Partner without a name.
         self.assertEqual(
             self.child_partner_no_name.display_name,
+            "Test Company Name, Invoice Address",
+        )
+        self.assertEqual(
+            self.child_partner_no_name.with_context(
+                _keep_partner_address_type=True
+            ).display_name,
             "Test Company Name\nInvoice Address",
         )


### PR DESCRIPTION
Do not split on two lines if name is empty as it would display the address type on a new line in the report.
This happens because Odoo splits the display_name on \n character and discards the first element to get the address from the display_name. In which case, the address type would appear as part of the address.

In case this is still needed, an added context key allows to still display the address type.