### PR TITLE
[FIX] partner_contact_job_position: avoid accidental job position creations

### DIFF
--- a/partner_contact_job_position/views/res_partner_view.xml
+++ b/partner_contact_job_position/views/res_partner_view.xml
@@ -9,7 +9,7 @@
                 <field
                     name="job_position_id"
                     attrs="{'invisible': [('is_company','=', True)]}"
-                    options='{"no_open": True}'
+                    options='{"no_open": True, "no_create": True}'
                 />
             </field>
             <xpath
@@ -20,7 +20,7 @@
                 <field
                     name="job_position_id"
                     attrs="{'invisible': [('is_company','=', True)]}"
-                    options='{"no_open": True}'
+                    options='{"no_open": True, "no_create": True}'
                 />
             </xpath>
         </field>


### PR DESCRIPTION

Users were creating job positions accidentally.

In our customers' use case, a few users create and organize job positions, and the rest just use them. I think it's the more common case.

@moduon MT-8760