### PR TITLE
[16.0][FIX] partner_contact_department: zip() takes no keyword arguments

### DIFF
--- a/partner_contact_department/models/res_partner.py
+++ b/partner_contact_department/models/res_partner.py
@@ -47,7 +47,7 @@ class ResPartnerDepartment(models.Model):
     def name_get(self):
         """Prepend parent name to department name."""
         result = super().name_get()
-        for position, ((id_, name), rec) in enumerate(zip(result, self, strict=True)):
+        for position, ((id_, name), rec) in enumerate(zip(result, self)):
             while rec.parent_id.name:
                 name = f"{rec.parent_id.name} / {name}"
                 rec = rec.parent_id


### PR DESCRIPTION
`strict=True` is available only in Python 3.10+ and is incompatible with Odoo 16.0 that runs on a lower version of Python.