### PR TITLE
[17.0][FIX] partner_stage_only_confirmed: fix getting issue for dynamic domain

### DIFF
--- a/partner_stage_only_confirmed/models/base.py
+++ b/partner_stage_only_confirmed/models/base.py
@@ -29,11 +29,15 @@ class Base(models.AbstractModel):
                             if not domain:
                                 domain = "[('state', '=', 'confirmed')]"
                             elif isinstance(domain, str):
-                                if domain in ("", "[]"):
+                                dom = domain.strip()
+                                if dom in ("", "[]"):
                                     domain = "[('state', '=', 'confirmed')]"
+                                elif dom.startswith("["):
+                                    domain = dom[:-1] + ", ('state', '=', 'confirmed')]"
                                 else:
-                                    domain = domain[:-1]
-                                    domain += ", ('state', '=', 'confirmed')]"
+                                    # dynamic domain: partner_delivery_domain, etc.
+                                    # -> extend it as a list
+                                    domain = "%s + [('state', '=', 'confirmed')]" % dom
                             else:
                                 domain = list(domain)
                                 domain.append(("state", "=", "confirmed"))


### PR DESCRIPTION
This PR fixes the issue when there is a dynamic domain for many2one field.
Can see the issue in runboat of this PR.
https://github.com/OCA/partner-contact/pull/2221

@qrtl