### PR TITLE
[16.0][FIX] partner_auto_archive: Add mail dependency to fix tracking parameter warning

### DIFF
--- a/partner_stage/__manifest__.py
+++ b/partner_stage/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Sales/CRM",
     "version": "16.0.1.0.1",
     "license": "AGPL-3",
-    "depends": ["contacts"],
+    "depends": ["contacts", "mail"],
     "data": [
         "security/ir.model.access.csv",
         "data/partner_stage_data.xml",


### PR DESCRIPTION
When installing or upgrading the module, a warning appeared about the unknown 
'tracking' parameter. This fix adds mail as a dependency to properly support 
the tracking parameter on fields, ensuring clean installation and upgrades 
without warnings.