### PR TITLE
[17.0][FIX] base_location_geonames_import: Fixes for re-imports

### DIFF
--- a/base_location_geonames_import/wizard/geonames_import.py
+++ b/base_location_geonames_import/wizard/geonames_import.py
@@ -60,7 +60,7 @@ class CityZipGeonamesImport(models.TransientModel):
     def _select_city(self, row, country, state):
         return self.env["res.city"].search(
             [
-                ("name", "=", row[2]),
+                ("name", "=", self.transform_city_name(row[2], country)),
                 ("country_id", "=", country.id),
                 ("state_id", "=", state.id),
             ],
@@ -250,7 +250,7 @@ class CityZipGeonamesImport(models.TransientModel):
                 if zip_vals not in zip_vals_list:
                     zip_vals_list.append(zip_vals)
             else:
-                old_zips.discard(zip_code.id)
+                old_zips -= set(zip_code.ids)
         zip_model.create(zip_vals_list)
         if not max_import:
             if old_zips:


### PR DESCRIPTION
Forward-port of #1911

Before this commit, there were 2 possible errors re-importing ZIPs:

- If city names are changed on the import process (like capitalization), the code for detecting existing entries was not taking that into account, failing to find the city.
- If there's more than one found result, using `discard` for removing the result from the ZIPs to remove gives an error.

@Tecnativa TT52020