### PR TITLE
[18.0][FIX] partner_property: export of res.users

### DIFF
--- a/partner_property/models/res_partner.py
+++ b/partner_property/models/res_partner.py
@@ -35,9 +35,7 @@ class ResPartner(models.Model):
         query.add_where(
             SQL(
                 "%s %s %s",
-                self._field_to_sql(
-                    "properties_company_id", "properties_company_id", query
-                ),
+                self._field_to_sql(self._table, "properties_company_id", query),
                 SQL_OPERATORS[operator],
                 value,
             )
@@ -48,7 +46,8 @@ class ResPartner(models.Model):
         # OVERRIDE to allow to export the properties
         if fname == "properties_company_id":
             return SQL(
-                """COALESCE(company_id, %(env_company)s)""",
+                """COALESCE(%(company_column)s, %(env_company)s)""",
+                company_column=SQL.identifier(alias, "company_id"),
                 env_company=self.env.company.id,
             )
         return super()._field_to_sql(alias, fname, query, flush)

--- a/partner_property/tests/test_export.py
+++ b/partner_property/tests/test_export.py
@@ -3,10 +3,11 @@
 
 import json
 
-from odoo.tests import HttpCase
+from odoo.tests import HttpCase, users
 
 
 class TextPartnerExport(HttpCase):
+    @users("admin")
     def test_export_get_fields(self):
         """Text the export wizard get_fields method.
 
@@ -28,7 +29,6 @@ class TextPartnerExport(HttpCase):
                 raise ValueError(f"Cannot convert {field} to SQL because it is not stored")
             ValueError: Cannot convert res.partner.properties_company_id to SQL because it is not stored
         """  # noqa: E501
-        self.authenticate("admin", "admin")
         self.url_open(
             "/web/export/get_fields",
             data=json.dumps(
@@ -37,6 +37,23 @@ class TextPartnerExport(HttpCase):
                         "model": "res.partner",
                         "import_compat": True,
                         "domain": [("id", "in", self.env.user.partner_id.ids)],
+                    }
+                }
+            ),
+            headers={"Content-Type": "application/json"},
+        ).raise_for_status()
+
+    @users("admin")
+    def test_export_get_fields_res_users(self):
+        """Test also the export of res.users"""
+        self.url_open(
+            "/web/export/get_fields",
+            data=json.dumps(
+                {
+                    "params": {
+                        "model": "res.users",
+                        "import_compat": True,
+                        "domain": [("id", "in", self.env.user.ids)],
                     }
                 }
             ),


### PR DESCRIPTION
Originally attempted to fix it here: 36b93fa723f020e2d0f5e7e85166f3574982ce29 (https://github.com/OCA/partner-contact/pull/2190)

But that fix only worked for res.partners due to not properly using the alias in the `_field_to_sql` method.
Then, when trying to export res.users (or any model that inherits from res.partner), we'd get the following error:

```
  File ".../odoo/addons/web/controllers/export.py", line 324, in _get_property_fields
    definition_records = target_model.search_fetch(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../odoo/odoo/models.py", line 1781, in search_fetch
    return self._fetch_query(query, fields_to_fetch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../odoo/odoo/models.py", line 4240, in _fetch_query
    rows = self.env.execute_query(query.select(*sql_terms))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../odoo/odoo/api.py", line 993, in execute_query
    self.cr.execute(query)
  File ".../odoo/odoo/sql_db.py", line 582, in execute
    return self._cursor.execute(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../odoo/odoo/sql_db.py", line 357, in execute
    res = self._obj.execute(query, params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.AmbiguousColumn: column reference "company_id" is ambiguous
LINE 1: ...TRUE) AND ("res_company"."id" IN (SELECT COALESCE(company_id...
```

Sorry for the trouble. I missed this last time