### PR TITLE
[IMP] partner_firstname : french translation

### DIFF
--- a/partner_firstname/i18n/fr.po
+++ b/partner_firstname/i18n/fr.po
@@ -63,7 +63,7 @@ msgstr "Prénom"
 #: model:ir.model.fields,field_description:partner_firstname.field_res_partner__lastname
 #: model:ir.model.fields,field_description:partner_firstname.field_res_users__lastname
 msgid "Last name"
-msgstr "Nom"
+msgstr "Nom de famille"
 
 #. module: partner_firstname
 #: model:ir.model.fields,field_description:partner_firstname.field_res_partner__name


### PR DESCRIPTION
Functionally we have an issue in french <br/>
Odoo is already using "Nom" (name in french) for his field <br/>
So when exporting etc the end user don't know on which field he is working

