### PR TITLE
[17.0][FIX] partner_identification ca.po translation

### DIFF
--- a/partner_identification/i18n/ca.po
+++ b/partner_identification/i18n/ca.po
@@ -160,7 +160,7 @@ msgid ""
 "({error})"
 msgstr ""
 "Error en avaluar el codi de validació id_category: \n"
-" {nom} \n"
+" {name} \n"
 "({error})"
 
 #. module: partner_identification


### PR DESCRIPTION
The purpose of this PR is to fix a pre-commit issue caused by a translation parsing error in the partner_identification/i18n/ca.po file.

You can see the pre-commit failures in the following related PRs:
- https://github.com/OCA/partner-contact/pull/2018
- https://github.com/OCA/partner-contact/pull/2079