### PR TITLE
[17.0] [IMP] partner_fax: option to display fax in the qweb contact widget

### DIFF
--- a/partner_fax/README.rst
+++ b/partner_fax/README.rst
@@ -60,11 +60,13 @@ Credits
 Contributors
 ------------
 
--  Francesco Apruzzese <cescoap@gmail.com>
--  Aitor Bouzas <aitor.bouzas@adaptivecity.com>
--  Pimolnat Suntian <pimolnats@ecosoft.co.th>
--  Nadal Francisco Garcia <nadal.francisco@braintec.com>
-   (https://braintec.com)
+- Francesco Apruzzese <cescoap@gmail.com>
+- Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+- Pimolnat Suntian <pimolnats@ecosoft.co.th>
+- Nadal Francisco Garcia <nadal.francisco@braintec.com>
+  (https://braintec.com)
+- Iván Todorovich <ivan.todorovich@camptocamp.com>
+  (https://www.camptocamp.com)
 
 Maintainers
 -----------

--- a/partner_fax/__manifest__.py
+++ b/partner_fax/__manifest__.py
@@ -10,6 +10,6 @@
     "author": "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/partner-contact",
     "depends": ["base_setup"],
-    "data": ["views/res_partner.xml"],
+    "data": ["views/res_partner.xml", "views/templates.xml"],
     "installable": True,
 }

--- a/partner_fax/models/ir_qweb_fields.py
+++ b/partner_fax/models/ir_qweb_fields.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models
+
+
+class Contact(models.AbstractModel):
+    _inherit = "ir.qweb.field.contact"
+
+    @api.model
+    def get_available_options(self):
+        options = super().get_available_options()
+        options["fields"]["params"]["params"].append(
+            {
+                "field_name": "fax",
+                "label": _("Fax"),
+            }
+        )
+        return options

--- a/partner_fax/readme/CONTRIBUTORS.md
+++ b/partner_fax/readme/CONTRIBUTORS.md
@@ -1,5 +1,5 @@
 - Francesco Apruzzese \<<cescoap@gmail.com>\>
 - Aitor Bouzas \<<aitor.bouzas@adaptivecity.com>\>
 - Pimolnat Suntian \<<pimolnats@ecosoft.co.th>\>
-- Nadal Francisco Garcia \<<nadal.francisco@braintec.com>\>
-  (<https://braintec.com>)
+- Nadal Francisco Garcia \<<nadal.francisco@braintec.com>\> (<https://braintec.com>)
+- Iván Todorovich \<<ivan.todorovich@camptocamp.com>\> (<https://www.camptocamp.com>)

--- a/partner_fax/static/description/index.html
+++ b/partner_fax/static/description/index.html
@@ -410,6 +410,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
 <li>Nadal Francisco Garcia &lt;<a class="reference external" href="mailto:nadal.francisco&#64;braintec.com">nadal.francisco&#64;braintec.com</a>&gt;
 (<a class="reference external" href="https://braintec.com">https://braintec.com</a>)</li>
+<li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;camptocamp.com">ivan.todorovich&#64;camptocamp.com</a>&gt;
+(<a class="reference external" href="https://www.camptocamp.com">https://www.camptocamp.com</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/partner_fax/tests/__init__.py
+++ b/partner_fax/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_qweb_contact_field

--- a/partner_fax/tests/test_qweb_contact_field.py
+++ b/partner_fax/tests/test_qweb_contact_field.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import TransactionCase
+
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+
+
+class TestQwebContactField(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "fax": "1234567890",
+            }
+        )
+
+    def test_qweb_contact_field_fax_displayed(self):
+        Contact = self.env["ir.qweb.field.contact"]
+        result = Contact.value_to_html(self.partner, {"fields": ["name", "fax"]})
+        self.assertIn("1234567890", result)
+        self.assertIn('itemprop="faxNumber"', result)
+
+    def test_qweb_contact_field_fax_hidden_if_not_set(self):
+        self.partner.fax = None
+        Contact = self.env["ir.qweb.field.contact"]
+        result = Contact.value_to_html(self.partner, {"fields": ["name", "fax"]})
+        self.assertNotIn('itemprop="faxNumber"', result)
+
+    def test_qweb_contact_field_fax_hidden_by_default(self):
+        Contact = self.env["ir.qweb.field.contact"]
+        result = Contact.value_to_html(self.partner, {})
+        self.assertNotIn("1234567890", result)
+        self.assertNotIn('itemprop="faxNumber"', result)

--- a/partner_fax/views/templates.xml
+++ b/partner_fax/views/templates.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2024 Camptocamp SA (https://www.camptocamp.com).
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <template id="contact" inherit_id="base.contact">
+        <div t-if="mobile and 'mobile' in fields" position="after">
+            <div
+                class="d-flex align-items-center gap-1"
+                t-if="object.fax and 'fax' in fields"
+            >
+                <i
+                    t-if="not options.get('no_marker') or options.get('phone_icons')"
+                    class='fa fa-fax fa-fw'
+                    role="img"
+                    aria-label="Fax"
+                    title="Fax"
+                />
+                <span class="o_force_ltr" itemprop="faxNumber" t-esc="object.fax" />
+            </div>
+        </div>
+    </template>
+
+</odoo>


### PR DESCRIPTION
So that it can be displayed along `mobile`, `phone`, etc.. on reports, using the standard QWeb contact widget