### PR TITLE
[FIX] [16.0] partner_contact_access_link: Hide icon when contact is not saved

### DIFF
--- a/partner_contact_access_link/views/res_partner_views.xml
+++ b/partner_contact_access_link/views/res_partner_views.xml
@@ -17,6 +17,7 @@
                     type="object"
                     name="open_child_form"
                     title="Open full form"
+                    attrs="{'invisible': [('id', '=', False)]}"
                 >
                     <i
                         class="fa fa-caret-right fa-2x"


### PR DESCRIPTION
Hide icon when contact is not saved

Fixes https://github.com/OCA/partner-contact/issues/1878

MT-7665 @moduon @fcvalgar @gelojr @rafaelbn @yajo please review if you want 😄 