### PR TITLE
[18.0][FIX] partner_firstname: res.partner copy() not honoring defaults

### DIFF
--- a/base_partner_sequence/models/partner.py
+++ b/base_partner_sequence/models/partner.py
@@ -25,11 +25,12 @@ class ResPartner(models.Model):
                 vals["ref"] = self._get_next_ref(vals=vals)
         return super().create(vals_list)
 
-    def copy(self, default=None):
-        default = default or {}
-        if self._needs_ref():
-            default["ref"] = self._get_next_ref()
-        return super().copy(default=default)
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        for record, vals in zip(self, vals_list, strict=False):
+            if record._needs_ref():
+                vals["ref"] = record._get_next_ref()
+        return vals_list
 
     def write(self, vals):
         for partner in self:

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -83,23 +83,38 @@ class ResPartner(models.Model):
             ).create([vals])
         return created_partners
 
-    def get_extra_default_copy_values(self):
+    def get_extra_default_copy_values(self, default=None):
         """Method to add '(copy)' suffix to lastname or firstname, depending on name
         order configuration.
         """
-        if self._get_names_order() == "first_last":
-            return {
-                "lastname": _("%s (copy)", self.lastname)
-                if self.lastname
-                else _("(copy)")
+        default = default or {}
+        if default.get("name"):
+            values = self._get_inverse_name(default["name"], self.is_company)
+        else:
+            values = {
+                "firstname": default.get("firstname", self.firstname) or "",
+                "lastname": default.get("lastname", self.lastname) or "",
             }
-        return {
-            "firstname": _("%s (copy)", self.firstname)
-            if self.firstname
-            else _("(copy)")
-        }
+            if self._get_names_order() == "first_last":
+                if not default.get("lastname"):
+                    values["lastname"] = (
+                        _("%s (copy)", values["lastname"])
+                        if values["lastname"]
+                        else _("(copy)")
+                    )
+            else:
+                if not default.get("firstname"):
+                    values["firstname"] = (
+                        _("%s (copy)", values["firstname"])
+                        if values["firstname"]
+                        else _("(copy)")
+                    )
+            values["name"] = self._get_computed_name(
+                values["lastname"], values["firstname"]
+            )
+        return values
 
-    def copy(self, default=None):
+    def copy_data(self, default=None):
         """Ensure partners are copied right.
 
         Odoo adds ``(copy)`` to the end of :attr:`~.name`, but that would get
@@ -107,13 +122,11 @@ class ResPartner(models.Model):
         and lastname fields.
         """
         default = default or {}
-        records = self.browse()
-        for record in self:
-            extra_default_values = record.get_extra_default_copy_values()
-            records |= super(ResPartner, record.with_context(copy=True)).copy(
-                default | extra_default_values
-            )
-        return records
+        vals_list = super().copy_data(default=default)
+        return [
+            dict(vals, **partner.get_extra_default_copy_values(default))
+            for partner, vals in zip(self, vals_list, strict=False)
+        ]
 
     @api.depends("firstname", "lastname")
     def _compute_name(self):

--- a/partner_firstname/tests/base.py
+++ b/partner_firstname/tests/base.py
@@ -1,9 +1,27 @@
 # Copyright 2014 Nemry Jonathan (Acsone SA/NV) (http://www.acsone.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import functools
+
 from odoo.tests import TransactionCase
 
 from .. import exceptions as ex
+
+
+def partner_names_orders(func):
+    """Execute test method for each partner_names_order selection."""
+
+    @functools.wraps(func)
+    def _orders(self):
+        for order, _title in self.env[
+            "res.config.settings"
+        ]._partner_names_order_selection():
+            with self.subTest(order=order), self.env.cr.savepoint() as sp:
+                self.env["ir.config_parameter"].set_param("partner_names_order", order)
+                func(self)
+                sp.rollback()
+
+    return _orders
 
 
 class MailInstalled:

--- a/partner_firstname/tests/test_copy.py
+++ b/partner_firstname/tests/test_copy.py
@@ -3,7 +3,64 @@
 
 from odoo.tests import TransactionCase
 
-from .base import MailInstalled
+from .base import MailInstalled, partner_names_orders
+
+
+class PartnerCase(TransactionCase):
+    """Test ``res.partner``."""
+
+    def setUp(self):
+        super().setUp()
+        self.original = self.env.ref("base.partner_demo")
+
+    def compare(self, copy, *, firstname="Marc2", lastname="Demo2"):
+        self.assertEqual(copy.lastname, lastname)
+        self.assertEqual(copy.firstname, firstname)
+        name = {
+            "last_first": f"{lastname} {firstname}",
+            "last_first_comma": f"{lastname}, {firstname}",
+            "first_last": f"{firstname} {lastname}",
+        }[self.env["res.partner"]._get_names_order()]
+        self.assertEqual(copy.name, name)
+
+    def test_copy_last_first(self):
+        self.env["ir.config_parameter"].set_param("partner_names_order", "last_first")
+        copy = self.original.copy()
+        self.compare(copy, firstname="Marc (copy)", lastname="Demo")
+
+    def test_copy_last_first_comma(self):
+        self.env["ir.config_parameter"].set_param(
+            "partner_names_order", "last_first_comma"
+        )
+        copy = self.original.copy()
+        self.compare(copy, firstname="Marc (copy)", lastname="Demo")
+
+    def test_copy_first_last(self):
+        self.env["ir.config_parameter"].set_param("partner_names_order", "first_last")
+        copy = self.original.copy()
+        self.compare(copy, firstname="Marc", lastname="Demo (copy)")
+
+    def test_copy_name(self):
+        """Copy original with default name set - firstname lastname not set."""
+        copy = self.original.copy({"name": "Marc2 Demo2"})
+        self.compare(copy)
+
+    @partner_names_orders
+    def test_copy_firstname_lastname(self):
+        """Copy original with default firstname and lastname set"""
+        copy = self.original.copy({"firstname": "Marc2", "lastname": "Demo2"})
+        self.compare(copy)
+
+    def test_copy_firstname_lastname_name(self):
+        """Copy original with default firstname, lastname and name set"""
+        copy = self.original.copy(
+            {
+                "firstname": "Marc2",
+                "lastname": "Demo2",
+                "name": "Marc2 Demo2",
+            }
+        )
+        self.compare(copy)
 
 
 class UserCase(TransactionCase, MailInstalled):
@@ -41,7 +98,12 @@ class UserCase(TransactionCase, MailInstalled):
     def compare(self, copy):
         self.assertEqual(copy.lastname, "Lastname2")
         self.assertEqual(copy.firstname, "Firstname2")
-        self.assertEqual(copy.name, "Firstname2 Lastname2")
+        name = {
+            "last_first": "Lastname2 Firstname2",
+            "last_first_comma": "Lastname2, Firstname2",
+            "first_last": "Firstname2 Lastname2",
+        }[self.env["res.partner"]._get_names_order()]
+        self.assertEqual(copy.name, name)
 
     def test_copy_login(self):
         copy = self.original.copy()
@@ -56,6 +118,7 @@ class UserCase(TransactionCase, MailInstalled):
         copy = self.original.copy({"name": "Firstname2 Lastname2"})
         self.compare(copy)
 
+    @partner_names_orders
     def test_copy_firstname_lastname(self):
         """Copy original with default firstname and lastname set"""
         copy = self.original.copy({"firstname": "Firstname2", "lastname": "Lastname2"})

--- a/partner_second_lastname/models/res_partner.py
+++ b/partner_second_lastname/models/res_partner.py
@@ -22,7 +22,7 @@ class ResPartner(models.Model):
         """Override to check if `lastname2` is in vals."""
         return super().name_fields_in_vals(vals) or vals.get("lastname2")
 
-    def get_extra_default_copy_values(self):
+    def get_extra_default_copy_values(self, default=None):
         """Override to add '(copy)' suffix to lastname2 instead of lastname."""
         if self._get_names_order() == "first_last":
             return {
@@ -30,7 +30,7 @@ class ResPartner(models.Model):
                 if self.lastname2
                 else _("(copy)")
             }
-        return super().get_extra_default_copy_values()
+        return super().get_extra_default_copy_values(default)
 
     @api.model
     def _get_computed_name(self, lastname, firstname, lastname2=None):


### PR DESCRIPTION
This makes get_extra_default_copy_values aware of the default dict passed to copy or copy_data.