### PR TITLE
[17.0][FIX] partner_stage: rule access_partner_stage_read has no group

### DIFF
--- a/partner_stage/security/ir.model.access.csv
+++ b/partner_stage/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_partner_stage_edit","access_partner_stage_edit","model_res_partner_stage","base.group_system",1,1,1,1
-"access_partner_stage_read","access_partner_stage_read","model_res_partner_stage",,1,0,0,0
+"access_partner_stage_read","access_partner_stage_read","model_res_partner_stage",base.group_user,1,0,0,0


### PR DESCRIPTION
Fixes warning in logs:
```
odoo.addons.base.models.ir_model: Rule access_partner_stage_read has no group, this is a deprecated feature. Every access-granting rule should specify a group.
```