### PR TITLE
[16.0] [FIX] fix pre-commit cache + partner_contact_age_range test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements

--- a/partner_contact_age_range/tests/test_res_partner_age_range.py
+++ b/partner_contact_age_range/tests/test_res_partner_age_range.py
@@ -22,13 +22,14 @@ class TestRespartnerAgeRange(TransactionCase):
         self.partner = self.partner_model.create(
             {
                 "name": "Test",
-                "birthdate_date": datetime.today() - relativedelta(years=1, days=10),
+                "birthdate_date": datetime(2024, 2, 7)
+                - relativedelta(years=1, days=10),
             }
         )
         self.partner2 = self.partner_model.create(
             {
                 "name": "Test2",
-                "birthdate_date": datetime.today() + relativedelta(years=1),
+                "birthdate_date": datetime(2024, 2, 7) + relativedelta(years=1),
             }
         )
 


### PR DESCRIPTION
With this fix that I found here: https://github.com/OCA/oca-addons-repo-template/issues/334
, I'm trying to resolve the problems experienced here: https://github.com/OCA/partner-contact/pull/2258

The problem with partner_contact_age_range was that the birthdate was set to today, while the test is executed with the year 2024 frozen. When the age is computed, it also uses today, but inside the test "today" is 2024. As a result, the calculation becomes today minus birthdate (2024 vs 2026), which leads to an age of -1 (depending on the month).