### PR TITLE
[FIX] partner_contact_department: avoid accidental department creations

### DIFF
--- a/partner_contact_department/views/res_partner_view.xml
+++ b/partner_contact_department/views/res_partner_view.xml
@@ -10,7 +10,7 @@
                     name="department_id"
                     placeholder="Department"
                     attrs="{'invisible': [('is_company','=', True)]}"
-                    options='{"no_open": True}'
+                    options='{"no_open": True, "no_create": True}'
                 />
             </xpath>
             <xpath
@@ -22,7 +22,7 @@
                     name="department_id"
                     placeholder="Department"
                     attrs="{'invisible': [('is_company','=', True)]}"
-                    options='{"no_open": True}'
+                    options='{"no_open": True, "no_create": True}'
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Users were creating departments accidentally.

In our customers' use case, a few users create and organize departments, and the rest just use them. I think it's the more common case.

@moduon MT-8760