### PR TITLE
[18.0][FIX] partner_tier_validation: guard write for res.users

### DIFF
--- a/partner_tier_validation/models/res_partner.py
+++ b/partner_tier_validation/models/res_partner.py
@@ -34,6 +34,10 @@ class ResPartner(models.Model):
         ]
 
     def write(self, vals):
+        # Only apply tier validation for res.partner, not for inheriting
+        # models like res.users which have a different state field.
+        if self._name != "res.partner":
+            return super().write(vals)
         # Changing certain fields requires a new validation process
         revalidate_fields = self._partner_tier_revalidation_fields(vals)
         if any(x in revalidate_fields for x in vals.keys()):


### PR DESCRIPTION
The `write()` override sets `vals['state']` to tier validation states like 'draft' or 'confirmed', but `res.users` inherits `res.partner` via `_inherits` and has its own `state` field with different valid values ('active', 'inactive').

This causes `ValueError: Wrong value for res.users.state: 'draft'` when creating a user.

**Fix**: Add a guard to skip tier validation logic when the model is not `res.partner`, preventing the state field collision with inheriting models.

Closes #2239