### PR TITLE
[18.0] [Improvement] [UI] partner_firstname: Improve partner names order settings view layout and styling (#1)

### DIFF
--- a/partner_firstname/views/base_config_view.xml
+++ b/partner_firstname/views/base_config_view.xml
@@ -5,23 +5,31 @@
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[@id='companies']" position='after'>
-                <block
-                    title="Partner Names Order"
-                    name="partner_names_order_setting_container"
-                >
-                    <setting>
-                        <field name="partner_names_order" nolabel="1" />
-                        <field name="partner_names_order_changed" invisible="1" />
-                        <button
-                            name="action_recalculate_partners_name"
-                            string="Recalculate names"
-                            icon="fa-play"
-                            type="object"
-                            help="Recalculate names for all partners. This process could take so much time if there are more than 10,000 active partners"
-                            invisible="not partner_names_order_changed"
-                        />
-                    </setting>
-                </block>
+                <h2>Partner Names Order</h2>
+                <div class="row mt16 o_settings_container" name="partner_names_order_setting_container">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="partner_names_order" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="partner_names_order" />
+                            <div class="text-muted">
+                                Configure how partner names are displayed
+                            </div>
+                            <div class="content-group mt16" invisible="not partner_names_order_changed">
+                                <field name="partner_names_order_changed" invisible="1" />
+                                <button
+                                    name="action_recalculate_partners_name"
+                                    string="Recalculate names"
+                                    icon="fa-play"
+                                    type="object"
+                                    class="btn-secondary"
+                                    help="Recalculate names for all partners. This process could take so much time if there are more than 10,000 active partners"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>

--- a/partner_firstname/views/base_config_view.xml
+++ b/partner_firstname/views/base_config_view.xml
@@ -6,7 +6,10 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@id='companies']" position='after'>
                 <h2>Partner Names Order</h2>
-                <div class="row mt16 o_settings_container" name="partner_names_order_setting_container">
+                <div
+                    class="row mt16 o_settings_container"
+                    name="partner_names_order_setting_container"
+                >
                     <div class="col-xs-12 col-md-6 o_setting_box">
                         <div class="o_setting_left_pane">
                             <field name="partner_names_order" />
@@ -16,8 +19,14 @@
                             <div class="text-muted">
                                 Configure how partner names are displayed
                             </div>
-                            <div class="content-group mt16" invisible="not partner_names_order_changed">
-                                <field name="partner_names_order_changed" invisible="1" />
+                            <div
+                                class="content-group mt16"
+                                invisible="not partner_names_order_changed"
+                            >
+                                <field
+                                    name="partner_names_order_changed"
+                                    invisible="1"
+                                />
                                 <button
                                     name="action_recalculate_partners_name"
                                     string="Recalculate names"


### PR DESCRIPTION
This PR refactors the configuration view of `partner_firstname` to use the modern settings layout introduced in Odoo 18.0.

- Replaces legacy `<block>`/`<setting>` tags with `o_setting_box` structure
- Ensures compatibility with new layout expectations
- No functional change, purely cosmetic/UI alignment


Suggested labels: [18.0], [Improvement], [UI]

-- 
Task migrated from legacy style to comply with OCA UI guidelines for 18.0
