### PR TITLE
[17.0][IMP] partner_identification: Add chatter in res.partner.id_number form pop-up

### DIFF
--- a/partner_identification/views/res_partner_id_number_view.xml
+++ b/partner_identification/views/res_partner_id_number_view.xml
@@ -6,21 +6,32 @@
         <field name="arch" type="xml">
             <form string="Partner ID Numbers">
                 <sheet>
-                    <group>
-                        <field name="partner_id" />
-                        <field name="category_id" />
-                        <field name="name" />
-                        <field name="partner_issued_id" />
-                        <field name="date_issued" />
-                        <field name="place_issuance" />
-                        <field name="valid_from" />
-                        <field name="valid_until" />
-                        <field name="status" />
-                    </group>
+                    <div class="o_row">
+                        <div class="o_col">
+                            <group>
+                                <field name="partner_id" />
+                                <field
+                                    name="category_id"
+                                    options="{'no_open': True, 'no_create': True}"
+                                />
+                                <field name="name" />
+                                <field name="partner_issued_id" />
+                                <field name="date_issued" />
+                                <field name="place_issuance" />
+                            </group>
+                        </div>
+                        <div class="o_low">
+                            <group>
+                                <field name="valid_from" />
+                                <field name="valid_until" />
+                                <field name="status" />
+                            </group>
+                        </div>
+                    </div>
                     <separator colspan="4" string="Notes" />
                     <field name="comment" colspan="4" nolabel="1" />
                 </sheet>
-                <div class="oe_chatter">
+                <div class="oe_chatter" style="display:block;">
                     <field name="message_follower_ids" />
                     <field name="activity_ids" />
                     <field name="message_ids" />

--- a/partner_identification/views/res_partner_view.xml
+++ b/partner_identification/views/res_partner_view.xml
@@ -1,5 +1,5 @@
 <odoo>
-    <!-- Modification of Partner - Adding Tab for Idenification Numbers -->
+    <!-- Modification of Partner - Adding Tab for Identification Numbers -->
     <record model="ir.ui.view" id="view_partner_form">
         <field name="name">res.partner.form.id_number</field>
         <field name="model">res.partner</field>


### PR DESCRIPTION
Description:
Integrate the Odoo Chatter to enable uploading attachment files through the `res.partner` pop-up form for ID Numbers.

cc @cvinh