### PR TITLE
[18.0][FIX] partner_firstname: copy() multiple res.users records at once.

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -109,9 +109,13 @@ class ResPartner(models.Model):
         """
         default = default or {}
         order = self._get_names_order()
-        extra_default_values = self.get_extra_default_copy_values(order)
-        default.update(extra_default_values)
-        return super(ResPartner, self.with_context(copy=True)).copy(default)
+        records = self.browse()
+        for record in self:
+            extra_default_values = record.get_extra_default_copy_values(order)
+            records |= super(ResPartner, record.with_context(copy=True)).copy(
+                default | extra_default_values
+            )
+        return records
 
     @api.model
     def default_get(self, fields_list):

--- a/partner_firstname/models/res_users.py
+++ b/partner_firstname/models/res_users.py
@@ -2,7 +2,7 @@
 # Copyright 2014 Agile Business Group (<http://www.agilebg.com>)
 # Copyright 2015 Grupo ESOC (<http://www.grupoesoc.es>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import _, api, models
+from odoo import api, models
 
 
 class ResUser(models.Model):
@@ -32,18 +32,21 @@ class ResUser(models.Model):
             rec.name = rec.partner_id._get_computed_name(rec.lastname, rec.firstname)
 
     def copy(self, default=None):
-        self.ensure_one()
-        default = dict(default or {})
-        if ("name" not in default) and ("partner_id" not in default):
-            default["name"] = _("%(name)s (copy)", name=self.name)
-        if "login" not in default:
-            default["login"] = _("%(login)s (copy)", login=self.login)
-        if (
-            ("firstname" not in default)
-            and ("lastname" not in default)
-            and ("name" in default)
-        ):
-            default.update(
-                self.env["res.partner"]._get_inverse_name(default["name"], False)
-            )
-        return super().copy(default)
+        default_ = default or {}
+        records = self.browse()
+        for record in self:
+            default = dict(default_)
+            if ("name" not in default) and ("partner_id" not in default):
+                default["name"] = self.env._("%(name)s (copy)", name=record.name)
+            if "login" not in default:
+                default["login"] = self.env._("%(login)s (copy)", login=record.login)
+            if (
+                ("firstname" not in default)
+                and ("lastname" not in default)
+                and ("name" in default)
+            ):
+                default.update(
+                    self.env["res.partner"]._get_inverse_name(default["name"], False)
+                )
+            records |= super(ResUser, record).copy(default)
+        return records

--- a/partner_firstname/tests/test_copy.py
+++ b/partner_firstname/tests/test_copy.py
@@ -38,13 +38,18 @@ class UserCase(TransactionCase, MailInstalled):
             )
         )
 
-    def tearDown(self):
-        super().tearDown()
-
     def compare(self, copy):
         self.assertEqual(copy.lastname, "Lastname2")
         self.assertEqual(copy.firstname, "Firstname2")
         self.assertEqual(copy.name, "Firstname2 Lastname2")
+
+    def test_copy_login(self):
+        copy = self.original.copy()
+        self.assertEqual(copy.login, "firstname.lastname (copy)")
+
+    def test_copy_login_default(self):
+        copy = self.original.copy({"login": "login"})
+        self.assertEqual(copy.login, "login")
 
     def test_copy_name(self):
         """Copy original with default name set - firstname lastname not set."""
@@ -94,3 +99,15 @@ class UserCase(TransactionCase, MailInstalled):
                 }
             ],
         )
+
+    def test_copy_multiple_partners(self):
+        partners = self.env.ref("base.partner_admin") | self.env.ref(
+            "base.partner_demo"
+        )
+        dupes = partners.copy()
+        self.assertEqual(len(dupes), 2)
+
+    def test_copy_multiple_users(self):
+        users = self.env.ref("base.user_admin") | self.env.ref("base.user_demo")
+        dupes = users.copy()
+        self.assertEqual(len(dupes), 2)


### PR DESCRIPTION
This avoids a ValueError being raised to the user interface when a user attempts Actions > Duplicate for multiple users at once.