### PR TITLE
[16.0][FIX] partner_industry_secondary: Fix industry populate

### DIFF
--- a/partner_industry_secondary/models/res_partner_industry.py
+++ b/partner_industry_secondary/models/res_partner_industry.py
@@ -4,9 +4,11 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
 # Copyright 2019 Tecnativa - Cristina Martin R.
 # Copyright 2025 Moduon - Eduardo de Miguel
+# Copyright 2025, 2026 XCG SAS
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, exceptions, fields, models
+from odoo.tools import populate
 
 
 class ResPartnerIndustry(models.Model):
@@ -66,3 +68,19 @@ class ResPartnerIndustry(models.Model):
         if "name" not in default or default["name"] == self.name:
             default["name"] = self.name + " 2"
         return super(ResPartnerIndustry, self).copy(default=default)
+
+    def _populate_factories(self):
+        result = super()._populate_factories()
+        modified_result = []
+        # search for name to replace it to avoid empty names
+        for field_name, populate_function in result:
+            if field_name == "name":
+                modified_result.append(
+                    (
+                        field_name,
+                        populate.cartesian(["Industry name {counter}"], [1.0]),
+                    )
+                )
+            else:
+                modified_result.append((field_name, populate_function))
+        return modified_result

--- a/partner_industry_secondary/models/res_partner_industry.py
+++ b/partner_industry_secondary/models/res_partner_industry.py
@@ -53,15 +53,19 @@ class ResPartnerIndustry(models.Model):
 
     @api.constrains("name", "parent_id")
     def _check_uniq_name(self):
-        if (
-            self.search_count(
-                [("name", "=", self.name), ("parent_id", "=", self.parent_id.id)]
-            )
-            > 1
-        ):
-            raise exceptions.ValidationError(
-                _("Error! Industry with same name and parent already exists.")
-            )
+        for industry in self:
+            if (
+                self.search_count(
+                    [
+                        ("name", "=", industry.name),
+                        ("parent_id", "=", industry.parent_id.id),
+                    ]
+                )
+                > 1
+            ):
+                raise exceptions.ValidationError(
+                    _("Error! Industry with same name and parent already exists.")
+                )
 
     def copy(self, default=None):
         default = default or {}

--- a/partner_industry_secondary/readme/newsframents/+populate.feature.rst
+++ b/partner_industry_secondary/readme/newsframents/+populate.feature.rst
@@ -1,0 +1,1 @@
+Fix industry populate to take to handle required name.


### PR DESCRIPTION
Fix industry populate to take to handle required name.

The fix needs to be ported to 17.0 and 18.0 too, as it affects those versions too.
I have not looked in older versions.