### PR TITLE
[18.0][FIX] partner_stage: Add 'order' in _read_group_stage_id to fix group

### DIFF
--- a/partner_stage/models/res_partner.py
+++ b/partner_stage/models/res_partner.py
@@ -14,12 +14,13 @@ class Partner(models.Model):
         )
 
     @api.model
-    def _read_group_stage_id(self, states, domain):
-        return states.search([])
+    def _read_group_stage_ids(self, stages, domain):
+        order = stages._order or "sequence, id"
+        return stages.search([], order=order)
 
     stage_id = fields.Many2one(
         comodel_name="res.partner.stage",
-        group_expand="_read_group_stage_id",
+        group_expand="_read_group_stage_ids",
         default=_get_default_stage_id,
         copy=False,
         index=True,

--- a/partner_stage/tests/test_partner_stage.py
+++ b/partner_stage/tests/test_partner_stage.py
@@ -70,7 +70,7 @@ class TestPartnerStage(TransactionCase):
         default_stage = self.env.ref("partner_stage.partner_stage_active")
         new_partner = self.Partner.create({"name": "A Partner"})
         self.assertTrue(new_partner.stage_id, default_stage)
-        states = new_partner._read_group_stage_id(self.Stage, [])
+        states = new_partner._read_group_stage_ids(self.Stage, [])
         self.assertTrue(states.ids, [1, 2, 3])
 
     def test_03_stage_default_constraint(self):


### PR DESCRIPTION
Added 'order' argument with a default value to avoid errors in staging in the contacts view.

This PR replaces the previous one (https://github.com/OCA/partner-contact/pull/1985), which was closed.