### PR TITLE
[IMP] base_partner_sequence: add server action to update partners

### DIFF
--- a/base_partner_sequence/README.rst
+++ b/base_partner_sequence/README.rst
@@ -40,6 +40,8 @@ modified from the commercial partner.
 No references are assigned for contacts such as shipping and invoice
 addresses.
 
+The module also adds a server action to update all partners ref.
+
 **Table of contents**
 
 .. contents::
@@ -69,22 +71,22 @@ Authors
 Contributors
 ------------
 
--  Thomas Rehn <thomas.rehn@initos.com>
--  Stefan Rijnhart <stefan@therp.nl>
--  Yannick Vaucher <yannick.vaucher@camptocamp.com>
--  Sandy Carter <sandy.carter@savoirfairelinux.com>
--  Laurent Mignon (ACSONE) <laurent.mignon@acsone.eu>
--  Guewen Baconnier <guewen.baconnier@camptocamp.com>
--  Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
--  Vicent Cubells <vicent.cubells@tecnativa.com>
--  Akim Juillerat <akim.juillerat@camptocamp.com>
--  Cas Vissers <c.vissers@brahoo.nl>
--  Quentin Groulard <quentin.groulard@acsone.eu>
--  Kevin Khao <kevinkhao@gmail.com>
--  Francesco Apruzzese <cescoap@gmail.com>
--  Daniel Reis <dreis@opensourceintegrators.com>
--  Nikul Chaudhary <nchaudhary@opensourceintegrators.com>
--  Khoi (Kien Kim) <khoikk@trobz.com>
+- Thomas Rehn <thomas.rehn@initos.com>
+- Stefan Rijnhart <stefan@therp.nl>
+- Yannick Vaucher <yannick.vaucher@camptocamp.com>
+- Sandy Carter <sandy.carter@savoirfairelinux.com>
+- Laurent Mignon (ACSONE) <laurent.mignon@acsone.eu>
+- Guewen Baconnier <guewen.baconnier@camptocamp.com>
+- Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+- Vicent Cubells <vicent.cubells@tecnativa.com>
+- Akim Juillerat <akim.juillerat@camptocamp.com>
+- Cas Vissers <c.vissers@brahoo.nl>
+- Quentin Groulard <quentin.groulard@acsone.eu>
+- Kevin Khao <kevinkhao@gmail.com>
+- Francesco Apruzzese <cescoap@gmail.com>
+- Daniel Reis <dreis@opensourceintegrators.com>
+- Nikul Chaudhary <nchaudhary@opensourceintegrators.com>
+- Khoi (Kien Kim) <khoikk@trobz.com>
 
 Other credits
 -------------
@@ -92,7 +94,7 @@ Other credits
 The migration of this module from 17.0 to 18.0 was financially supported
 by:
 
--  Camptocamp
+- Camptocamp
 
 Maintainers
 -----------

--- a/base_partner_sequence/__manifest__.py
+++ b/base_partner_sequence/__manifest__.py
@@ -18,7 +18,11 @@
     "website": "https://github.com/OCA/partner-contact",
     "depends": ["base"],
     "summary": "Sets customer's code from a sequence",
-    "data": ["data/partner_sequence.xml", "views/partner_view.xml"],
+    "data": [
+        "data/partner_sequence.xml",
+        "data/ir_actions_server.xml",
+        "views/partner_view.xml",
+    ],
     "installable": True,
     "license": "AGPL-3",
 }

--- a/base_partner_sequence/data/ir_actions_server.xml
+++ b/base_partner_sequence/data/ir_actions_server.xml
@@ -1,0 +1,10 @@
+<odoo>
+    <record id="action_update_partners_ref" model="ir.actions.server">
+        <field name="name">Update Partners Ref</field>
+        <field name="model_id" ref="base.model_res_partner" />
+        <field name="binding_model_id" ref="base.model_res_partner" />
+        <field name="state">code</field>
+        <field name="binding_view_types">list,form</field>
+        <field name="code">action = model.update_partners_ref()</field>
+    </record>
+</odoo>

--- a/base_partner_sequence/models/partner.py
+++ b/base_partner_sequence/models/partner.py
@@ -6,6 +6,8 @@
 
 from odoo import _, api, exceptions, models
 
+BATCH_SIZE = 5000
+
 
 class ResPartner(models.Model):
     """Assigns 'ref' from a sequence on creation and copying"""
@@ -72,3 +74,21 @@ class ResPartner(models.Model):
         to the partner's contacts
         """
         return super()._commercial_fields() + ["ref"]
+
+    def update_partners_ref(self):
+        """Calculate ref of all partners. Called from a server action"""
+        offset = 0
+
+        while True:
+            partners = self.search(
+                [("ref", "=", False)], offset=offset, limit=BATCH_SIZE
+            )
+
+            if not partners:
+                break
+
+            for partner in partners:
+                if partner._needs_ref():
+                    partner.write({})
+
+            offset += BATCH_SIZE

--- a/base_partner_sequence/readme/DESCRIPTION.md
+++ b/base_partner_sequence/readme/DESCRIPTION.md
@@ -9,3 +9,5 @@ modified from the commercial partner.
 
 No references are assigned for contacts such as shipping and invoice
 addresses.
+
+The module also adds a server action to update all partners ref.

--- a/base_partner_sequence/static/description/index.html
+++ b/base_partner_sequence/static/description/index.html
@@ -379,6 +379,7 @@ contacts. The field is visible on the contacts, but it can only be
 modified from the commercial partner.</p>
 <p>No references are assigned for contacts such as shipping and invoice
 addresses.</p>
+<p>The module also adds a server action to update all partners ref.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/base_partner_sequence/tests/test_base_partner_sequence.py
+++ b/base_partner_sequence/tests/test_base_partner_sequence.py
@@ -57,3 +57,10 @@ class TestBasePartnerSequence(BaseCommon):
         contact.write({"parent_id": False})
         self.assertTrue(contact.ref)
         self.assertFalse(contact.ref == self.partner.ref)
+
+    def test_update_partners_ref(self):
+        """Assert that after the ir_action_server a sequence is set
+        on a partner that did not have one previously"""
+        self.partner.write({"ref": False})
+        self.partner.update_partners_ref()
+        self.assertTrue(self.partner.ref)


### PR DESCRIPTION
When installing this module on a large db with a lot of res.partners we want to be able to quickly add a ref on them.

This pr adds a server action that allows us to do that.