### PR TITLE
[18.0] [IMP] partner_rank_single: less invasive constraint on rank increase

### DIFF
--- a/partner_rank_single/models/res_partner.py
+++ b/partner_rank_single/models/res_partner.py
@@ -17,8 +17,13 @@ class Contact(models.Model):
                 )
 
     def _increase_rank(self, field, n=1):
-        # OVERRIDE: to check single rank
-        # Because of direct SQL update in the super method
+        # OVERRIDE: to ignore increasing the rank if the partner is already ranked
+        # in the opposite field
+        field_inverses = {
+            "customer_rank": "supplier_rank",
+            "supplier_rank": "customer_rank",
+        }
+        field_inverse = field_inverses[field]
+        self = self.filtered(lambda rec: not rec[field_inverse])
         res = super()._increase_rank(field, n=n)
-        self._constrains_single_rank()
         return res

--- a/partner_rank_single/tests/test_partner_rank_single.py
+++ b/partner_rank_single/tests/test_partner_rank_single.py
@@ -5,26 +5,32 @@ from odoo import Command, fields
 from odoo.exceptions import ValidationError
 from odoo.tests import common, tagged
 
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+
 
 @tagged("res_partner")
 class TestPartnerRankSingle(common.TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.Partner = self.env["res.partner"].with_context(no_state_required=True)
-        self.Product = self.env["product.product"]
-        self.customer = self.Partner.create(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context, no_state_required=True, **DISABLED_MAIL_CONTEXT
+            )
+        )
+        cls.customer = cls.env["res.partner"].create(
             {
                 "name": "Customer",
                 "is_company": True,
             }
         )
-        self.supplier = self.Partner.create(
+        cls.supplier = cls.env["res.partner"].create(
             {
                 "name": "Supplier",
                 "is_company": True,
             }
         )
-        self.table = self.Product.create({"name": "Table"})
+        cls.table = cls.env["product.product"].create({"name": "Table"})
 
     def _create_invoice(self, move_type, date, partner_id, **kwargs):
         move = self.env["account.move"].create(
@@ -50,27 +56,71 @@ class TestPartnerRankSingle(common.TransactionCase):
         return move.action_post()
 
     def test_00_customer_rank_single(self):
+        # No rank yet
+        self.assertFalse(self.customer.customer_rank)
+        self.assertFalse(self.customer.supplier_rank)
+        # Create an invoice as customer
         self._create_invoice(
             move_type="out_invoice", date=fields.Date.today(), partner_id=self.customer
         )
-        with self.assertRaises(
-            ValidationError, msg="A contact cannot be both a customer and a supplier."
-        ):
-            self._create_invoice(
-                move_type="in_invoice",
-                date=fields.Date.today(),
-                partner_id=self.customer,
-            )
+        self.assertEqual(self.customer.customer_rank, 1, "Ranked")
+        self.assertFalse(self.customer.supplier_rank, "Not ranked")
+        # Create an invoice as supplier
+        self._create_invoice(
+            move_type="in_invoice",
+            date=fields.Date.today(),
+            partner_id=self.customer,
+        )
+        self.assertEqual(self.customer.customer_rank, 1, "Rank unchanged")
+        self.assertFalse(self.customer.supplier_rank, "Not ranked")
+        # Create another invoice as customer
+        self._create_invoice(
+            move_type="out_invoice",
+            date=fields.Date.today(),
+            partner_id=self.customer,
+        )
+        self.assertEqual(self.customer.customer_rank, 2, "Rank increased")
+        self.assertFalse(self.customer.supplier_rank, "Not ranked")
 
     def test_01_supplier_rank_single(self):
+        # No rank yet
+        self.assertFalse(self.supplier.customer_rank)
+        self.assertFalse(self.supplier.supplier_rank)
+        # Create an invoice as supplier
         self._create_invoice(
-            move_type="in_invoice", date=fields.Date.today(), partner_id=self.supplier
+            move_type="in_invoice",
+            date=fields.Date.today(),
+            partner_id=self.supplier,
         )
-        with self.assertRaises(
-            ValidationError, msg="A contact cannot be both a customer and a supplier."
+        self.assertEqual(self.supplier.supplier_rank, 1, "Ranked")
+        self.assertFalse(self.supplier.customer_rank, "Not ranked")
+        # Create an invoice as customer
+        self._create_invoice(
+            move_type="out_invoice",
+            date=fields.Date.today(),
+            partner_id=self.supplier,
+        )
+        self.assertFalse(self.supplier.customer_rank, "Not ranked")
+        self.assertEqual(self.supplier.supplier_rank, 1, "Rank unchanged")
+        # Create another invoice as supplier
+        self._create_invoice(
+            move_type="in_invoice",
+            date=fields.Date.today(),
+            partner_id=self.supplier,
+        )
+        self.assertEqual(self.supplier.supplier_rank, 2, "Rank increased")
+        self.assertFalse(self.supplier.customer_rank, "Not ranked")
+
+    def test_03_customer_rank_manual(self):
+        self.customer.customer_rank = 10
+        with self.assertRaisesRegex(
+            ValidationError, "A contact cannot be both a customer and a supplier."
         ):
-            self._create_invoice(
-                move_type="out_invoice",
-                date=fields.Date.today(),
-                partner_id=self.supplier,
-            )
+            self.customer.supplier_rank = 1
+
+    def test_04_supplier_rank_manual(self):
+        self.supplier.supplier_rank = 10
+        with self.assertRaisesRegex(
+            ValidationError, "A contact cannot be both a customer and a supplier."
+        ):
+            self.supplier.customer_rank = 1


### PR DESCRIPTION
Instead of running the constraint check on `_increase_rank`, we now avoid increasing it if the partner is already ranked in the opposite field.

This fixes an error that occurs when installing demo data of core modules:

```python-traceback
2025-12-11 11:44:05,845 35 ERROR testdb odoo.addons.account.demo.account_demo: Error while posting demo data
Traceback (most recent call last):
  File ".../odoo/addons/account/demo/account_demo.py", line 90, in _post_load_demo_data
    move.action_post()
  File ".../odoo/addons/account/models/account_move.py", line 5426, in action_post
    self._post(soft=False)
  File ".../odoo/addons/account/models/account_move.py", line 5154, in _post
    (partner | partner.commercial_partner_id)._increase_rank('supplier_rank', count)
  File ".../partner-contact/partner_rank_single/models/res_partner.py", line 23, in _increase_rank
    "supplier_rank": "customer_rank",
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../partner-contact/partner_rank_single/models/res_partner.py", line 15, in _constrains_single_rank
    raise ValidationError(
odoo.exceptions.ValidationError: A contact cannot be both a customer and a supplier.
```