### PR TITLE
[17.0][FW][IMP] partner_contact_address_default: add option to allow selecting any partner

### DIFF
--- a/partner_contact_address_default/README.rst
+++ b/partner_contact_address_default/README.rst
@@ -37,6 +37,14 @@ contacts.
 .. contents::
    :local:
 
+Configuration
+=============
+
+1. Go to Settings.
+2. Under Contact Category, enable Contact Address Default Allow All
+   Partners to allow selecting any partner, instead of being limited to
+   child contacts.
+
 Usage
 =====
 
@@ -65,23 +73,27 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Carlos Dauden
-  - Sergio Teruel
-  - Juan Carlos Oñate
+   -  Carlos Dauden
+   -  Sergio Teruel
+   -  Juan Carlos Oñate
 
-- `Sygel <https://www.sygel.es>`__:
+-  `Sygel <https://www.sygel.es>`__:
 
-  - Manuel Regidor
+   -  Manuel Regidor
 
-- `Studio73 <https://www.studio73.es>`__:
+-  `Studio73 <https://www.studio73.es>`__:
 
-  - Carlos Reyes
+   -  Carlos Reyes
 
-- `ForgeFlow <https://www.forgeflow.com>`__:
+-  `ForgeFlow <https://www.forgeflow.com>`__:
 
-  - Laura Cazorla
+   -  Laura Cazorla
+
+-  `Quartile <https://www.quartile.co>`__:
+
+   -  Aung Ko Ko Lin
 
 Maintainers
 -----------

--- a/partner_contact_address_default/README.rst
+++ b/partner_contact_address_default/README.rst
@@ -40,10 +40,22 @@ contacts.
 Configuration
 =============
 
-1. Go to Settings.
-2. Under Contact Category, enable Contact Address Default Allow All
-   Partners to allow selecting any partner, instead of being limited to
-   child contacts.
+1. Go to **Settings**.
+
+2. Under **Contact Category**, configure the following options:
+
+   -  | **Contact Address Default Allow All Partners**
+      | Enable this option to allow selecting any partner, instead of
+        being limited
+      | to child contacts of the commercial partner.
+
+   -  | **Contact Shipping Address Delivery & Partner Only**
+      | Enable this option to restrict the **Shipping address** field to
+      | delivery-type contacts of the commercial partner and the partner
+        itself.
+      | This setting takes precedence over **Contact Address Default
+        Allow All
+        Partners** for shipping addresses.
 
 Usage
 =====

--- a/partner_contact_address_default/__manifest__.py
+++ b/partner_contact_address_default/__manifest__.py
@@ -14,6 +14,9 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["base"],
-    "data": ["views/res_partner_views.xml"],
+    "depends": ["base_setup"],
+    "data": [
+        "views/res_config_settings_views.xml",
+        "views/res_partner_views.xml",
+    ],
 }

--- a/partner_contact_address_default/models/__init__.py
+++ b/partner_contact_address_default/models/__init__.py
@@ -1,2 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import res_company
+from . import res_config_settings
 from . import res_partner

--- a/partner_contact_address_default/models/res_company.py
+++ b/partner_contact_address_default/models/res_company.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    contact_address_default_allow_all_partners = fields.Boolean()

--- a/partner_contact_address_default/models/res_company.py
+++ b/partner_contact_address_default/models/res_company.py
@@ -8,3 +8,4 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     contact_address_default_allow_all_partners = fields.Boolean()
+    contact_shipping_address_delivery_partner_only = fields.Boolean()

--- a/partner_contact_address_default/models/res_config_settings.py
+++ b/partner_contact_address_default/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    contact_address_default_allow_all_partners = fields.Boolean(
+        related="company_id.contact_address_default_allow_all_partners",
+        readonly=False,
+    )

--- a/partner_contact_address_default/models/res_config_settings.py
+++ b/partner_contact_address_default/models/res_config_settings.py
@@ -11,3 +11,7 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.contact_address_default_allow_all_partners",
         readonly=False,
     )
+    contact_shipping_address_delivery_partner_only = fields.Boolean(
+        related="company_id.contact_shipping_address_delivery_partner_only",
+        readonly=False,
+    )

--- a/partner_contact_address_default/models/res_partner.py
+++ b/partner_contact_address_default/models/res_partner.py
@@ -2,7 +2,8 @@
 # Copyright 2020 Tecnativa - Sergio Teruel
 # Copyright 2024 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.osv import expression
 
 
 class ResPartner(models.Model):
@@ -20,6 +21,29 @@ class ResPartner(models.Model):
         comodel_name="res.partner",
         string="Default contact",
     )
+    partner_delivery_domain = fields.Binary(compute="_compute_partner_domains")
+    partner_invoice_domain = fields.Binary(compute="_compute_partner_domains")
+    partner_contact_domain = fields.Binary(compute="_compute_partner_domains")
+
+    @api.depends_context("company")
+    @api.depends("commercial_partner_id")
+    def _compute_partner_domains(self):
+        for partner in self:
+            if self.env.company.contact_address_default_allow_all_partners:
+                partner.partner_delivery_domain = []
+                partner.partner_invoice_domain = []
+                partner.partner_contact_domain = []
+                continue
+            base_domain = [("id", "child_of", partner.commercial_partner_id.id)]
+            partner.partner_delivery_domain = expression.AND(
+                [base_domain, [("type", "=", "delivery")]]
+            )
+            partner.partner_invoice_domain = expression.AND(
+                [base_domain, [("type", "=", "invoice")]]
+            )
+            partner.partner_contact_domain = expression.AND(
+                [base_domain, [("type", "=", "contact")]]
+            )
 
     def get_address_default_type(self):
         """This will be the extension method for other contact types"""

--- a/partner_contact_address_default/models/res_partner.py
+++ b/partner_contact_address_default/models/res_partner.py
@@ -28,16 +28,26 @@ class ResPartner(models.Model):
     @api.depends_context("company")
     @api.depends("commercial_partner_id")
     def _compute_partner_domains(self):
+        company = self.env.company
         for partner in self:
-            if self.env.company.contact_address_default_allow_all_partners:
+            base_domain = [("id", "child_of", partner.commercial_partner_id.id)]
+            if company.contact_shipping_address_delivery_partner_only:
+                partner.partner_delivery_domain = expression.OR(
+                    [
+                        [("id", "=", partner.commercial_partner_id.id)],
+                        expression.AND([base_domain, [("type", "=", "delivery")]]),
+                    ]
+                )
+            elif company.contact_address_default_allow_all_partners:
                 partner.partner_delivery_domain = []
+            else:
+                partner.partner_delivery_domain = expression.AND(
+                    [base_domain, [("type", "=", "delivery")]]
+                )
+            if company.contact_address_default_allow_all_partners:
                 partner.partner_invoice_domain = []
                 partner.partner_contact_domain = []
                 continue
-            base_domain = [("id", "child_of", partner.commercial_partner_id.id)]
-            partner.partner_delivery_domain = expression.AND(
-                [base_domain, [("type", "=", "delivery")]]
-            )
             partner.partner_invoice_domain = expression.AND(
                 [base_domain, [("type", "=", "invoice")]]
             )

--- a/partner_contact_address_default/readme/CONFIGURE.md
+++ b/partner_contact_address_default/readme/CONFIGURE.md
@@ -1,0 +1,4 @@
+1.  Go to Settings.
+2.  Under Contact Category, enable Contact Address Default Allow All
+    Partners to allow selecting any partner, instead of being limited to
+    child contacts.

--- a/partner_contact_address_default/readme/CONFIGURE.md
+++ b/partner_contact_address_default/readme/CONFIGURE.md
@@ -1,4 +1,12 @@
-1.  Go to Settings.
-2.  Under Contact Category, enable Contact Address Default Allow All
-    Partners to allow selecting any partner, instead of being limited to
-    child contacts.
+1. Go to **Settings**.
+2. Under **Contact Category**, configure the following options:
+
+    * **Contact Address Default Allow All Partners**  
+      Enable this option to allow selecting any partner, instead of being limited  
+      to child contacts of the commercial partner.
+
+    * **Contact Shipping Address Delivery & Partner Only**  
+      Enable this option to restrict the **Shipping address** field to  
+      delivery-type contacts of the commercial partner and the partner itself.  
+      This setting takes precedence over **Contact Address Default Allow All  
+      Partners** for shipping addresses.

--- a/partner_contact_address_default/readme/CONTRIBUTORS.md
+++ b/partner_contact_address_default/readme/CONTRIBUTORS.md
@@ -8,3 +8,5 @@
   - Carlos Reyes
 - [ForgeFlow](https://www.forgeflow.com):
   - Laura Cazorla
+- [Quartile](https://www.quartile.co):
+  - Aung Ko Ko Lin

--- a/partner_contact_address_default/static/description/index.html
+++ b/partner_contact_address_default/static/description/index.html
@@ -389,11 +389,30 @@ contacts.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
-<ol class="arabic simple">
-<li>Go to Settings.</li>
-<li>Under Contact Category, enable Contact Address Default Allow All
-Partners to allow selecting any partner, instead of being limited to
-child contacts.</li>
+<ol class="arabic">
+<li><p class="first">Go to <strong>Settings</strong>.</p>
+</li>
+<li><p class="first">Under <strong>Contact Category</strong>, configure the following options:</p>
+<ul>
+<li><div class="first line-block">
+<div class="line"><strong>Contact Address Default Allow All Partners</strong></div>
+<div class="line">Enable this option to allow selecting any partner, instead of
+being limited</div>
+<div class="line">to child contacts of the commercial partner.</div>
+</div>
+</li>
+<li><div class="first line-block">
+<div class="line"><strong>Contact Shipping Address Delivery &amp; Partner Only</strong></div>
+<div class="line">Enable this option to restrict the <strong>Shipping address</strong> field to</div>
+<div class="line">delivery-type contacts of the commercial partner and the partner
+itself.</div>
+<div class="line">This setting takes precedence over <strong>Contact Address Default
+Allow All
+Partners</strong> for shipping addresses.</div>
+</div>
+</li>
+</ul>
+</li>
 </ol>
 </div>
 <div class="section" id="usage">

--- a/partner_contact_address_default/static/description/index.html
+++ b/partner_contact_address_default/static/description/index.html
@@ -376,18 +376,28 @@ contacts.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<ol class="arabic simple">
+<li>Go to Settings.</li>
+<li>Under Contact Category, enable Contact Address Default Allow All
+Partners to allow selecting any partner, instead of being limited to
+child contacts.</li>
+</ol>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <ol class="arabic simple">
 <li>Go to <em>Contacts</em>.</li>
 <li>Select default delivery address, invoice address or contact for
@@ -395,7 +405,7 @@ partner.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/partner-contact/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -403,15 +413,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Carlos Dauden</li>
@@ -431,10 +441,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Laura Cazorla</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/partner_contact_address_default/tests/test_partner_contact_address_default.py
+++ b/partner_contact_address_default/tests/test_partner_contact_address_default.py
@@ -81,3 +81,14 @@ class TestPartnerContactAddressDefault(BaseCommon):
         self.assertEqual(self.partner.partner_delivery_domain, [])
         self.assertEqual(self.partner.partner_invoice_domain, [])
         self.assertEqual(self.partner.partner_contact_domain, [])
+        self.env.company.contact_shipping_address_delivery_partner_only = True
+        self.partner._compute_partner_domains()
+        expected_delivery = expression.OR(
+            [
+                [("id", "=", self.partner.commercial_partner_id.id)],
+                expression.AND([expected_base, [("type", "=", "delivery")]]),
+            ]
+        )
+        self.assertEqual(self.partner.partner_delivery_domain, expected_delivery)
+        self.assertEqual(self.partner.partner_invoice_domain, [])
+        self.assertEqual(self.partner.partner_contact_domain, [])

--- a/partner_contact_address_default/tests/test_partner_contact_address_default.py
+++ b/partner_contact_address_default/tests/test_partner_contact_address_default.py
@@ -1,6 +1,9 @@
 # Copyright 2020 Tecnativa - Carlos Dauden
 # Copyright 2020 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.osv import expression
+
 from odoo.addons.base.tests.common import BaseCommon
 
 
@@ -63,3 +66,18 @@ class TestPartnerContactAddressDefault(BaseCommon):
         self.assertEqual(res["delivery"], self.partner_child_delivery1.id)
         self.assertEqual(res["invoice"], self.partner.id)
         self.assertEqual(res["contact"], self.partner.id)
+
+    def test_partner_domains(self):
+        self.partner._compute_partner_domains()
+        expected_base = [("id", "child_of", self.partner.commercial_partner_id.id)]
+        expected_delivery = expression.AND([expected_base, [("type", "=", "delivery")]])
+        expected_invoice = expression.AND([expected_base, [("type", "=", "invoice")]])
+        expected_contact = expression.AND([expected_base, [("type", "=", "contact")]])
+        self.assertEqual(self.partner.partner_delivery_domain, expected_delivery)
+        self.assertEqual(self.partner.partner_invoice_domain, expected_invoice)
+        self.assertEqual(self.partner.partner_contact_domain, expected_contact)
+        self.env.company.contact_address_default_allow_all_partners = True
+        self.partner._compute_partner_domains()
+        self.assertEqual(self.partner.partner_delivery_domain, [])
+        self.assertEqual(self.partner.partner_invoice_domain, [])
+        self.assertEqual(self.partner.partner_contact_domain, [])

--- a/partner_contact_address_default/views/res_config_settings_views.xml
+++ b/partner_contact_address_default/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@id='partner_autocomplete']" position="after">
+                <setting
+                    help="If enabled, the default delivery, invoice, and contact addresses are not limited to the partner’s child contacts—you can select any contact."
+                    id="contact_address_default_allow_all_partners"
+                >
+                    <field name="contact_address_default_allow_all_partners" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/partner_contact_address_default/views/res_config_settings_views.xml
+++ b/partner_contact_address_default/views/res_config_settings_views.xml
@@ -12,6 +12,14 @@
                 >
                     <field name="contact_address_default_allow_all_partners" />
                 </setting>
+                <setting
+                    id="contact_shipping_address_delivery_partner_only"
+                    help="If enabled, the Shipping address field is limited to delivery-type
+                    contacts of the commercial partner and the partner itself. This setting
+                    takes precedence over allowing all partners for shipping addresses."
+                >
+                    <field name="contact_shipping_address_delivery_partner_only" />
+                </setting>
             </xpath>
         </field>
     </record>

--- a/partner_contact_address_default/views/res_partner_views.xml
+++ b/partner_contact_address_default/views/res_partner_views.xml
@@ -6,22 +6,25 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='child_ids']" position="before">
                 <group>
+                    <field name="partner_delivery_domain" invisible="1" />
+                    <field name="partner_invoice_domain" invisible="1" />
+                    <field name="partner_contact_domain" invisible="1" />
                     <group>
                         <field
                             name="partner_delivery_id"
-                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'delivery')]"
+                            domain="partner_delivery_domain"
                             options="{'no_open': True, 'no_create': True}"
                         />
                         <field
                             name="partner_invoice_id"
-                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'invoice')]"
+                            domain="partner_invoice_domain"
                             options="{'no_open': True, 'no_create': True}"
                         />
                     </group>
                     <group>
                         <field
                             name="partner_contact_id"
-                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'contact')]"
+                            domain="partner_contact_domain"
                             options="{'no_open': True, 'no_create': True}"
                         />
                     </group>
@@ -29,6 +32,9 @@
             </xpath>
             <xpath expr="//field[@name='child_ids']//form//group" position="after">
                 <group string="Force addresses" invisible="type != 'contact'">
+                    <field name="partner_delivery_domain" invisible="1" />
+                    <field name="partner_invoice_domain" invisible="1" />
+                    <field name="partner_contact_domain" invisible="1" />
                     <group colspan="4">
                         <field name="commercial_partner_id" invisible="1" />
                         <div class="oe_grey" colspan="4">
@@ -40,19 +46,19 @@
                     <group colspan="4">
                         <field
                             name="partner_delivery_id"
-                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'delivery')]"
+                            domain="partner_delivery_domain"
                         />
                     </group>
                     <group colspan="4">
                         <field
                             name="partner_invoice_id"
-                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'invoice')]"
+                            domain="partner_invoice_domain"
                         />
                     </group>
                     <group colspan="4">
                         <field
                             name="partner_contact_id"
-                            domain="[('id', 'child_of', commercial_partner_id), ('type', '=', 'contact')]"
+                            domain="partner_contact_domain"
                         />
                     </group>
                 </group>


### PR DESCRIPTION
Forward port of https://github.com/OCA/partner-contact/pull/2187

This PR adds an option to allow selecting any partner for default addresses, instead of restricting selections to child contacts.

@qrtl QT5088