### PR TITLE
[FIX] parter_multi_relation: Reorganize menu hierachy

### DIFF
--- a/partner_multi_relation/views/menu.xml
+++ b/partner_multi_relation/views/menu.xml
@@ -3,12 +3,12 @@
     <menuitem
         id="menu_res_partner_relation"
         name="Relations"
-        sequence="3"
+        sequence="11"
         parent="contacts.menu_contacts"
     />
     <menuitem
         id="menu_res_partner_relation_all"
-        sequence="3"
+        sequence="10"
         parent="menu_res_partner_relation"
         action="action_res_partner_relation_all"
     />
@@ -22,5 +22,9 @@
         name="Relation Types"
         parent="menu_res_partner_relation"
         action="action_res_partner_relation_type"
+        sequence="20"
     />
+    <record id="contacts.res_partner_menu_config" model="ir.ui.menu">
+        <field name="sequence">20</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this change, in the Contacts module, the menu items did not follow a consistent hierarchical structure.

Before
<img width="467" height="148" alt="image" src="https://github.com/user-attachments/assets/e0027369-07ab-4173-9edc-55eb697b395b" />

After

<img width="469" height="147" alt="image" src="https://github.com/user-attachments/assets/b270e842-3905-4b05-83c7-7a2213896ce2" />


MT-12511 @moduon @yajo @rafaelbn 