### PR TITLE
[17.0][IMP] partner_property: add kanban view to display properties

### DIFF
--- a/partner_property/views/res_partner_views.xml
+++ b/partner_property/views/res_partner_views.xml
@@ -20,4 +20,24 @@
             </notebook>
         </field>
     </record>
+    <record id="res_partner_kanban_view" model="ir.ui.view">
+        <field name="name">res.partner.kanban</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.res_partner_kanban_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='active']" position="after">
+                <field name="properties_company_id" />
+            </xpath>
+            <xpath expr="//div[hasclass('o_kanban_record_bottom')]" position="before">
+                <div>
+                    <t t-if="record.is_company.raw_value">
+                        <field name="properties_type_company" widget="properties" />
+                    </t>
+                    <t t-if="!record.is_company.raw_value">
+                        <field name="properties_type_person" widget="properties" />
+                    </t>
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit, the field properties marked as `Display in Cards` were not displayed in the kanban view.
After this commit, the field properties marked as `Display in Cards` are displayed correctly in the kanban view.

![image](https://github.com/user-attachments/assets/b9e8e752-3f5e-4f61-80e5-2ac068adb72b)

![image](https://github.com/user-attachments/assets/5e16ea65-4b9f-4253-acd8-47117eabe02d)

TT55430
@Tecnativa @pedrobaeza @victoralmau @pilarvargas-tecnativa could you please review this?