### PR TITLE
[17.0][IMP] partner_property: Display the appropriate company in partner property field definitions

### DIFF
--- a/partner_property/models/res_company.py
+++ b/partner_property/models/res_company.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2024-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -55,3 +55,34 @@ class ResCompany(models.Model):
                 item.partner_properties_definition_person, item
             )
             ICP.sudo().set_param("partner_property.properties_definition_person", value)
+
+    @api.model
+    def web_search_read(
+        self, domain, specification, offset=0, limit=None, order=None, count_limit=None
+    ):
+        """Override the method to return the "appropriate" company if searched
+        by any of the fields.
+        This method is used to display the search fields (Add custom filter), the
+        properties in the partners are multi-company, and the domain
+        [("partner_properties_definition_company", "!=', False)] would return all
+        the companies, in that case the data of the last company would be displayed,
+        which would be totally confusing.
+        Example:
+        Existing companies: Company A + Company B + Company C
+        Selected company: Company A
+        Now it will show: Property custom (Company A).
+        """
+        f_names = [
+            "partner_properties_definition_company",
+            "partner_properties_definition_person",
+        ]
+        if any(dom[0] in f_names for dom in domain):
+            domain = [("id", "=", self.env.company.id)]
+        return super().web_search_read(
+            domain,
+            specification,
+            offset=offset,
+            limit=limit,
+            order=order,
+            count_limit=count_limit,
+        )


### PR DESCRIPTION
Display the appropriate company in partner property field definitions

**Before**
![antes](https://github.com/user-attachments/assets/38fb6833-274b-4527-8146-9e38b64ce7a0)

**After**
![despues](https://github.com/user-attachments/assets/98ab06ed-d22d-4cac-91e4-b1f5cfe73717)

Please @pedrobaeza and @carlos-lopez-tecnativa and @carlosdauden can you review it?

@Tecnativa TT56823