### PR TITLE
[18.0][IMP] base_location_nuts: NUTS fields view in one line

### DIFF
--- a/base_location_nuts/views/res_partner_view.xml
+++ b/base_location_nuts/views/res_partner_view.xml
@@ -5,46 +5,61 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <xpath expr="//sheet/group//field[@name='vat']" position="before">
-                <field name="allowed_nut_ids" invisible="1" />
-                <field
-                    name="nuts1_id"
-                    context="{'default_country_id': country_id, 'default_level': 1}"
-                />
-                <field
-                    name="nuts2_id"
-                    context="{'default_country_id': country_id, 'default_level': 2, 'default_parent_id': nuts1_id}"
-                />
-                <field
-                    name="nuts3_id"
-                    context="{'default_country_id': country_id, 'default_level': 3, 'default_parent_id': nuts2_id}"
-                />
-                <field
-                    name="nuts4_id"
-                    context="{'default_country_id': country_id, 'default_level': 4, 'default_parent_id': nuts3_id}"
-                />
+            <xpath
+                expr="//sheet/group//div[hasclass('o_address_format')]"
+                position="inside"
+            >
+                <div class="o_row">
+                    <field name="allowed_nut_ids" invisible="1" />
+                    <field
+                        name="nuts1_id"
+                        placeholder="NUTS L1"
+                        context="{'default_country_id': country_id, 'default_level': 1}"
+                    />
+                    <field
+                        name="nuts2_id"
+                        placeholder="NUTS L2"
+                        context="{'default_country_id': country_id, 'default_level': 2, 'default_parent_id': nuts1_id}"
+                    />
+                    <field
+                        name="nuts3_id"
+                        placeholder="NUTS L3"
+                        context="{'default_country_id': country_id, 'default_level': 3, 'default_parent_id': nuts2_id}"
+                    />
+                    <field
+                        name="nuts4_id"
+                        placeholder="NUTS L4"
+                        context="{'default_country_id': country_id, 'default_level': 4, 'default_parent_id': nuts3_id}"
+                    />
+                </div>
             </xpath>
             <xpath
-                expr="//field[@name='child_ids']/form//field[@name='country_id']/.."
-                position="after"
+                expr="//field[@name='child_ids']/form//div[hasclass('o_address_format')]"
+                position="inside"
             >
-                <field name="allowed_nut_ids" invisible="1" />
-                <field
-                    name="nuts1_id"
-                    context="{'default_country_id': country_id, 'default_level': 1}"
-                />
-                <field
-                    name="nuts2_id"
-                    context="{'default_country_id': country_id, 'default_level': 2, 'default_parent_id': nuts1_id}"
-                />
-                <field
-                    name="nuts3_id"
-                    context="{'default_country_id': country_id, 'default_level': 3, 'default_parent_id': nuts2_id}"
-                />
-                <field
-                    name="nuts4_id"
-                    context="{'default_country_id': country_id, 'default_level': 4, 'default_parent_id': nuts3_id}"
-                />
+                <div class="o_row">
+                    <field name="allowed_nut_ids" invisible="1" />
+                    <field
+                        name="nuts1_id"
+                        placeholder="NUTS L1"
+                        context="{'default_country_id': country_id, 'default_level': 1}"
+                    />
+                    <field
+                        name="nuts2_id"
+                        placeholder="NUTS L2"
+                        context="{'default_country_id': country_id, 'default_level': 2, 'default_parent_id': nuts1_id}"
+                    />
+                    <field
+                        name="nuts3_id"
+                        placeholder="NUTS L3"
+                        context="{'default_country_id': country_id, 'default_level': 3, 'default_parent_id': nuts2_id}"
+                    />
+                    <field
+                        name="nuts4_id"
+                        placeholder="NUTS L4"
+                        context="{'default_country_id': country_id, 'default_level': 4, 'default_parent_id': nuts3_id}"
+                    />
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
With `base_vat` module installed, the fields appear disorganized and also shift the VAT field.

### Contact view without `base_vat` installed
<img width="826" height="525" alt="nuts_pre" src="https://github.com/user-attachments/assets/e807f3e7-8db9-4f29-8e2a-189603d58a4f" />


### Contact view with `base_vat` installed
<img width="826" height="525" alt="nuts_base_vat" src="https://github.com/user-attachments/assets/d6c36c8a-bc00-4363-87e2-99948e6bebd7" />


### Contact view with `base_vat` installed and this PR applied
<img width="1039" height="877" alt="nuts_compatible" src="https://github.com/user-attachments/assets/f85630e9-a3b8-4e38-a7d1-7a451b3ffb17" />


MT-12514 @moduon @fcvalgar @EmilioPascual @yajo please @Andrii9090 @astirpe @kos94ok-3D please review if you want 😄 