### PR TITLE
[18.0] [FIX] partner_property: broken partner/user export

### DIFF
--- a/partner_property/models/res_company.py
+++ b/partner_property/models/res_company.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.osv.expression import FALSE_DOMAIN, TRUE_DOMAIN
 
 
 class ResCompany(models.Model):
@@ -11,11 +12,13 @@ class ResCompany(models.Model):
         string="Partner Properties (company)",
         compute="_compute_partner_properties_definition_company",
         inverse="_inverse_partner_properties_definition_company",
+        search="_search_partner_properties_definition_company",
     )
     partner_properties_definition_person = fields.PropertiesDefinition(
         string="Partner Properties (person)",
         compute="_compute_partner_properties_definition_person",
         inverse="_inverse_partner_properties_definition_person",
+        search="_search_partner_properties_definition_person",
     )
 
     @api.depends_context("company")
@@ -55,6 +58,22 @@ class ResCompany(models.Model):
                 item.partner_properties_definition_person, item
             )
             ICP.sudo().set_param("partner_property.properties_definition_person", value)
+
+    def _search_partner_properties_definition_company(self, operator, value):
+        if operator not in ("=", "!=") or value is not False:  # pragma: no cover
+            raise NotImplementedError("Only = and != operators are supported")
+        ICP = self.env["ir.config_parameter"]
+        value = ICP.sudo().get_param("partner_property.properties_definition_company")
+        condition = operator == "!=" and bool(value) or not value
+        return condition and TRUE_DOMAIN or FALSE_DOMAIN
+
+    def _search_partner_properties_definition_person(self, operator, value):
+        if operator not in ("=", "!=") or value is not False:  # pragma: no cover
+            raise NotImplementedError("Only = and != operators are supported")
+        ICP = self.env["ir.config_parameter"]
+        value = ICP.sudo().get_param("partner_property.properties_definition_person")
+        condition = operator == "!=" and bool(value) or not value
+        return condition and TRUE_DOMAIN or FALSE_DOMAIN
 
     @api.model
     def web_search_read(

--- a/partner_property/models/res_partner.py
+++ b/partner_property/models/res_partner.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.osv.expression import SQL_OPERATORS
+from odoo.tools.sql import SQL
 
 
 class ResPartner(models.Model):
@@ -9,6 +11,7 @@ class ResPartner(models.Model):
 
     properties_company_id = fields.Many2one(
         compute="_compute_properties_company_id",
+        search="_search_properties_company_id",
         comodel_name="res.company",
     )
     properties_type_company = fields.Properties(
@@ -25,3 +28,27 @@ class ResPartner(models.Model):
     def _compute_properties_company_id(self):
         for item in self:
             item.properties_company_id = item.company_id or self.env.company
+
+    def _search_properties_company_id(self, operator, value):
+        self.flush_model(["company_id"])
+        query = self._where_calc([])
+        query.add_where(
+            SQL(
+                "%s %s %s",
+                self._field_to_sql(
+                    "properties_company_id", "properties_company_id", query
+                ),
+                SQL_OPERATORS[operator],
+                value,
+            )
+        )
+        return [("id", "in", query)]
+
+    def _field_to_sql(self, alias, fname, query=None, flush: bool = True) -> SQL:
+        # OVERRIDE to allow to export the properties
+        if fname == "properties_company_id":
+            return SQL(
+                """COALESCE(company_id, %(env_company)s)""",
+                env_company=self.env.company.id,
+            )
+        return super()._field_to_sql(alias, fname, query, flush)

--- a/partner_property/tests/__init__.py
+++ b/partner_property/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_export
 from . import test_res_partner

--- a/partner_property/tests/test_export.py
+++ b/partner_property/tests/test_export.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import json
+
+from odoo.tests import HttpCase
+
+
+class TextPartnerExport(HttpCase):
+    def test_export_get_fields(self):
+        """Text the export wizard get_fields method.
+
+        Due to the way `properties_company_id` is computed and used in the path of the
+        properties definition, the export wizard fails as it expects a stored field.
+
+        A fix is done by implementing the `_field_to_sql` and
+        `_search_properties_company_id` methods. This unit test would fail without it.
+
+        .. traceback::
+
+            File "/odoo/src/odoo/addons/web/controllers/export.py", line 400, in get_fields
+                exportable_fields.update(self._get_property_fields(fields, model, domain=domain))
+                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            File "/odoo/src/odoo/addons/web/controllers/export.py", line 321, in _get_property_fields
+                field_to_get = Model._field_to_sql(Model._table, definition_record, self_subquery)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            File "/odoo/src/odoo/odoo/models.py", line 2976, in _field_to_sql
+                raise ValueError(f"Cannot convert {field} to SQL because it is not stored")
+            ValueError: Cannot convert res.partner.properties_company_id to SQL because it is not stored
+        """  # noqa: E501
+        self.authenticate("admin", "admin")
+        self.url_open(
+            "/web/export/get_fields",
+            data=json.dumps(
+                {
+                    "params": {
+                        "model": "res.partner",
+                        "import_compat": True,
+                        "domain": [("id", "in", self.env.user.partner_id.ids)],
+                    }
+                }
+            ),
+            headers={"Content-Type": "application/json"},
+        ).raise_for_status()

--- a/partner_property/tests/test_res_partner.py
+++ b/partner_property/tests/test_res_partner.py
@@ -49,3 +49,73 @@ class TestResPartnerProperty(TransactionCase):
             partner.properties_company_id,
             self.company_b,
         )
+
+    def test_properties_company_id(self):
+        partner = self.env["res.partner"].create({"name": "Partner Test"})
+        # The partner has no company set, so the properties_company_id should
+        # always match the current context company.
+        self.assertEqual(
+            partner.with_company(self.company_a.id).properties_company_id,
+            self.company_a,
+        )
+        self.assertEqual(
+            partner.with_company(self.company_b.id).properties_company_id,
+            self.company_b,
+        )
+        # Searching should also work..
+        self.assertEqual(
+            self.env["res.partner"]
+            .with_company(self.company_a.id)
+            .search(
+                [
+                    ("properties_company_id", "=", self.company_a.id),
+                    ("id", "=", partner.id),
+                ]
+            ),
+            partner,
+        )
+        self.assertEqual(
+            self.env["res.partner"]
+            .with_company(self.company_b.id)
+            .search(
+                [
+                    ("properties_company_id", "=", self.company_b.id),
+                    ("id", "=", partner.id),
+                ]
+            ),
+            partner,
+        )
+        # Except if we set an explicit company.. then it should match that
+        # company regardless of the context company.
+        partner.company_id = self.company_a
+        self.assertEqual(
+            partner.with_company(self.company_a.id).properties_company_id,
+            self.company_a,
+        )
+        self.assertEqual(
+            partner.with_company(self.company_b.id).properties_company_id,
+            self.company_a,
+        )
+        # Searching should also work..
+        self.assertEqual(
+            self.env["res.partner"]
+            .with_company(self.company_a.id)
+            .search(
+                [
+                    ("properties_company_id", "=", self.company_a.id),
+                    ("id", "=", partner.id),
+                ]
+            ),
+            partner,
+        )
+        self.assertFalse(
+            self.env["res.partner"]
+            .with_company(self.company_b.id)
+            .search(
+                [
+                    ("properties_company_id", "=", self.company_b.id),
+                    ("id", "=", partner.id),
+                ]
+            ),
+            partner,
+        )


### PR DESCRIPTION
**Steps to reproduce:**

1. Go in the partner or users list view
2. Select a few records
3. Click on Actions > Export

**Expected:**

The Export wizard should open.

**Result:**

https://github.com/user-attachments/assets/804f6019-d845-48dd-a86a-f6658ba63f77

```
File "/odoo/src/odoo/addons/web/controllers/export.py", line 400, in get_fields
    exportable_fields.update(self._get_property_fields(fields, model, domain=domain))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/odoo/src/odoo/addons/web/controllers/export.py", line 321, in _get_property_fields
    field_to_get = Model._field_to_sql(Model._table, definition_record, self_subquery)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/odoo/src/odoo/odoo/models.py", line 2976, in _field_to_sql
    raise ValueError(f"Cannot convert {field} to SQL because it is not stored")
ValueError: Cannot convert res.partner.properties_company_id to SQL because it is not stored
```