### PR TITLE
[FIX] partner_contact_department: proper version bump

### DIFF
--- a/partner_contact_department/__manifest__.py
+++ b/partner_contact_department/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Partner Contact Department",
     "summary": "Assign contacts to departments",
-    "version": "16.0.1.2.2",
+    "version": "16.0.1.3.0",
     "category": "Customer Relationship Management",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",


### PR DESCRIPTION
https://github.com/OCA/partner-contact/pull/2023 added a migration script for version 16.0.1.3.0 because it was expected to be merged as a minor bump.

However, it was merged by mistake as a patch bump in https://github.com/OCA/partner-contact/pull/2023#pullrequestreview-2697254654, resulting in the migration script not being run.

Hence, this just bumps the version appropriately to force running that script on updates.

@moduon MT-8760