### PR TITLE
[FIX] partner_address_street3: copy street3 from parent when creating contact

### DIFF
--- a/partner_address_street3/models/res_partner.py
+++ b/partner_address_street3/models/res_partner.py
@@ -18,6 +18,18 @@ class ResPartner(models.Model):
         res.append("street3")
         return res
 
+    @api.model
+    def default_get(self, default_fields):
+        values = super().default_get(default_fields)
+        parent_id = self.env.context.get("default_parent_id") or values.get("parent_id")
+        if parent_id:
+            parent = self.browse(parent_id)
+            for field in self._address_fields():
+                if field in default_fields and not values.get(field):
+                    val = parent[field]
+                    values[field] = val.id if isinstance(val, models.BaseModel) else val
+        return values
+
     def _display_address(self, without_company=False):
         """Remove empty lines which can happen when street3 field is empty."""
         res = super()._display_address(without_company=without_company)

--- a/partner_address_street3/tests/test_street_3.py
+++ b/partner_address_street3/tests/test_street_3.py
@@ -54,3 +54,55 @@ class TestStreet3(TransactionCase):
         uninstall_hook(self.env)
         us_country = self.env.ref("base.us")
         self.assertTrue("%(street3)s" not in us_country.address_format)
+
+    def test_default_get_copies_street3_from_default_parent_id(self):
+        """Replicate the "Add in Contacts & Addresses" inline form context.
+
+        Odoo passes ``default_parent_id`` in the context when the inline
+        ``child_ids`` form is opened from a company contact, so ``default_get``
+        must pre-fill the address fields (including ``street3``) from that
+        parent.
+        """
+        parent = self.env["res.partner"].create(
+            {
+                "name": "Parent Company",
+                "street": "123 Main St",
+                "street2": "Floor 2",
+                "street3": "Suite 100",
+                "city": "Springfield",
+                "country_id": self.env.ref("base.us").id,
+            }
+        )
+        values = (
+            self.env["res.partner"]
+            .with_context(default_parent_id=parent.id, default_type="contact")
+            .default_get(["street", "street2", "street3", "city"])
+        )
+        self.assertEqual(values.get("street3"), "Suite 100")
+        self.assertEqual(values.get("street2"), "Floor 2")
+        self.assertEqual(values.get("street"), "123 Main St")
+        self.assertEqual(values.get("city"), "Springfield")
+
+    def test_default_get_does_not_overwrite_explicit_value(self):
+        """An explicit default must win over the parent's value."""
+        parent = self.env["res.partner"].create(
+            {"name": "Parent", "street3": "From parent"}
+        )
+        values = (
+            self.env["res.partner"]
+            .with_context(
+                default_parent_id=parent.id,
+                default_type="contact",
+                default_street3="Explicit",
+            )
+            .default_get(["street3"])
+        )
+        self.assertEqual(values.get("street3"), "Explicit")
+
+    def test_default_get_no_parent(self):
+        values = (
+            self.env["res.partner"]
+            .with_context(default_type="contact")
+            .default_get(["street3"])
+        )
+        self.assertNotIn("street3", values)


### PR DESCRIPTION
## Summary

When creating a contact inside a company using the "Add" button in **Contacts & Addresses**, the `street3` field was not being copied from the parent company, unlike other address fields (street, street2, zip, city, etc.).

## Fix

Override `default_get` to copy all address fields (including `street3`) from the parent company when creating a child contact.

## Steps to reproduce

1. Create a company contact and set a value in the `Street 3` field
2. Click **Add** in **Contacts & Addresses** to create a contact in the company
3. The **Create Contact** dialog shows an empty Street 3 field

## Expected behavior

The Street 3 value should be copied from the parent company.

## Fixes

Closes #2298