### PR TITLE
[18.0][FIX] partner_firstname: res.partner name_create("") fails

### DIFF
--- a/partner_firstname/models/firstname_mixin.py
+++ b/partner_firstname/models/firstname_mixin.py
@@ -133,7 +133,7 @@ class FirstNameMixin(models.AbstractModel):
         """
         # Company name goes to the lastname
         if is_company or not name:
-            parts = [name or False, False]
+            parts = [name or "", ""]
         # Guess name splitting
         else:
             order = self._get_names_order()
@@ -164,9 +164,9 @@ class FirstNameMixin(models.AbstractModel):
         for record in self:
             if any(
                 [
-                    record.is_company and not record.name,
-                    record.firstname_required and not record.firstname,
-                    record.lastname_required and not record.lastname,
+                    record.is_company and type(record.name) is not str,
+                    record.firstname_required and type(record.firstname) is not str,
+                    record.lastname_required and type(record.lastname) is not str,
                 ]
             ):
                 raise exceptions.EmptyNamesError(record, self.env)

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -169,3 +169,10 @@ class ResPartner(models.Model):
     # Disabling SQL constraint givint a more explicit error using a Python
     # contstraint
     _sql_constraints = [("check_name", "CHECK( 1=1 )", "Contacts require a name.")]
+
+    @api.model
+    def name_create(self, name):
+        if not name:
+            record = self.create(self._get_inverse_name(name))
+            return record.id, record.display_name
+        return super().name_create(name)

--- a/partner_firstname/tests/test_create.py
+++ b/partner_firstname/tests/test_create.py
@@ -37,6 +37,11 @@ class PersonCase(TransactionCase):
         """Name is calculated."""
         del self.values["name"]
 
+    def test_only_name(self):
+        """Name is inversed."""
+        del self.values["firstname"]
+        del self.values["lastname"]
+
     def test_wrong_name_value(self):
         """Wrong name value is ignored, name is calculated."""
         self.values["name"] = "BÄD"

--- a/partner_firstname/tests/test_empty.py
+++ b/partner_firstname/tests/test_empty.py
@@ -8,7 +8,6 @@ To have more accurate results, remove the ``mail`` module before testing.
 
 from odoo.tests import TransactionCase
 
-from .. import exceptions as ex
 from .base import MailInstalled
 
 
@@ -22,8 +21,7 @@ class CompanyCase(TransactionCase):
         try:
             data = {"name": self.name}
             model = self.env[self.model].with_context(**self.context)
-            with self.assertRaises(ex.EmptyNamesError):
-                model.create(data)
+            model.create(data)
         finally:
             super().tearDown()
 

--- a/partner_firstname/tests/test_name.py
+++ b/partner_firstname/tests/test_name.py
@@ -96,7 +96,7 @@ class PartnerCompanyCase(BaseCase):
     def test_company_inverse(self):
         """Test the inverse method in a company record."""
         name = "Thïs is a Companŷ"
-        self.expect(name, False, name)
+        self.expect(name, "", name)
         self.original.name = name
 
 

--- a/partner_firstname/tests/test_order.py
+++ b/partner_firstname/tests/test_order.py
@@ -36,3 +36,11 @@ class PartnerNamesOrder(TransactionCase):
             result = self.env["res.partner"]._get_inverse_name(name)
             self.assertEqual(result["lastname"], lastname)
             self.assertEqual(result["firstname"], firstname)
+
+    def test_name_create_empty(self):
+        # See addons/mail/tests/test_res_partner.py test_name_create_corner_cases
+        for name in ("", " ", False, None):
+            with self.subTest(name=name):
+                res_id = self.env["res.partner"].name_create("")[0]
+                record = self.env["res.partner"].browse(res_id)
+                self.assertEqual(record.name, "")

--- a/partner_firstname/tests/test_partner_form.py
+++ b/partner_firstname/tests/test_partner_form.py
@@ -8,8 +8,6 @@ The form operates in onchange mode, with its limitations.
 
 from odoo.tests import Form, TransactionCase
 
-from ..exceptions import EmptyNamesError
-
 
 class PartnerCompanyCase(TransactionCase):
     is_company = True
@@ -21,7 +19,7 @@ class PartnerCompanyCase(TransactionCase):
             partner_form.name = name
 
         self.assertEqual(partner_form.name, name)
-        self.assertEqual(partner_form.firstname, False)
+        self.assertEqual(partner_form.firstname, "")
         self.assertEqual(partner_form.lastname, name)
 
     def test_empty_name(self):
@@ -39,20 +37,18 @@ class PartnerCompanyCase(TransactionCase):
             # call save to  trigger the inverse
             partner_form.save()
             self.assertEqual(partner_form.name, name)
-            self.assertEqual(partner_form.firstname, False)
+            self.assertEqual(partner_form.firstname, "")
             self.assertEqual(partner_form.lastname, name)
 
             # User unsets name
             partner_form.name = ""
-            # call save to  trigger the inverse and therefore raise an exception
-            with self.assertRaises(EmptyNamesError), self.env.cr.savepoint():
-                partner_form.save()
+            partner_form.save()
 
             name += " bis"
             partner_form.name = name
             partner_form.save()
             self.assertEqual(partner_form.name, name)
-            self.assertEqual(partner_form.firstname, False)
+            self.assertEqual(partner_form.firstname, "")
 
             # assert below will fail until merge of
             #   https://github.com/odoo/odoo/pull/45355
@@ -71,7 +67,7 @@ class PartnerContactCase(TransactionCase):
             # Changes firstname, which triggers compute
             partner_form.firstname = firstname
 
-        self.assertEqual(partner_form.lastname, False)
+        self.assertEqual(partner_form.lastname, "")
         self.assertEqual(partner_form.firstname, firstname)
         self.assertEqual(partner_form.name, firstname)
 
@@ -84,7 +80,7 @@ class PartnerContactCase(TransactionCase):
             # Changes lastname, which triggers compute
             partner_form.lastname = lastname
 
-        self.assertEqual(partner_form.firstname, False)
+        self.assertEqual(partner_form.firstname, "")
         self.assertEqual(partner_form.lastname, lastname)
         self.assertEqual(partner_form.name, lastname)
 

--- a/partner_firstname/tests/test_user_form.py
+++ b/partner_firstname/tests/test_user_form.py
@@ -14,7 +14,7 @@ class UserOnchangeCase(TransactionCase):
             # Changes firstname, which triggers onchanges
             user_form.firstname = firstname
 
-        self.assertEqual(user_form.lastname, False)
+        self.assertEqual(user_form.lastname, "")
         self.assertEqual(user_form.firstname, firstname)
         self.assertEqual(user_form.name, firstname)
 
@@ -27,7 +27,7 @@ class UserOnchangeCase(TransactionCase):
             # Changes lastname, which triggers onchanges
             user_form.lastname = lastname
 
-        self.assertEqual(user_form.firstname, False)
+        self.assertEqual(user_form.firstname, "")
         self.assertEqual(user_form.lastname, lastname)
         self.assertEqual(user_form.name, lastname)
 


### PR DESCRIPTION
The name field constraint in core Odoo only requires that name IS NOT NULL, allowing an empty string.

This causes unit tests to fail for the main Odoo `mail` module: 
```
2025-10-05 17:03:43,999 1 ERROR odoo odoo.addons.mail.tests.test_res_partner: ERROR: Subtest TestPartner.test_name_create_corner_cases (sample='', login='admin')
Traceback (most recent call last):
  File "<decorator-gen-130>", line 2, in test_name_create_corner_cases
  File "/usr/lib/python3/dist-packages/odoo/tests/common.py", line 2344, in _users
    func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/addons/mail/tests/test_res_partner.py", line 508, in test_name_create_corner_cases
    self.env['res.partner'].name_create(sample)[0]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/res_partner.py", line 937, in name_create
    partner = self.create(create_values)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-174>", line 2, in create
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 497, in _model_create_multi
    return create(self, [arg])
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/metricwise/oca/partner-contact/partner_firstname/models/res_partner.py", line 84, in create
    ).create([vals])
      ^^^^^^^^^^^^^^
  File "<decorator-gen-23>", line 2, in create
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 498, in _model_create_multi
    return create(self, arg)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/res_partner.py", line 806, in create
    partners = super().create(vals_list)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-57>", line 2, in create
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 498, in _model_create_multi
    return create(self, arg)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/addons/mail/models/mail_thread.py", line 278, in create
    threads = super(MailThread, self).create(vals_list)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-0>", line 2, in create
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 498, in _model_create_multi
    return create(self, arg)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5033, in create
    records = self._create(data_list)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5291, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 1631, in _validate_fields
    check(self)
  File "/usr/local/src/metricwise/oca/partner-contact/partner_firstname/models/res_partner.py", line 261, in _check_name
    raise exceptions.EmptyNamesError(record, self.env)
odoo.addons.partner_firstname.exceptions.EmptyNamesError: ("Error(s) with partner 818's name.", 'No name is set.')
```

Fixes #2227