### PR TITLE
[17.0][IMP] partner_manual_rank: store is_customer and is_supplier

### DIFF
--- a/partner_manual_rank/models/res_partner.py
+++ b/partner_manual_rank/models/res_partner.py
@@ -2,15 +2,7 @@
 # Copyright 2022 Vauxoo, S.A.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError
-
-DOMAIN_SEARCH = {
-    ("=", False): ("=", 0),
-    ("=", True): (">=", 1),
-    ("!=", False): (">=", 1),
-    ("!=", True): ("=", 0),
-}
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -19,15 +11,15 @@ class ResPartner(models.Model):
     is_customer = fields.Boolean(
         compute="_compute_is_customer",
         inverse="_inverse_is_customer",
-        search="_search_is_customer",
         string="Is a Customer",
+        store=True,
         default=lambda self: self._default_is_customer(),
     )
     is_supplier = fields.Boolean(
         compute="_compute_is_supplier",
         inverse="_inverse_is_supplier",
-        search="_search_is_supplier",
         string="Is a Supplier",
+        store=True,
         default=lambda self: self._default_is_supplier(),
     )
 
@@ -44,28 +36,18 @@ class ResPartner(models.Model):
                 partner.is_supplier = bool(partner.supplier_rank)
 
     def _inverse_is_customer(self):
-        self.filtered(lambda p: not p.is_customer).write({"customer_rank": 0})
-        self.filtered(lambda p: p.is_customer and not p.customer_rank).write(
-            {"customer_rank": 1}
-        )
-
-    def _search_is_customer(self, operator, value):
-        if operator not in ["=", "!="] or not isinstance(value, bool):
-            raise UserError(_("Operation not supported"))
-        operator, value = DOMAIN_SEARCH.get((operator, value))
-        return [("customer_rank", operator, value)]
+        for partner in self:
+            if partner.is_customer and partner.customer_rank < 1:
+                partner.customer_rank = 1
+            elif not partner.is_customer and partner.customer_rank > 0:
+                partner.customer_rank = 0
 
     def _inverse_is_supplier(self):
-        self.filtered(lambda p: not p.is_supplier).write({"supplier_rank": 0})
-        self.filtered(lambda p: p.is_supplier and not p.supplier_rank).write(
-            {"supplier_rank": 1}
-        )
-
-    def _search_is_supplier(self, operator, value):
-        if operator not in ["=", "!="] or not isinstance(value, bool):
-            raise UserError(_("Operation not supported"))
-        operator, value = DOMAIN_SEARCH.get((operator, value))
-        return [("supplier_rank", operator, value)]
+        for partner in self:
+            if partner.is_supplier and partner.supplier_rank < 1:
+                partner.supplier_rank = 1
+            elif not partner.is_supplier and partner.supplier_rank > 0:
+                partner.supplier_rank = 0
 
     def _default_is_customer(self):
         return self.env.context.get("res_partner_search_mode") == "customer"

--- a/partner_manual_rank/tests/test_res_partner.py
+++ b/partner_manual_rank/tests/test_res_partner.py
@@ -1,4 +1,3 @@
-from odoo.exceptions import UserError
 from odoo.tests import common, tagged
 
 
@@ -52,8 +51,6 @@ class TestResPartner(common.TransactionCase):
                 {"is_customer": True, "customer_rank": 1},
             ],
         )
-        with self.assertRaisesRegex(UserError, "Operation not supported"):
-            self.env["res.partner"].search([("is_customer", "in", [True, False])])
 
     def test_02_is_supplier(self):
         partners = self.partner | self.partner_2
@@ -98,5 +95,51 @@ class TestResPartner(common.TransactionCase):
                 {"is_supplier": True, "supplier_rank": 1},
             ],
         )
-        with self.assertRaisesRegex(UserError, "Operation not supported"):
-            self.env["res.partner"].search([("is_supplier", "in", [True, False])])
+
+    def test_03_increase_rank(self):
+        partners = self.partner | self.partner_2
+
+        self.assertRecordValues(
+            partners,
+            [
+                {
+                    "is_customer": False,
+                    "customer_rank": 0,
+                    "is_supplier": False,
+                    "supplier_rank": 0,
+                },
+                {
+                    "is_customer": False,
+                    "customer_rank": 0,
+                    "is_supplier": False,
+                    "supplier_rank": 0,
+                },
+            ],
+        )
+
+        # Incrementing supplier_rank must flip is_supplier to True
+        self.partner._increase_rank("supplier_rank")
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_supplier": True, "supplier_rank": 1},
+                {"is_supplier": False, "supplier_rank": 0},
+            ],
+        )
+
+        # Incrementing customer_rank must flip is_customer to True
+        self.partner_2._increase_rank("customer_rank")
+        self.assertRecordValues(
+            partners,
+            [
+                {"is_customer": False, "customer_rank": 0},
+                {"is_customer": True, "customer_rank": 1},
+            ],
+        )
+
+        # Multiple increments keep the flag True and accumulate the rank
+        self.partner._increase_rank("supplier_rank", n=2)
+        self.assertRecordValues(
+            self.partner,
+            [{"is_supplier": True, "supplier_rank": 3}],
+        )


### PR DESCRIPTION
The fields `is_customer` and `is_supplier` were originally implemented as
non-stored computed fields with custom `_search_is_customer` /
`_search_is_supplier` methods. This was necessary because Odoo's
`_increase_rank()` method (used when e.g. a sale order or purchase order is
confirmed) performs a direct SQL UPDATE on `customer_rank` /
`supplier_rank`, bypassing the ORM. Before Odoo 16.0, this meant that
`@api.depends` triggers were never fired after `_increase_rank`, so any
stored computed field that depended on those ranks would silently become
stale. The workaround was to keep the fields non-stored and translate every
domain search through `DOMAIN_SEARCH` back to a `customer_rank` /
`supplier_rank` criterion.

Since Odoo 16.0, `_increase_rank` calls `self.modified([field])` after the
SQL write [1]. `self.modified()` notifies the ORM that the given field has
changed, invalidating cached values and scheduling a recomputation of every
stored computed field that `@api.depends` on it. This means
`is_customer` / `is_supplier` are now kept in sync automatically whenever
`_increase_rank` is called.

We can therefore:
- mark both fields as `store=True`, letting the database index handle
  searches natively (no more custom `_search_*` methods or `DOMAIN_SEARCH`),
- drop the `UserError`-raising search guards that prevented unsupported
  operators,
- add `test_03_increase_rank` to explicitly cover the `_increase_rank`
  code path and assert that the boolean flags are flipped correctly.

[1] https://github.com/odoo/odoo/blob/16.0/addons/account/models/partner.py#L700