### PR TITLE
[FIX] base_location: add required comment to always-invisible field in res.company view

### DIFF
--- a/base_location/views/res_company_view.xml
+++ b/base_location/views/res_company_view.xml
@@ -15,7 +15,7 @@
                 />
             </field>
             <field name="city" position="after">
-                <field name="country_enforce_cities" invisible="1" />
+                <field name="country_enforce_cities" invisible="1" /><!--technical field for below conditional-->
                 <field name='city_id' invisible="country_enforce_cities == False" />
             </field>
             <field name="city" position="attributes">


### PR DESCRIPTION
This PR adds the missing explanatory comment next to an always-invisible field in base_location/views/res_company_view.xml.
Odoo’s core test base/tests/test_views.py::TestInvisibleField::test_uncommented_invisible_field enforces that any field with invisible="1" (or True) must be accompanied by a comment explaining why it is always invisible. Without the comment, the test fails.