### PR TITLE
[FIX] partner_identification: add external dependency

### DIFF
--- a/partner_identification/README.rst
+++ b/partner_identification/README.rst
@@ -32,12 +32,12 @@ This module allows to manage all sort of identification numbers and
 certificates which are assigned to a partner (company or individual) and
 vary from country to country.
 
--  Commercial register
--  VAT ID
--  Fiscal ID's
--  Membership numbers
--  Driver license
--  etc
+- Commercial register
+- VAT ID
+- Fiscal ID's
+- Membership numbers
+- Driver license
+- etc
 
 **Table of contents**
 
@@ -107,8 +107,8 @@ add any IDs to this partner, defining:
 Known issues / Roadmap
 ======================
 
--  If you want to search a partner by ID you will use advance search
-   form. You can't search by issuer, valid dates, category or notes.
+- If you want to search a partner by ID you will use advance search
+  form. You can't search by issuer, valid dates, category or notes.
 
 Bug Tracker
 ===========
@@ -136,25 +136,25 @@ Authors
 Contributors
 ------------
 
--  Antonio Espinosa <antonio.espinosa@tecnativa.com>
--  Ferdinand Gassauer <office@chrcar.at>
--  Gerhard Könighofer <gerhard.koenighofer@swing-system.com>
--  Laurent Mignon <laurent.mignon@acsone.eu>
--  Jairo Llopis <jairo.llopis@tecnativa.com>
--  Dave Lasley <dave@laslabs.com>
--  Simone Orsi <simone.orsi@camptocamp.com>
--  Dennis Sluijk <d.sluijk@onestein.nl>
--  Phuc Tran Thanh <phuc@trobz.com>
--  Marie Lejeune <marie.lejeune@acsone.eu>
--  Nils Coenen <nils.coenen@nico-solutions.de>
--  Chau Le <chaulb@trobz.com>
+- Antonio Espinosa <antonio.espinosa@tecnativa.com>
+- Ferdinand Gassauer <office@chrcar.at>
+- Gerhard Könighofer <gerhard.koenighofer@swing-system.com>
+- Laurent Mignon <laurent.mignon@acsone.eu>
+- Jairo Llopis <jairo.llopis@tecnativa.com>
+- Dave Lasley <dave@laslabs.com>
+- Simone Orsi <simone.orsi@camptocamp.com>
+- Dennis Sluijk <d.sluijk@onestein.nl>
+- Phuc Tran Thanh <phuc@trobz.com>
+- Marie Lejeune <marie.lejeune@acsone.eu>
+- Nils Coenen <nils.coenen@nico-solutions.de>
+- Chau Le <chaulb@trobz.com>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
--  Camptocamp
+- Camptocamp
 
 Maintainers
 -----------

--- a/partner_identification/__manifest__.py
+++ b/partner_identification/__manifest__.py
@@ -18,6 +18,9 @@
         "views/res_partner_id_number_view.xml",
         "views/res_partner_view.xml",
     ],
+    "external_dependencies": {
+        "python": ["odoo_test_helper"],
+    },
     "author": "ChriCar Beteiligungs- und Beratungs- GmbH,"
     "Tecnativa,"
     "Camptocamp,"

--- a/partner_identification/static/description/index.html
+++ b/partner_identification/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -520,9 +519,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # generated from manifests external_dependencies
 email-validator
+odoo_test_helper


### PR DESCRIPTION
The external python dependency "odoo_test_helper" is used in the tests.