### PR TITLE
[18.0][FIX] partner_firstname: fix mail tests

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -226,7 +226,7 @@ class ResPartner(models.Model):
         """
         # Company name goes to the lastname
         if is_company or not name:
-            parts = [name or False, False]
+            parts = [name, False]
         # Guess name splitting
         else:
             order = self._get_names_order()
@@ -259,7 +259,7 @@ class ResPartner(models.Model):
             if all(
                 (
                     record.type == "contact" or record.is_company,
-                    not (record.firstname or record.lastname),
+                    record.firstname is False and record.lastname is False,
                 )
             ):
                 raise exceptions.EmptyNamesError(record, self.env)

--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -4,8 +4,10 @@
 # Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import logging
+from collections import defaultdict
 
 from odoo import _, api, fields, models
+from odoo.tools import frozendict
 
 from .. import exceptions
 
@@ -58,6 +60,7 @@ class ResPartner(models.Model):
         the correct context.
         """
         created_partners = self.browse()
+        vals_by_context = defaultdict(list)
         for vals in vals_list:
             partner_context = dict(self.env.context)
             is_company = vals.get("company_type") == "company"
@@ -78,10 +81,12 @@ class ResPartner(models.Model):
                     # Remove the combined fields
                     vals.pop("name", None)
                     partner_context.pop("default_name", None)
+            vals_by_context[frozendict(partner_context)].append(vals)
+        for partner_context, vals_list in vals_by_context.items():
             # pylint: disable=W8121
             created_partners |= super(
                 ResPartner, self.with_context(partner_context)
-            ).create([vals])
+            ).create(vals_list)
         return created_partners
 
     def get_extra_default_copy_values(self, order):

--- a/partner_firstname/readme/newsfragments/2227.bugfix.rst
+++ b/partner_firstname/readme/newsfragments/2227.bugfix.rst
@@ -1,0 +1,1 @@
+Fix so that mail tests succeed.

--- a/partner_firstname/tests/test_create.py
+++ b/partner_firstname/tests/test_create.py
@@ -52,6 +52,19 @@ class PersonCase(TransactionCase):
         self.context["default_name"] = "BÄD2"
 
 
+class PersonEmptyCase(TransactionCase):
+    context = {"default_is_company": False}
+    model = "res.partner"
+
+    def test_name_empty_string(self):
+        """Test what happens when the name is an empty string."""
+        self.record = (
+            self.env[self.model].with_context(**self.context).create({"name": ""})
+        )
+        for key, value in (("name", ""), ("lastname", "")):
+            self.assertEqual(self.record[key], value, f"Checking key {key}")
+
+
 class CompanyCase(PersonCase):
     """Test ``res.partner`` when it is a company."""
 
@@ -61,6 +74,12 @@ class CompanyCase(PersonCase):
         super().setUp()
         self.good_values.update(lastname=self.values["name"], firstname=False)
         self.values = self.good_values.copy()
+
+
+class CompanyEmptyCase(PersonEmptyCase):
+    """Test ``res.partner`` when it is a company."""
+
+    context = {"default_is_company": True}
 
 
 class UserCase(PersonCase, MailInstalled):
@@ -77,3 +96,10 @@ class UserCase(PersonCase, MailInstalled):
         else:
             # Run tests
             super().tearDown()
+
+
+class UserEmptyCase(PersonEmptyCase, MailInstalled):
+    """Test ``res.users``."""
+
+    model = "res.users"
+    context = {"default_login": "user@example.com"}

--- a/partner_firstname/tests/test_empty.py
+++ b/partner_firstname/tests/test_empty.py
@@ -27,10 +27,6 @@ class CompanyCase(TransactionCase):
         finally:
             super().tearDown()
 
-    def test_name_empty_string(self):
-        """Test what happens when the name is an empty string."""
-        self.name = ""
-
     def test_name_false(self):
         """Test what happens when the name is ``False``."""
         self.name = False

--- a/partner_firstname/tests/test_partner_form.py
+++ b/partner_firstname/tests/test_partner_form.py
@@ -8,8 +8,6 @@ The form operates in onchange mode, with its limitations.
 
 from odoo.tests import Form, TransactionCase
 
-from ..exceptions import EmptyNamesError
-
 
 class PartnerCompanyCase(TransactionCase):
     is_company = True
@@ -42,10 +40,13 @@ class PartnerCompanyCase(TransactionCase):
             self.assertEqual(partner_form.firstname, False)
             self.assertEqual(partner_form.lastname, name)
 
-            # User unsets name
+            # User empty name
             partner_form.name = ""
+            partner_form.save()
+            # User unsets name
+            partner_form.name = False
             # call save to  trigger the inverse and therefore raise an exception
-            with self.assertRaises(EmptyNamesError), self.env.cr.savepoint():
+            with self.assertRaises(AssertionError), self.env.cr.savepoint():
                 partner_form.save()
 
             name += " bis"
@@ -70,6 +71,7 @@ class PartnerContactCase(TransactionCase):
 
             # Changes firstname, which triggers compute
             partner_form.firstname = firstname
+            partner_form.lastname = False
 
         self.assertEqual(partner_form.lastname, False)
         self.assertEqual(partner_form.firstname, firstname)

--- a/partner_firstname/tests/test_user_form.py
+++ b/partner_firstname/tests/test_user_form.py
@@ -13,6 +13,7 @@ class UserOnchangeCase(TransactionCase):
             user_form.login = login
             # Changes firstname, which triggers onchanges
             user_form.firstname = firstname
+            user_form.lastname = False
 
         self.assertEqual(user_form.lastname, False)
         self.assertEqual(user_form.firstname, firstname)


### PR DESCRIPTION
1. Do not replace falsey value in name by False
2. In the check, check only False, not falsey values.

Fixes #2227