### PR TITLE
[FIX] partner_contact_department: make display name lang-aware

### DIFF
--- a/partner_contact_department/README.rst
+++ b/partner_contact_department/README.rst
@@ -103,6 +103,17 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-rafaelbn| image:: https://github.com/rafaelbn.png?size=40px
+    :target: https://github.com/rafaelbn
+    :alt: rafaelbn
+.. |maintainer-yajo| image:: https://github.com/yajo.png?size=40px
+    :target: https://github.com/yajo
+    :alt: yajo
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-rafaelbn| |maintainer-yajo| 
+
 This module is part of the `OCA/partner-contact <https://github.com/OCA/partner-contact/tree/16.0/partner_contact_department>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/partner_contact_department/__manifest__.py
+++ b/partner_contact_department/__manifest__.py
@@ -18,5 +18,6 @@
         "views/res_partner_department_view.xml",
         "views/res_partner_view.xml",
     ],
+    "maintainers": ["rafaelbn", "yajo"],
     "installable": True,
 }

--- a/partner_contact_department/migrations/16.0.1.3.0/post-migration.py
+++ b/partner_contact_department/migrations/16.0.1.3.0/post-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2025 Moduon Team S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Update displayed names of departments, to be multi-language."""
+    env["res.partner.department"].search([])._compute_display_name()

--- a/partner_contact_department/static/description/index.html
+++ b/partner_contact_department/static/description/index.html
@@ -446,6 +446,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/rafaelbn"><img alt="rafaelbn" src="https://github.com/rafaelbn.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/yajo"><img alt="yajo" src="https://github.com/yajo.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/partner-contact/tree/16.0/partner_contact_department">OCA/partner-contact</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/partner_contact_department/tests/test_recursion.py
+++ b/partner_contact_department/tests/test_recursion.py
@@ -1,35 +1,38 @@
 # © 2016 Tecnativa - Vicent Cubells
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
 from odoo.exceptions import UserError
-from odoo.tests import common
+from odoo.tests import Form, common, new_test_user
 
 
 class TestRecursion(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.department_obj = cls.env["res.partner.department"]
+        cls.env["res.lang"].load_lang("es_ES")
+        cls.uid = new_test_user(
+            cls.env, login="test_user", groups="base.group_partner_manager"
+        )
 
         # Instances
-        cls.dpt1 = cls.department_obj.create({"name": "Dpt. 1"})
-        cls.dpt2 = cls.department_obj.create(
+        cls.dpt1 = cls.env["res.partner.department"].create({"name": "Dpt. 1"})
+        cls.dpt2 = cls.env["res.partner.department"].create(
             {"name": "Dep. 2", "parent_id": cls.dpt1.id}
         )
 
     def test_recursion(self):
         """Testing recursion"""
-        self.dpt3 = self.department_obj.create(
+        dpt3 = self.env["res.partner.department"].create(
             {"name": "Dep. 3", "parent_id": self.dpt2.id}
         )
         # Creating a parent's child department using dpt1.
         with self.assertRaises(UserError):
-            self.dpt1.write(vals={"parent_id": self.dpt3.id})
+            self.dpt1.write(vals={"parent_id": dpt3.id})
 
     def test_order(self):
         dpt3 = self.env["res.partner.department"].create({"name": "A"})
-        dpts = self.env["res.partner.department"].search(
-            [("id", "in", (self.dpt1 | self.dpt2 | dpt3).ids)]
-        )
+        dpt3.with_context(lang="es_ES").name = "ES A"
+        all_ids = (self.dpt1 | self.dpt2 | dpt3).ids
+        dpts = self.env["res.partner.department"].search([("id", "in", all_ids)])
         self.assertRecordValues(
             dpts,
             [
@@ -38,3 +41,38 @@ class TestRecursion(common.TransactionCase):
                 {"name": "Dep. 2", "display_name": "Dpt. 1 / Dep. 2"},
             ],
         )
+        # Test order is language-aware
+        self.dpt1.with_context(lang="es_ES").name = "Dpt. 1 ES"
+        dpts_es = (
+            self.env["res.partner.department"]
+            .with_context(lang="es_ES")
+            .search([("id", "in", all_ids)])
+        )
+        self.assertRecordValues(
+            dpts_es,
+            [
+                {"name": "Dpt. 1 ES", "display_name": "Dpt. 1 ES"},
+                {"name": "Dep. 2", "display_name": "Dpt. 1 ES / Dep. 2"},
+                {"name": "ES A", "display_name": "ES A"},
+            ],
+        )
+
+    def test_creation(self):
+        dpt_f = Form(
+            self.env["res.partner.department"],
+            "partner_contact_department.res_partner_department_tree_view",
+        )
+        self.assertFalse(dpt_f.display_name)
+        dpt_f.name = "test"
+        self.assertEqual(dpt_f.display_name, "test")
+        dpt_f.parent_id = self.dpt1
+        self.assertEqual(dpt_f.display_name, "Dpt. 1 / test")
+        dpt = dpt_f.save()
+        self.assertEqual(dpt.display_name, "Dpt. 1 / test")
+
+    def test_grandparent_rename(self):
+        dpt3 = self.env["res.partner.department"].create(
+            {"name": "Dep. 3", "parent_id": self.dpt2.id}
+        )
+        self.dpt1.name = "Dpt. 1 changed"
+        self.assertEqual(dpt3.display_name, "Dpt. 1 changed / Dep. 2 / Dep. 3")

--- a/partner_contact_department/views/res_partner_department_view.xml
+++ b/partner_contact_department/views/res_partner_department_view.xml
@@ -10,6 +10,7 @@
         <field name="model">res.partner.department</field>
         <field name="arch" type="xml">
             <tree name="Departments" editable="top">
+                <field name="display_name" optional="show" />
                 <field name="name" />
                 <field name="parent_id" />
             </tree>


### PR DESCRIPTION
Yet another iteration over https://github.com/OCA/partner-contact/pull/2009.

`display_name` wasn't translatable, but `name` was. Thus, stored record order was always on English. Now, if department names are translated and the user switches to another language, the order the user will see will match the language it is displaying.

Another fix is that now, when changing a parent department name name, children display names will change too.

I took the chance to apply some anti-flaky-tests good practices in current test suite (apart from increasing coverage to cover these new cases).

@moduon MT-8760