### PR TITLE
[18.0][FIX] partner_contact_address_default: use allowed_company_ids in depends_context

### DIFF
--- a/partner_contact_address_default/models/res_partner.py
+++ b/partner_contact_address_default/models/res_partner.py
@@ -25,7 +25,7 @@ class ResPartner(models.Model):
     partner_invoice_domain = fields.Binary(compute="_compute_partner_domains")
     partner_contact_domain = fields.Binary(compute="_compute_partner_domains")
 
-    @api.depends_context("company")
+    @api.depends_context("allowed_company_ids")
     @api.depends("commercial_partner_id")
     def _compute_partner_domains(self):
         for partner in self:


### PR DESCRIPTION
Using `@api.depends_context("company")` on a Binary field causes a stale cache key when `env.company` is switched mid-transaction, resulting in:


`ValueError: Compute method failed to assign res.partner.partner_delivery_domain`

Replace with `@api.depends_context("allowed_company_ids")`, which reads directly from context and keeps the cache key consistent.

@Tecnativa TT59807
@pedrobaeza 