### PR TITLE
[17.0][IMP] partner_firstname: add is_address_readonly and is_individual for more UI customizable

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -27,6 +27,22 @@ class ResPartner(models.Model):
         readonly=False,
     )
 
+    is_address_readonly = fields.Boolean(compute="_compute_contact_type")
+    is_individual = fields.Boolean(compute="_compute_contact_type")
+
+    @api.depends("is_company", "type", "parent_id")
+    def _compute_contact_type(self):
+        for partner in self:
+            partner.is_address_readonly = not (
+                partner.is_company
+                or not partner.parent_id
+                or partner.type not in ["contact"]
+            )
+            partner.is_individual = not partner.is_company and partner.type in [
+                "contact",
+                "other",
+            ]
+
     @api.model
     def name_fields_in_vals(self, vals):
         """Method to check if any name fields are in `vals`."""

--- a/partner_firstname/views/res_partner.xml
+++ b/partner_firstname/views/res_partner.xml
@@ -3,26 +3,22 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_simple_form" />
         <field name="arch" type="xml">
+                <field name="is_company" position="after">
+                    <field name="is_individual" invisible="1" />
+                </field>
             <xpath expr="//field[@id='individual']" position="attributes">
                 <attribute name="invisible">is_company</attribute>
-                <attribute name="readonly">not is_company</attribute>
-                <attribute name="required">type == 'contract' and is_company</attribute>
+                <attribute name="readonly">is_individual</attribute>
+                <attribute name="required">is_individual</attribute>
             </xpath>
             <xpath expr="//field[@id='company']" position="attributes">
-                <attribute name="invisible">is_company == False</attribute>
-                <attribute name="readonly">not is_company</attribute>
-                <attribute name="required">type == 'contract' and is_company</attribute>
+                <attribute name="invisible">not is_company</attribute>
+                <attribute name="required">is_company</attribute>
             </xpath>
             <xpath expr="//h1//field[@id='company']/.." position="before">
-                <group invisible="is_company">
-                    <field
-                        name="lastname"
-                        required="not firstname and not is_company and type == 'contact'"
-                    />
-                    <field
-                        name="firstname"
-                        required="not lastname and not is_company and type == 'contact'"
-                    />
+                <group invisible="not is_individual">
+                    <field name="lastname" required="not firstname and is_individual" />
+                    <field name="firstname" required="not lastname and is_individual" />
                 </group>
             </xpath>
         </field>
@@ -31,55 +27,97 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
+            <field name="is_company" position="after">
+                <field name="is_individual" invisible="1" />
+                <field name="is_address_readonly" invisible="1" />
+            </field>
             <xpath expr="//field[@id='individual']" position="attributes">
                 <attribute name="invisible">is_company</attribute>
-                <attribute name="readonly">not is_company</attribute>
-                <attribute name="required">type == 'contract' and is_company</attribute>
+                <attribute name="required">is_individual</attribute>
+                <attribute name="readonly">is_individual</attribute>
             </xpath>
             <xpath expr="//field[@id='company']" position="attributes">
                 <attribute name="invisible">not is_company</attribute>
-                <attribute name="readonly">not is_company</attribute>
-                <attribute name="required">type == 'contract' and is_company</attribute>
+                <attribute name="required">is_company</attribute>
             </xpath>
             <xpath
                 expr="//div[hasclass('oe_title')]//field[@id='company']/.."
                 position="after"
             >
                 <div class="oe_edit_only">
-                    <group invisible="is_company">
+                    <group invisible="not is_individual">
                         <field
                             name="lastname"
-                            required="not firstname and not is_company and type == 'contact'"
+                            required="not firstname and is_individual"
                         />
                         <field
                             name="firstname"
-                            required="not lastname and not is_company and type == 'contact'"
+                            required="not lastname and is_individual"
                         />
                     </group>
                 </div>
             </xpath>
+
+            <xpath
+                expr="//div[hasclass('o_address_format')]//field[@name='street']"
+                position="attributes"
+            >
+                <attribute name="readonly">is_address_readonly</attribute>
+            </xpath>
+            <xpath
+                expr="//div[hasclass('o_address_format')]//field[@name='street2']"
+                position="attributes"
+            >
+                <attribute name="readonly">is_address_readonly</attribute>
+            </xpath>
+            <xpath
+                expr="//div[hasclass('o_address_format')]//field[@name='city']"
+                position="attributes"
+            >
+                <attribute name="readonly">is_address_readonly</attribute>
+            </xpath>
+            <xpath
+                expr="//div[hasclass('o_address_format')]//field[@name='state_id']"
+                position="attributes"
+            >
+                <attribute name="readonly">is_address_readonly</attribute>
+            </xpath>
+            <xpath
+                expr="//div[hasclass('o_address_format')]//field[@name='zip']"
+                position="attributes"
+            >
+                <attribute name="readonly">is_address_readonly</attribute>
+            </xpath>
+            <xpath
+                expr="//div[hasclass('o_address_format')]//field[@name='country_id']"
+                position="attributes"
+            >
+                <attribute name="readonly">is_address_readonly</attribute>
+            </xpath>
+
             <!-- Modify inner contact form of child_ids -->
             <xpath
                 expr="//field[@name='child_ids']/form//field[@name='name']"
                 position="attributes"
             >
-                <attribute name="readonly">not is_company</attribute>
-                <attribute name="required">is_company</attribute>
+                <attribute name="readonly">is_individual</attribute>
+                <attribute name="required">is_individual</attribute>
             </xpath>
             <xpath
                 expr="//field[@name='child_ids']/form//field[@name='name']"
                 position="after"
             >
                 <div class="oe_edit_only" colspan="2">
-                    <field name="is_company" invisible="True" />
-                    <group invisible="is_company">
+                    <field name="is_individual" invisible="1" />
+                    <field name="is_company" invisible="1" />
+                    <group invisible="not is_individual">
                         <field
                             name="lastname"
-                            required="not firstname and not is_company and type == 'contact'"
+                            required="not firstname and is_individual"
                         />
                         <field
                             name="firstname"
-                            required="not lastname and not is_company and type == 'contact'"
+                            required="not lastname and is_individual"
                         />
                     </group>
                 </div>


### PR DESCRIPTION
We are currently unhappy that invoice or shipping address has a firstname. Shipping addresses sometimes need an department name or other additional information, which are not person/individual like.

Therefore I would like to make the module more flexible and add an overloadable attribute is_individual, where you can control whether firstname should be visible or not. Modules could overload the _compute_contact_type method to do a different type definition of address types.

I also changed the visibility of the UI elements to is_individual and is_address_readonly instead of the address type.
The is_address_readonly we use to add another address type "contact_address" which is an individual, but also has an editiable address like address type "other". We use "other" for office addresses of a company and need to filter out these contacts for not adding these contacts to e.g. newsletters. Nevertheless we need the possibility to add individual addresses e.g. for people who are mostly working in the homeoffice and don't need their mails to the office.#

What do you think of these changes? Maybe also add this into an own module https://github.com/OCA/partner-contact/pull/1891 (my preferred solution), but than partner_firstname needs to derive from this module because the views overwrite readonly/visibility. 