### PR TITLE
[14.0][IMP][partner_tier_validation] ensure default state at partner …

### DIFF
--- a/partner_tier_validation/models/res_partner.py
+++ b/partner_tier_validation/models/res_partner.py
@@ -48,3 +48,11 @@ class ResPartner(models.Model):
         if "stage_id" in vals and vals.get("stage_id") in self._state_from:
             self.restart_validation()
         return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        default_stage_id = self._get_default_stage_id().id
+        for vals in vals_list:
+            if not vals.get("stage_id") and default_stage_id:
+                vals["stage_id"] = default_stage_id
+        return super().create(vals_list)

--- a/partner_tier_validation/tests/test_tier_validation.py
+++ b/partner_tier_validation/tests/test_tier_validation.py
@@ -93,3 +93,20 @@ class TestPartnerTierValidation(common.SavepointCase):
         # Can move to confirmed state without approval
         contact.write({"stage_id": self.stage_confirmed.id})
         self.assertEqual(contact.state, "confirmed")
+
+    def test_create_partner_with_default_state(self):
+        new_partner = self.env["res.partner"].create(
+            {
+                "name": "Company bis for test",
+            }
+        )
+        self.assertEqual(new_partner.state, "draft")
+
+    def test_create_partner_with_stage_defined(self):
+        new_partner = self.env["res.partner"].create(
+            {
+                "name": "Not Company for test",
+                "stage_id": self.stage_confirmed.id,
+            }
+        )
+        self.assertEqual(new_partner.state, "confirmed")


### PR DESCRIPTION
When creating a new partner, we can directly set a normal / confirmed state on it, without validation.
This PR avoid that by forcing the default stage on partner creation.