### PR TITLE
[18.0][IMP] partner_identification: Change where the mock has to be loaded

### DIFF
--- a/partner_category_type/tests/test_partner_category_type.py
+++ b/partner_category_type/tests/test_partner_category_type.py
@@ -1,5 +1,6 @@
 # Copyright 2023 ForgeFlow, S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from unittest import mock
 
 from odoo.exceptions import ValidationError
 
@@ -64,23 +65,15 @@ class TestResPartnerCategory(BaseCommon):
         child2 = self.env["res.partner.category"].create(
             {"name": "Child 2", "parent_id": child1.id}
         )
-
-        def extended_selection(self):
-            return [("generic", "Generic"), ("test", "Test")]
-
-        original_selection = type(parent)._get_category_type_selection
-
-        try:
-            type(parent)._get_category_type_selection = extended_selection
+        # Replaces the selection in the field definition of category_type
+        with mock.patch.object(
+            type(parent),
+            "_get_category_type_selection",
+            [("generic", "Generic"), ("test", "Test")],
+        ):
             parent.category_type = "test"
             self.assertEqual(child1.category_type, "test")
             self.assertEqual(child2.category_type, "test")
-        finally:
-            type(
-                parent
-            )._get_category_type_selection = (
-                original_selection  # Ensure this always runs
-            )
 
     def test_05_compute_category_type(self):
         """Test computation of category type based on parent"""

--- a/partner_contact_age_range/tests/test_res_partner_age_range.py
+++ b/partner_contact_age_range/tests/test_res_partner_age_range.py
@@ -51,6 +51,9 @@ class TestRespartnerAgeRange(BaseCommon):
 
     @freeze_time("2024-02-07")
     def test_cron_update_age_range_id(self):
+        # We need to define a date earlier than the one defined in freeze_time so
+        # that the age field has a positive value.
+        self.partner.birthdate_date = "2023-02-10"
         self.partner_model._cron_update_age_range_id()
         self.assertEqual(self.partner.age_range_id, self.baby_range)
 

--- a/partner_identification/tests/test_res_partner.py
+++ b/partner_identification/tests/test_res_partner.py
@@ -8,42 +8,40 @@ from odoo.tests import common
 
 
 class TestResPartner(common.TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .fake_models import ResPartner
 
-        cls.loader.update_registry((ResPartner,))
+        self.loader.update_registry((ResPartner,))
 
-        bad_cat = cls.env["res.partner.id_category"].create(
+        bad_cat = self.env["res.partner.id_category"].create(
             {"code": "another_code", "name": "another_name"}
         )
-        cls.env["res.partner.id_number"].create(
+        self.env["res.partner.id_number"].create(
             {
                 "name": "Bad ID",
                 "category_id": bad_cat.id,
-                "partner_id": cls.env.user.partner_id.id,
+                "partner_id": self.env.user.partner_id.id,
             }
         )
-        cls.partner_id_category = cls.env["res.partner.id_category"].create(
+        self.partner_id_category = self.env["res.partner.id_category"].create(
             {"code": "id_code", "name": "id_name"}
         )
-        cls.partner = cls.env.ref("base.main_partner")
-        cls.partner_id = cls.env["res.partner.id_number"].create(
+        self.partner = self.env.ref("base.main_partner")
+        self.partner_id = self.env["res.partner.id_number"].create(
             {
                 "name": "Good ID",
-                "category_id": cls.partner_id_category.id,
-                "partner_id": cls.partner.id,
+                "category_id": self.partner_id_category.id,
+                "partner_id": self.partner.id,
             }
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_compute_identification(self):
         """It should set the proper field to the proper ID name."""


### PR DESCRIPTION
Change where the mock has to be loaded

With the changes introduced in https://github.com/odoo/odoo/commit/de056cc#diff-b37c7fd5520c97a29ddc59495779e7be61a66e15e85603928e27b3affb9dc31f, an error was occurring because the change validation on the model was being performed before tearDownClass was executed. Therefore, it has been modified so that the mock changes are applied in each test and cleaned up after each test. This way, the error will no longer appear and the test will run normally.

@Tecnativa