### PR TITLE
[ADD] Migrate partner_coc to 16.0

### DIFF
--- a/partner_identification/migrations/16.0.1.0.0/post-migration.py
+++ b/partner_identification/migrations/16.0.1.0.0/post-migration.py
@@ -1,0 +1,29 @@
+# Copyright 2025 Therp BV (https://www.therp.nl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def migrate_partner_coc(env):
+    """Migrate the id number of the now non-existent module partner_coc."""
+    openupgrade.logged_query(
+        env.cr,
+        """
+        WITH xmlid AS (
+            SELECT res_id AS id FROM ir_model_data
+            WHERE module = 'partner_coc' AND name = 'id_category_coc'
+            LIMIT 1
+        )
+        UPDATE res_partner rp SET company_registry = r.name
+        FROM (
+            SELECT partner_id, name FROM res_partner_id_number
+            WHERE category_id = (SELECT id FROM xmlid)
+        ) AS r
+        WHERE rp.id = r.partner_id;
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, _):
+    migrate_partner_coc(env)


### PR DESCRIPTION
The module `partner_coc` does not exist anymore in 16.0, and it allowed a `res.partner.id.number` record to be used as a 'company registry' number field.
In odoo 16 we have `company_registry` on `res.partner` in the odoo base module, which should be the reason that `partner_coc` doesn't exist anymore.
But because the module doesn't exist anymore there isn't really a nice place to put this migration query.
So now I've put it in `partner_identification`.

This is a continuation from this PR: https://github.com/OCA/partner-contact/pull/1597
Pedro recommended putting it in the migration of the base module, but I feel that is still a weird place to migrate something which is not part of the odoo core modules.