### PR TITLE
[FIX][16.0] partner_firstname: overload missing 'private' partner form view

### DIFF
--- a/partner_firstname/views/res_partner.xml
+++ b/partner_firstname/views/res_partner.xml
@@ -1,4 +1,30 @@
 <odoo>
+
+     <record id="res_partner_view_form_private" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.res_partner_view_form_private" />
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <group>
+                    <group>
+                    <field
+                            name="lastname"
+                            attrs="{'required': [('firstname', '=', False)]}"
+                        /></group>
+                    <group>
+                    <field
+                            name="firstname"
+                            attrs="{'required': [('lastname', '=', False)]}"
+                        />
+                </group>
+                </group>
+            </field>
+            <field name="name" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </field>
+        </field>
+    </record>
+
     <record id="view_partner_simple_form" model="ir.ui.view">
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_simple_form" />


### PR DESCRIPTION
overload missing 'private' partner form view (used in HR > employee > Private Information at least). add first and last names fields.