### PR TITLE
[18.0][FIX] partner_tz: fix partner form rendering

### DIFF
--- a/partner_tz/views/res_partner.xml
+++ b/partner_tz/views/res_partner.xml
@@ -5,9 +5,10 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <field name="vat" position="before">
+            <!-- Put fields in the same group than address block -->
+            <xpath expr="//field[@name='street']/ancestor::group[1]" position="inside">
                 <field name="tz" />
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
When `base_vat` module is installed, the rendering of partner form is broken, with `tz` field displayed without label and "Tax ID" label at the wrong place:
![image](https://github.com/user-attachments/assets/40483f65-3037-4b50-a577-6d26087641d2)

Once fixed:
![image](https://github.com/user-attachments/assets/8dff6049-773b-4dc6-814d-7cad75e24091)