### PR TITLE
[18.0][IMP] partner_firstname: name order in form configurable

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -27,6 +27,19 @@ class ResPartner(models.Model):
         readonly=False,
     )
 
+    form_has_lastname_first = fields.Boolean(compute="_compute_form_has_lastname_first")
+
+    def _compute_form_has_lastname_first(self):
+        default_order = (
+            self.env["res.config.settings"].sudo()._partner_names_order_default()
+        )
+        self.form_has_lastname_first = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("partner_names_order", default_order)
+            != "first_last"
+        )
+
     @api.model
     def name_fields_in_vals(self, vals):
         """Method to check if any name fields are in `vals`."""

--- a/partner_firstname/views/res_partner.xml
+++ b/partner_firstname/views/res_partner.xml
@@ -16,12 +16,18 @@
             <xpath expr="//h1//field[@id='company']/.." position="before">
                 <group invisible="is_company">
                     <field
+                        invisible="not form_has_lastname_first"
                         name="lastname"
-                        required="not firstname and not is_company and type == 'contact'"
+                        required="form_has_lastname_first and not firstname and not is_company and type == 'contact'"
                     />
                     <field
                         name="firstname"
                         required="not lastname and not is_company and type == 'contact'"
+                    />
+                    <field
+                        invisible="form_has_lastname_first"
+                        name="lastname"
+                        required="not form_has_lastname_first and not firstname and not is_company and type == 'contact'"
                     />
                 </group>
             </xpath>
@@ -48,12 +54,18 @@
                 <div class="oe_edit_only">
                     <group invisible="is_company">
                         <field
+                            invisible="not form_has_lastname_first"
                             name="lastname"
-                            required="not firstname and not is_company and type == 'contact'"
+                            required="form_has_lastname_first and not firstname and not is_company and type == 'contact'"
                         />
                         <field
                             name="firstname"
                             required="not lastname and not is_company and type == 'contact'"
+                        />
+                        <field
+                            invisible="form_has_lastname_first"
+                            name="lastname"
+                            required="not form_has_lastname_first and not firstname and not is_company and type == 'contact'"
                         />
                     </group>
                 </div>
@@ -74,12 +86,18 @@
                     <field name="is_company" invisible="True" />
                     <group invisible="is_company">
                         <field
+                            invisible="not form_has_lastname_first"
                             name="lastname"
-                            required="not firstname and not is_company and type == 'contact'"
+                            required="form_has_lastname_first and not firstname and not is_company and type == 'contact'"
                         />
                         <field
                             name="firstname"
                             required="not lastname and not is_company and type == 'contact'"
+                        />
+                        <field
+                            invisible="form_has_lastname_first"
+                            name="lastname"
+                            required="form_has_lastname_first and not firstname and not is_company and type == 'contact'"
                         />
                     </group>
                 </div>

--- a/partner_firstname/views/res_user.xml
+++ b/partner_firstname/views/res_user.xml
@@ -10,8 +10,17 @@
             </xpath>
             <xpath expr="//field[@name='email']" position="after">
                 <group>
-                    <field name="lastname" required="not firstname" />
+                    <field
+                        name="lastname"
+                        required="form_has_lastname_first and not firstname"
+                        invisible="not form_has_lastname_first"
+                    />
                     <field name="firstname" required="not lastname" />
+                    <field
+                        name="lastname"
+                        required="not form_has_lastname_first and not firstname"
+                        invisible="form_has_lastname_first"
+                    />
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
This change makes the order in the form configurable in the settings.
![image](https://github.com/user-attachments/assets/2fe7c09a-bfa7-4111-be7d-65f6f5ac6b8b)

I am not very happy with the **form_has_lastname_first** field in **res.partner**. Is there a better way to implement this?