### PR TITLE
[16.0][IMP] partner_manual_rank : Using customer_rank/supplier_rank values in partner creation for is_customer/is_supplier values

### DIFF
--- a/partner_manual_rank/models/res_partner.py
+++ b/partner_manual_rank/models/res_partner.py
@@ -21,14 +21,12 @@ class ResPartner(models.Model):
         inverse="_inverse_is_customer",
         search="_search_is_customer",
         string="Is a Customer",
-        default=lambda self: self._default_is_customer(),
     )
     is_supplier = fields.Boolean(
         compute="_compute_is_supplier",
         inverse="_inverse_is_supplier",
         search="_search_is_supplier",
         string="Is a Supplier",
-        default=lambda self: self._default_is_supplier(),
     )
 
     @api.depends("customer_rank")
@@ -67,8 +65,16 @@ class ResPartner(models.Model):
         operator, value = DOMAIN_SEARCH.get((operator, value))
         return [("supplier_rank", operator, value)]
 
-    def _default_is_customer(self):
-        return self.env.context.get("res_partner_search_mode") == "customer"
+    @api.model_create_multi
+    def create(self, vals_list):
+        search_partner_mode = self.env.context.get("res_partner_search_mode")
+        ctx_customer = search_partner_mode == "customer"
+        ctx_supplier = search_partner_mode == "supplier"
 
-    def _default_is_supplier(self):
-        return self.env.context.get("res_partner_search_mode") == "supplier"
+        for vals in vals_list:
+            if ctx_customer:
+                vals["is_customer"] = True
+            if ctx_supplier:
+                vals["is_supplier"] = True
+
+        return super().create(vals_list)

--- a/partner_manual_rank/models/res_partner.py
+++ b/partner_manual_rank/models/res_partner.py
@@ -72,9 +72,9 @@ class ResPartner(models.Model):
         ctx_supplier = search_partner_mode == "supplier"
 
         for vals in vals_list:
-            if ctx_customer:
+            if bool(vals.get("customer_rank", 0)) or ctx_customer:
                 vals["is_customer"] = True
-            if ctx_supplier:
+            if bool(vals.get("supplier_rank", 0)) or ctx_supplier:
                 vals["is_supplier"] = True
 
         return super().create(vals_list)

--- a/partner_manual_rank/tests/test_res_partner.py
+++ b/partner_manual_rank/tests/test_res_partner.py
@@ -43,6 +43,21 @@ class TestResPartner(common.TransactionCase):
                 {"is_customer": False, "customer_rank": 0},
             ],
         )
+        created_partner_1 = (
+            self.env["res.partner"]
+            .with_context(res_partner_search_mode="customer")
+            .create({"name": "Odoo SA"})
+        )
+        created_partner_2 = self.env["res.partner"].create(
+            {"name": "Odoo Community Association", "customer_rank": 1}
+        )
+        self.assertRecordValues(
+            (created_partner_1 | created_partner_2),
+            [
+                {"is_customer": True, "customer_rank": 1},
+                {"is_customer": True, "customer_rank": 1},
+            ],
+        )
 
     def test_02_is_supplier(self):
         partners = self.partner | self.partner_2
@@ -77,5 +92,20 @@ class TestResPartner(common.TransactionCase):
             [
                 {"is_supplier": False, "supplier_rank": 0},
                 {"is_supplier": False, "supplier_rank": 0},
+            ],
+        )
+        created_partner_1 = (
+            self.env["res.partner"]
+            .with_context(res_partner_search_mode="supplier")
+            .create({"name": "Odoo SA"})
+        )
+        created_partner_2 = self.env["res.partner"].create(
+            {"name": "Odoo Community Association", "supplier_rank": 1}
+        )
+        self.assertRecordValues(
+            (created_partner_1 | created_partner_2),
+            [
+                {"is_supplier": True, "supplier_rank": 1},
+                {"is_supplier": True, "supplier_rank": 1},
             ],
         )


### PR DESCRIPTION
Currently, when creating a partner using the `customer_rank`/`supplier_rank` values, these get trumped by the `_inverse_is_customer` / `_inverse_is_supplier` methods, since the default values are only based in the `res_partner_search_mode` context values.

```py
>> partner = self.env["res.partner"].create({"name": "Test Partner", "customer_rank": 1})
>> partner.is_customer # Computed by `_default_is_customer`
False
>> partner.customer_rank # Computed by `_inverse_is_customer`
0
```

This can cause conflicts between modules, which originally didn't depend on this module to create partners as suppliers/customers, and can disrupt some usages.
For instance, the `OCA/edi` module `account_invoice_import` uses the `supplier_rank` value to create a Supplier partner for an imported partner - installing this module for front-end convenience would then disrupt that process, and create a non-supplier partner.

So, this PR aims to allow users to create new supplier/customer partners, using the `customer_rank`/`supplier_rank` values 