### PR TITLE
[19.0][FIX] partner_vat_unique: set application to False

### DIFF
--- a/partner_vat_unique/__manifest__.py
+++ b/partner_vat_unique/__manifest__.py
@@ -9,7 +9,7 @@
     "website": "https://github.com/OCA/partner-contact",
     "author": "Grant Thornton S.L.P, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "application": True,
+    "application": False,
     "installable": True,
     "depends": ["base_setup"],
     "data": [


### PR DESCRIPTION
## Summary
- set partner_vat_unique as non-application by disabling the application flag