### PR TITLE
[IMP] partner_firstname: compatible with standard sql constraint

### DIFF
--- a/partner_firstname/tests/base.py
+++ b/partner_firstname/tests/base.py
@@ -50,7 +50,7 @@ class BaseCase(TransactionCase, MailInstalled):
     def test_copy(self):
         """Copy the partner and compare the result."""
         self.expect("%s (copy)" % self.lastname, self.firstname)
-        self.changed = self.original.with_context(copy=True, lang="en_US").copy()
+        self.changed = self.original.with_context(lang="en_US").copy()
 
     def test_one_name(self):
         """Test what happens when only one name is given."""

--- a/partner_firstname/tests/test_create.py
+++ b/partner_firstname/tests/test_create.py
@@ -62,6 +62,12 @@ class CompanyCase(PersonCase):
         self.good_values.update(lastname=self.values["name"], firstname=False)
         self.values = self.good_values.copy()
 
+    def test_wrong_name_value(self):
+        """Name for company is taken."""
+
+    def test_wrong_name_value_and_context(self):
+        """Name for company is taken, defaults are ignored"""
+
 
 class UserCase(PersonCase, MailInstalled):
     """Test ``res.users``."""

--- a/partner_firstname/tests/test_empty.py
+++ b/partner_firstname/tests/test_empty.py
@@ -5,9 +5,10 @@
 
 To have more accurate results, remove the ``mail`` module before testing.
 """
+import psycopg2
+
 from odoo.tests.common import TransactionCase
 
-from .. import exceptions as ex
 from .base import MailInstalled
 
 
@@ -19,9 +20,9 @@ class CompanyCase(TransactionCase):
 
     def tearDown(self):
         try:
-            data = {"name": self.name}
+            data = {"name": False}
             model = self.env[self.model].with_context(**self.context)
-            with self.assertRaises(ex.EmptyNamesError):
+            with self.assertRaises(psycopg2.errors.CheckViolation):
                 model.create(data)
         finally:
             super().tearDown()

--- a/partner_second_lastname/models/res_partner.py
+++ b/partner_second_lastname/models/res_partner.py
@@ -33,6 +33,14 @@ class ResPartner(models.Model):
         return super().get_extra_default_copy_values(order)
 
     @api.model
+    def _get_computed_name_create(self, vals):
+        return self._get_computed_name(
+            self._get_whitespace_cleaned_name(vals.get("lastname")),
+            self._get_whitespace_cleaned_name(vals.get("firstname")),
+            self._get_whitespace_cleaned_name(vals.get("lastname2")),
+        )
+
+    @api.model
     def _get_computed_name(self, lastname, firstname, lastname2=None):
         """Compute the name combined with the second lastname too.
 


### PR DESCRIPTION
I prefer not to overwrite the standard constraint, because it is not necessary. 
To prevent recalculation and overwrite of firstname/lastname context variable is used. 