### PR TITLE
[19.0][FIX] partner_shipping_policy: set picking_policy via default_get

### DIFF
--- a/partner_shipping_policy/models/sale_order.py
+++ b/partner_shipping_policy/models/sale_order.py
@@ -12,6 +12,24 @@ class SaleOrder(models.Model):
         compute="_compute_picking_policy", store=True, readonly=False
     )
 
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if "picking_policy" in fields_list:
+            if "default_picking_policy" not in self.env.context:
+                partner_id = self.env.context.get(
+                    "default_partner_id"
+                ) or self.env.context.get("active_id")
+                if partner_id:
+                    partner = self.env["res.partner"].browse(partner_id)
+                    partner_policy = (
+                        partner.commercial_partner_id.picking_policy
+                        or partner.picking_policy
+                    )
+                    if partner_policy:
+                        res["picking_policy"] = partner_policy
+        return res
+
     @api.depends("partner_id")
     def _compute_picking_policy(self):
         for this in self:

--- a/partner_shipping_policy/tests/test_partner_shipping_policy.py
+++ b/partner_shipping_policy/tests/test_partner_shipping_policy.py
@@ -56,3 +56,34 @@ class TestPartnerShippingPolicy(BaseCommon):
         )
         sale_form.partner_id = self.partner_3
         self.assertEqual(sale_form.picking_policy, self.partner_3.picking_policy)
+
+    def test_03_default_get_picking_policy(self):
+        # Test when default_partner_id is in context
+        res_default_partner = self.sale_order_model.with_context(
+            default_partner_id=self.partner.id
+        ).default_get(["picking_policy"])
+        self.assertEqual(res_default_partner.get("picking_policy"), "one")
+
+        # Test when active_id is in context
+        res_active_id = self.sale_order_model.with_context(
+            active_id=self.partner.id
+        ).default_get(["picking_policy"])
+        self.assertEqual(res_active_id.get("picking_policy"), "one")
+
+        # Test when partner has no picking policy (falls back to default)
+        res_no_policy = self.sale_order_model.with_context(
+            default_partner_id=self.partner_2.id
+        ).default_get(["picking_policy"])
+        self.assertEqual(res_no_policy.get("picking_policy"), "direct")
+
+        # Test when default_picking_policy is explicitly in context
+        res_explicit = self.sale_order_model.with_context(
+            default_partner_id=self.partner.id, default_picking_policy="direct"
+        ).default_get(["picking_policy"])
+        self.assertEqual(res_explicit.get("picking_policy"), "direct")
+
+        # Test when picking_policy is not requested in fields_list
+        res_no_field = self.sale_order_model.with_context(
+            default_partner_id=self.partner.id
+        ).default_get(["name"])
+        self.assertNotIn("picking_policy", res_no_field)


### PR DESCRIPTION
When creating a sale order from a partner form via the smart button, the `picking_policy` from the partner was not being set because the `@api.depends('partner_id')` compute may not trigger during quick creation.

**Fix**: Add a `default_get` override to copy `picking_policy` from the partner at creation time, falling back to `commercial_partner_id` for child contacts.

Closes #2305