### PR TITLE
[18.0][FIX] base_location_nuts: fix dc terms prefix typo

### DIFF
--- a/base_location_nuts/wizard/nuts_import.py
+++ b/base_location_nuts/wizard/nuts_import.py
@@ -119,7 +119,7 @@ class NutsImport(models.TransientModel):
             PREFIX spdx: <http://spdx.org/rdf/terms#>
             PREFIX tableDescriptions: <http://publications.europa.eu/ontology/euvoc/tableDescriptions#>
             PREFIX temporalDescriptions: <http://publications.europa.eu/ontology/euvoc/temporalDescriptions#>
-            PREFIX terms: <'http://purl.org/dc/terms/>
+            PREFIX terms: <http://purl.org/dc/terms/>
             PREFIX time: <http://www.w3.org/2006/time#>
             PREFIX vann: <http://purl.org/vocab/vann/>
             PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>


### PR DESCRIPTION
Fix invalid SPARQL syntax in the `terms:` prefix definition. The single quote inside the angle brackets was causing HTTP 403 errors from the EU SPARQL endpoint.

**Before:**
PREFIX terms: <'[http://purl.org/dc/terms/>](http://purl.org/dc/terms/%3E)

**After:**
PREFIX terms: http://purl.org/dc/terms/

This allows the NUTS import wizard to successfully fetch data from the EU publications SPARQL endpoint.