### PR TITLE
[18.0][IMP] partner_industry_secondary: search by parent name includes descendants

### DIFF
--- a/partner_industry_secondary/models/res_partner_industry.py
+++ b/partner_industry_secondary/models/res_partner_industry.py
@@ -6,6 +6,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, exceptions, fields, models
+from odoo.osv import expression
 
 
 class ResPartnerIndustry(models.Model):
@@ -43,6 +44,14 @@ class ResPartnerIndustry(models.Model):
             raise exceptions.ValidationError(
                 self.env._("Error! Industry with same name and parent already exists.")
             )
+
+    def _search_display_name(self, operator, value):
+        if operator in ("ilike", "like", "=", "=ilike", "=like") and value:
+            matching = self.search([("name", operator, value)])
+            if matching:
+                return [("id", "child_of", matching.ids)]
+            return expression.FALSE_DOMAIN
+        return super()._search_display_name(operator, value)
 
     def copy(self, default=None):
         default = default or {}

--- a/partner_industry_secondary/tests/test_res_partner_industry.py
+++ b/partner_industry_secondary/tests/test_res_partner_industry.py
@@ -74,3 +74,39 @@ class TestResPartnerIndustry(common.TransactionCase):
         for individuals, based on user group."""
         self.partner._compute_show_partner_industry_for_person()
         self.assertEqual(self.partner.show_partner_industry_for_person, True)
+
+    def test_07_search_by_parent_name_returns_children(self):
+        """Searching by a parent industry name must also return its children."""
+        result_ids = {
+            r[0] for r in self.industry_model.name_search("Test", operator="ilike")
+        }
+        self.assertIn(self.industry_main.id, result_ids)
+        self.assertIn(self.industry_child.id, result_ids)
+
+    def test_08_search_by_child_name_does_not_return_parent(self):
+        """Searching by a child industry name must not return its parent."""
+        result_ids = {
+            r[0]
+            for r in self.industry_model.name_search("Test child", operator="ilike")
+        }
+        self.assertIn(self.industry_child.id, result_ids)
+        self.assertNotIn(self.industry_main.id, result_ids)
+
+    def test_09_search_by_grandparent_name_returns_all_descendants(self):
+        """Searching by a grandparent name must return all descendants."""
+        industry_grandchild = self.industry_model.create(
+            {"name": "Test grandchild", "parent_id": self.industry_child.id}
+        )
+        result_ids = {
+            r[0] for r in self.industry_model.name_search("Test", operator="ilike")
+        }
+        self.assertIn(self.industry_main.id, result_ids)
+        self.assertIn(self.industry_child.id, result_ids)
+        self.assertIn(industry_grandchild.id, result_ids)
+
+    def test_10_search_no_match_returns_empty(self):
+        """Searching for a non-existent name must return an empty result."""
+        result = self.industry_model.name_search(
+            "NonExistentIndustry", operator="ilike"
+        )
+        self.assertFalse(result)


### PR DESCRIPTION
Override _search_display_name to use child_of when searching by name, so that searching for a parent industry also returns all its descendants at any depth, using the stored parent_path for efficient SQL resolution.