### PR TITLE
[18.0][FIX] partner_email_check: Fix translation warning

### DIFF
--- a/partner_email_check/models/res_partner.py
+++ b/partner_email_check/models/res_partner.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import _, api, models
+from odoo import api, models
 from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ try:
         validate_email,
     )
 except ImportError:
-    _logger.debug(_("Cannot import 'email_validator'."))
+    _logger.debug("Cannot import 'email-validator'.")
 
     validate_email = None
 


### PR DESCRIPTION
This purpose of this PR is to fixes warning raised when loading module `partner_email_check`.

As you can see, @iggups already mentioned this in issue [#2128](https://github.com/OCA/partner-contact/issues/2128).