### PR TITLE
[FIX] partner_contact_department: really order by name

### DIFF
--- a/partner_contact_department/models/res_partner.py
+++ b/partner_contact_department/models/res_partner.py
@@ -2,7 +2,7 @@
 # © 2016 Tecnativa S.L. - Vicent Cubells
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -13,12 +13,12 @@ class ResPartner(models.Model):
 
 class ResPartnerDepartment(models.Model):
     _name = "res.partner.department"
-    _order = "parent_path, name"
-    _parent_order = "name"
+    _order = "display_name"
     _parent_store = True
     _description = "Department"
 
     name = fields.Char(required=True, translate=True)
+    display_name = fields.Char(compute="_compute_display_name", store=True, index=True)
     parent_id = fields.Many2one(
         "res.partner.department", "Parent department", ondelete="restrict"
     )
@@ -26,3 +26,23 @@ class ResPartnerDepartment(models.Model):
         "res.partner.department", "parent_id", "Child departments"
     )
     parent_path = fields.Char(index=True, unaccent=False)
+
+    @api.depends("parent_path", "name")
+    def _compute_display_name(self):
+        return super()._compute_display_name()
+
+    def name_get(self):
+        """Prepend parent name to department name."""
+        all_ids = set(
+            map(int, "/".join(rec.parent_path.strip("/") for rec in self).split("/"))
+        )
+        names = {rec.id: rec.name for rec in self.browse(all_ids)}
+        return [
+            (
+                rec.id,
+                " / ".join(
+                    names[int(id)] for id in rec.parent_path.strip("/").split("/")
+                ),
+            )
+            for rec in self
+        ]

--- a/partner_contact_department/tests/test_recursion.py
+++ b/partner_contact_department/tests/test_recursion.py
@@ -24,3 +24,17 @@ class TestRecursion(common.TransactionCase):
         # Creating a parent's child department using dpt1.
         with self.assertRaises(UserError):
             self.dpt1.write(vals={"parent_id": self.dpt3.id})
+
+    def test_order(self):
+        dpt3 = self.env["res.partner.department"].create({"name": "A"})
+        dpts = self.env["res.partner.department"].search(
+            [("id", "in", (self.dpt1 | self.dpt2 | dpt3).ids)]
+        )
+        self.assertRecordValues(
+            dpts,
+            [
+                {"name": "A", "display_name": "A"},
+                {"name": "Dpt. 1", "display_name": "Dpt. 1"},
+                {"name": "Dep. 2", "display_name": "Dpt. 1 / Dep. 2"},
+            ],
+        )


### PR DESCRIPTION
First attempt in https://github.com/OCA/partner-contact/pull/1983 didn't really work because `parent_path` always contained own ID.

Now departments will really be ordered by name, or by parent path + name if they have a parent.

@moduon MT-8760