### PR TITLE
[19.0][FIX] base_partner_sequence: assign a new ref when copying users

### DIFF
--- a/base_partner_sequence/models/partner.py
+++ b/base_partner_sequence/models/partner.py
@@ -4,13 +4,16 @@
 # Copyright 2016 Camptocamp - Akim Juillerat (<https://www.camptocamp.com>).
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, exceptions, models
+from odoo import api, exceptions, fields, models
 
 
 class ResPartner(models.Model):
     """Assigns 'ref' from a sequence on creation and copying"""
 
     _inherit = "res.partner"
+
+    # Configure field not to be copied by default
+    ref = fields.Char(copy=False)
 
     def _get_next_ref(self, vals=None):
         return self.env["ir.sequence"].next_by_code("res.partner")

--- a/base_partner_sequence/tests/test_base_partner_sequence.py
+++ b/base_partner_sequence/tests/test_base_partner_sequence.py
@@ -15,6 +15,27 @@ class TestBasePartnerSequence(BaseCommon):
             copy.ref, "A partner with ref created by copy has a ref by default."
         )
 
+    def test_ref_sequence_on_user(self):
+        # Test sequence on creating a user and copying it
+        user = self.env["res.users"].create(
+            {
+                "name": "user1@example.org",
+                "login": "user1@example.org",
+                "partner_id": self.partner.id,
+            }
+        )
+        user2 = user.copy(
+            {
+                "name": "user2@example.org",
+                "login": "user2@example.org",
+            }
+        )
+        # The new user has a partner with a ref
+        self.assertTrue(user2.partner_id.ref)
+        # This is a new partner with a distinct ref
+        self.assertNotEqual(user.partner_id, user2.partner_id)
+        self.assertNotEqual(user.partner_id.ref, user2.partner_id.ref)
+
     def test_ref_sequence_on_contact(self):
         # Test if sequence doesn't increase on creating a contact child
         contact = self.env["res.partner"].create(


### PR DESCRIPTION
Port forward of https://github.com/OCA/partner-contact/pull/2057

When copying a user that has a partner that is a company and that has a ref, the resulting new user was assigned a new partner but with the same ref.

This is an issue for instance for new users signing up, if the partner of the template user is a company and is assigned a reference.

Steps to reproduce the behavior:
1. Copy a user that has a partner that is a company and has a ref.

**Actual behavior**
The new user has a partner with the same reference as the copied partner.

**Expected behavior**
The new user has a partner with a newly assigned reference.