### PR TITLE
[18.0][FIX] base_location_nuts: Restrict permissions for creation and edition of Nuts

### DIFF
--- a/base_location_nuts/security/ir.model.access.csv
+++ b/base_location_nuts/security/ir.model.access.csv
@@ -1,4 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"access_res_partner_nuts_user_all","res_partner_nuts group_partner_manager_all","model_res_partner_nuts","base.group_portal",1,0,0,0
-"access_res_partner_nuts_user","res_partner_nuts group_partner_manager","model_res_partner_nuts","base.group_partner_manager",1,1,1,1
-"access_nuts_import","nuts.import access","model_nuts_import","base.group_partner_manager",1,1,1,1
+"access_res_partner_nuts_user_all","res_partner_nuts group_partner_portal_all","model_res_partner_nuts","base.group_portal",1,0,0,0
+"access_res_partner_nuts_manager","res_partner_nuts group_partner_manager","model_res_partner_nuts","base.group_partner_manager",1,0,0,0
+"access_res_partner_nuts_full","res_partner_nuts group_partner_manager","model_res_partner_nuts","base.group_system",1,1,1,1
+"access_nuts_import","nuts.import access","model_nuts_import","base.group_system",1,1,1,1

--- a/base_location_nuts/tests/test_base_location_nuts.py
+++ b/base_location_nuts/tests/test_base_location_nuts.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from requests.exceptions import HTTPError
 
+from odoo.exceptions import AccessError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase, new_test_user
 from odoo.tools import mute_logger
@@ -21,7 +22,7 @@ class TestBaseLocationNuts(TransactionCase):
         cls.uid = new_test_user(
             cls.env,
             login="test-nuts-import-user",
-            groups="base.group_partner_manager",
+            groups="base.group_system",
         )
         cls.nut_form = Form(cls.env["nuts.import"].with_user(cls.uid))
         cls.nut_wizard = cls.nut_form.save()
@@ -57,6 +58,15 @@ class TestBaseLocationNuts(TransactionCase):
         )
         cls.nuts4_2.state_id = cls.state_2
         cls.country_1.state_level = 4
+
+    def test_nuts_import_not_admin_user(self):
+        user = new_test_user(
+            self.env,
+            login="test-not-admin-user",
+            groups="base.group_user",
+        )
+        with self.assertRaises(AccessError):
+            Form(self.env["nuts.import"].with_user(user))
 
     def test_onchange_nuts_country(self):
         self.partner.nuts1_id = self.nuts1_2


### PR DESCRIPTION
Only users with administrator rights can create and edit Nuts. Users without administrator rights can only read Nuts.

Issue https://github.com/OCA/partner-contact/issues/2122

A short video with functional tests
https://www.loom.com/share/ab3b7cc464aa43898062620422fa04a5?sid=28da0f60-3a72-4b1c-a8ac-7a163a1ca11b

@moduon

MT-11302