### PR TITLE
17.0: base_partner_company_group: enable list → form navigation for c…

### DIFF
--- a/base_partner_company_group/README.rst
+++ b/base_partner_company_group/README.rst
@@ -60,13 +60,13 @@ Authors
 Contributors
 ------------
 
--  Timon Tschanz <timon.tschanz@camptocamp.com>
--  Yannick Vaucher <yannick.vaucher@camptocamp.com>
--  `Tecnativa <https://www.tecnativa.com>`__:
+- Timon Tschanz <timon.tschanz@camptocamp.com>
+- Yannick Vaucher <yannick.vaucher@camptocamp.com>
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-   -  Ernesto Tejeda
+  - Ernesto Tejeda
 
--  Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
+- Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
 
 Maintainers
 -----------

--- a/base_partner_company_group/__manifest__.py
+++ b/base_partner_company_group/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Partner Company Group",
     "summary": "Adds the possibility to add a company group to a company",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "category": "Sales",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/base_partner_company_group/views/contact_view.xml
+++ b/base_partner_company_group/views/contact_view.xml
@@ -47,7 +47,7 @@
         <field name="name">Company group members</field>
         <field name="res_model">res.partner</field>
         <field name="binding_model_id" ref="model_res_partner" />
-        <field name="view_mode">tree</field>
+        <field name="view_mode">tree,form</field>
         <field name="target">current</field>
         <field name="context">{'create': False}</field>
         <field


### PR DESCRIPTION
[FIX] base_partner_company_group: open form from Contacts list on row click

What
- XML-only fix so clicking a contact in the list (tree) view opens its form.

Why
- Current list view didn’t open the form on click, slowing navigation/editing.

How
- Adjusted ir.actions.act_window XML:
  - Ensure action `view_mode` includes both `tree,form`.

Scope
- Module: base_partner_company_group
- Files: XML view(s) only
- No Python/model changes.

Testing
- Verified locally: clicking a row in Contacts list opens the form.
- `pre-commit run --all-files` passes.
