### PR TITLE
[FIX] base_partner_company_group: fix character encoding in fr.po translation file

### DIFF
--- a/base_partner_company_group/i18n/fr.po
+++ b/base_partner_company_group/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2023-04-17 16:37+0000\n"
-"Last-Translator: C??dric ATANANE <cedric.atanane@gmail.com>\n"
+"PO-Revision-Date: 2025-11-25 16:06+0000\n"
+"Last-Translator: Cédric ATANANE <cedric.atanane@gmail.com>\n"
 "Language-Team: none\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -21,14 +21,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_partner_company_group.field_res_users__company_group_id
 #: model_terms:ir.ui.view,arch_db:base_partner_company_group.view_res_partner_filter
 msgid "Company Group"
-msgstr "Groupe de Soci??t??s"
+msgstr "Groupe de Sociétés"
 
 #. module: base_partner_company_group
 #: model:ir.actions.act_window,name:base_partner_company_group.action_open_group_members
 #: model:ir.model.fields,field_description:base_partner_company_group.field_res_partner__company_group_member_ids
 #: model:ir.model.fields,field_description:base_partner_company_group.field_res_users__company_group_member_ids
 msgid "Company group members"
-msgstr "Membres du groupe de soci??t??s"
+msgstr "Membres du groupe de sociétés"
 
 #. module: base_partner_company_group
 #: model:ir.model.fields,field_description:base_partner_company_group.field_res_partner__display_name
@@ -49,4 +49,4 @@ msgstr ""
 #~ msgstr "Contact"
 
 #~ msgid "Company group"
-#~ msgstr "Groupe de Soci??t??s"
+#~ msgstr "Groupe de Sociétés"


### PR DESCRIPTION
## Description
This PR fixes character encoding issues in the French translation file for the `base_partner_company_group` module.

## Changes
- Fixed encoding of special characters (é) that were displayed as `??` 
- Updated translator name from `C??dric` to `Cédric`
- Fixed "Société(s)" translations (4 occurrences)

## Files changed
- `base_partner_company_group/i18n/fr.po` (5 lines)

## Testing
- Pre-commit hooks passed ✅
- Manual verification of the corrected strings

## Checklist
- [x] Pre-commit hooks passed
- [x] No new linter errors introduced
- [x] Translation strings are properly encoded in UTF-8
- [x] Commit message follows OCA conventions