### PR TITLE
[19.0][IMP] partner_department: improve UX and enforce department integrity

### DIFF
--- a/partner_department/models/res_partner.py
+++ b/partner_department/models/res_partner.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -20,6 +21,13 @@ class ResPartner(models.Model):
     department_member_ids = fields.One2many(
         "res.partner",
         "department_id",
+        domain=[("type", "!=", "department")],
+        string="Direct Members",
+    )
+
+    department_all_member_ids = fields.Many2many(
+        "res.partner",
+        compute="_compute_department_all_member_ids",
         string="Members",
     )
 
@@ -35,16 +43,49 @@ class ResPartner(models.Model):
     )
 
     @api.depends("department_member_ids")
+    def _compute_department_all_member_ids(self):
+        for dept in self:
+            sub_depts = self.env["res.partner"].search(
+                [("department_id", "=", dept.id), ("type", "=", "department")]
+            )
+            all_members = dept.department_member_ids
+            for sub_dept in sub_depts:
+                all_members |= sub_dept.department_member_ids
+            dept.department_all_member_ids = all_members
+
+    @api.depends("department_all_member_ids")
     def _compute_department_member_count(self):
         for partner in self:
-            partner.department_member_count = len(partner.department_member_ids)
+            partner.department_member_count = len(partner.department_all_member_ids)
 
     def action_view_department_members(self):
+        sub_depts = self.env["res.partner"].search(
+            [("department_id", "=", self.id), ("type", "=", "department")]
+        )
+        dept_ids = [self.id] + sub_depts.ids
         return {
             "type": "ir.actions.act_window",
             "name": "Members",
             "res_model": "res.partner",
             "view_mode": "list,form",
-            "domain": [("department_id", "=", self.id)],
+            "domain": [
+                ("department_id", "in", dept_ids),
+                ("type", "!=", "department"),
+            ],
             "context": {"default_department_id": self.id},
         }
+
+    @api.constrains("parent_id", "type")
+    def _check_parent_not_department(self):
+        for partner in self:
+            if (
+                partner.parent_id
+                and partner.type in ("contact", "department")
+                and partner.parent_id.type == "department"
+            ):
+                raise ValidationError(
+                    self.env._(
+                        "A partner contact/department cannot have"
+                        " a department as its parent."
+                    )
+                )

--- a/partner_department/tests/test_partner_department.py
+++ b/partner_department/tests/test_partner_department.py
@@ -1,6 +1,7 @@
 # Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from odoo.exceptions import ValidationError
 from odoo.tests import common
 
 
@@ -44,9 +45,30 @@ class TestPartnerDepartment(common.TransactionCase):
         self.assertEqual(self.contact2.department_id, self.department)
 
     def test_department_member_ids(self):
-        """department_member_ids returns all contacts assigned to the department"""
+        """department_member_ids returns direct contacts (excluding sub-departments)"""
         self.assertIn(self.contact1, self.department.department_member_ids)
         self.assertIn(self.contact2, self.department.department_member_ids)
+
+    def test_department_all_member_ids_includes_sub_dept_members(self):
+        """department_all_member_ids includes members from sub-departments"""
+        sub_dept = self.Partner.create(
+            {
+                "name": "Frontend",
+                "type": "department",
+                "parent_id": self.company.id,
+                "department_id": self.department.id,
+            }
+        )
+        sub_contact = self.Partner.create(
+            {
+                "name": "Sub Contact",
+                "parent_id": self.company.id,
+                "department_id": sub_dept.id,
+            }
+        )
+        self.assertIn(sub_contact, self.department.department_all_member_ids)
+        self.assertNotIn(sub_contact, self.department.department_member_ids)
+        self.assertNotIn(sub_dept, self.department.department_all_member_ids)
 
     def test_search_by_department_type(self):
         """Can search partners filtered by type='department'"""
@@ -83,3 +105,29 @@ class TestPartnerDepartment(common.TransactionCase):
         )
         self.assertIn(contact, dept_sales.department_member_ids)
         self.assertNotIn(contact, self.department.department_member_ids)
+
+    def test_department_ids_contains_departments(self):
+        """department_ids contains only department-type children"""
+        self.assertIn(self.department, self.company.department_ids)
+        self.assertNotIn(self.contact1, self.company.department_ids)
+
+    def test_non_department_cannot_have_department_parent(self):
+        """A non-department partner cannot have a department as its parent_id"""
+        with self.assertRaises(ValidationError):
+            self.Partner.create(
+                {
+                    "name": "Bad Contact",
+                    "parent_id": self.department.id,
+                }
+            )
+
+    def test_department_cannot_have_department_parent(self):
+        """No partner, not even a department, can have a department as its parent_id"""
+        with self.assertRaises(ValidationError):
+            self.Partner.create(
+                {
+                    "name": "Frontend",
+                    "type": "department",
+                    "parent_id": self.department.id,
+                }
+            )

--- a/partner_department/views/res_partner_view.xml
+++ b/partner_department/views/res_partner_view.xml
@@ -31,7 +31,7 @@
                     options='{"no_open": False}'
                 />
             </xpath>
-            <!-- Same field inside the Contacts &amp; Addresses sub-form -->
+            <!-- department_id inside the Contacts child_ids form -->
             <xpath
                 expr="//field[@name='child_ids']/form//field[@name='function']"
                 position="after"
@@ -44,32 +44,120 @@
                 />
             </xpath>
             <!-- Exclude department-type partners from the Contacts tab -->
-            <xpath expr="//field[@name='child_ids']" position="attributes">
+            <xpath
+                expr="//page[@name='contact_addresses']//field[@name='child_ids']"
+                position="attributes"
+            >
                 <attribute name="domain">[('type', '!=', 'department')]</attribute>
             </xpath>
-            <!-- Departments tab, right after the Contacts tab -->
+            <!-- Members and Departments tabs, right after the Contacts tab -->
             <xpath expr="//page[@name='contact_addresses']" position="after">
-                <page string="Departments" invisible="not department_ids">
-                    <field name="department_ids">
-                        <list>
-                            <field name="name" />
-                            <field name="function" />
-                            <field name="phone" />
-                            <field name="email" />
-                        </list>
+                <page string="Members" invisible="type != 'department'">
+                    <field name="department_all_member_ids" readonly="1">
+                        <kanban color="color" create="0">
+                            <field name="color" />
+                            <field name="type" />
+                            <field name="is_company" />
+                            <templates>
+                                <t t-name="card" class="flex-row">
+                                    <aside class="o_kanban_aside_full">
+                                        <field
+                                            name="avatar_128"
+                                            class="o_kanban_image_fill w-100"
+                                            widget="image"
+                                            options="{'img_class': 'object-fit-cover'}"
+                                            alt="Contact image"
+                                        />
+                                    </aside>
+                                    <main class="ps-2 ps-md-0">
+                                        <field
+                                            name="name"
+                                            invisible="not name"
+                                            class="fw-bold"
+                                        />
+                                        <div
+                                            t-if="record.email.raw_value"
+                                            class="text-truncate"
+                                        >
+                                            <i
+                                                class="fa fa-fw me-1 fa-envelope text-primary"
+                                                title="Email"
+                                            />
+                                            <field name="email" />
+                                        </div>
+                                        <div t-if="record.phone.raw_value">
+                                            <i
+                                                class="fa fa-fw me-1 fa-phone text-primary"
+                                                title="Phone"
+                                            />
+                                            <field name="phone" />
+                                        </div>
+                                        <div invisible="not function">
+                                            <i
+                                                class="fa fa-fw me-1 fa-suitcase text-primary"
+                                                title="Position"
+                                            />
+                                            <field name="function" />
+                                        </div>
+                                    </main>
+                                </t>
+                            </templates>
+                        </kanban>
                     </field>
                 </page>
-            </xpath>
-            <!-- Members tab, only visible when this partner is a department -->
-            <xpath expr="//notebook" position="inside">
-                <page string="Members" invisible="type != 'department'">
-                    <field name="department_member_ids">
+                <page string="Departments" invisible="not department_ids">
+                    <field
+                        name="department_ids"
+                        context="{'default_type': 'department', 'default_parent_id': parent_id}"
+                    >
                         <list>
                             <field name="name" />
                             <field name="function" />
                             <field name="phone" />
                             <field name="email" />
                         </list>
+                        <form string="Department">
+                            <sheet>
+                                <field name="type" invisible="True" />
+                                <h3>
+                                    <field
+                                        name="name"
+                                        class="d-block"
+                                        string="Name"
+                                        default_focus="1"
+                                        required="1"
+                                        placeholder="e.g. Engineering"
+                                    />
+                                </h3>
+                                <div class="row flex-row">
+                                    <div class="d-flex align-items-baseline">
+                                        <i
+                                            class="fa fa-fw me-1 fa-envelope text-primary"
+                                            title="Email"
+                                        />
+                                        <field
+                                            name="email"
+                                            widget="email"
+                                            class="w-100"
+                                            placeholder="Email"
+                                        />
+                                    </div>
+                                    <div class="d-flex align-items-baseline">
+                                        <i
+                                            class="fa fa-fw me-1 fa-phone text-primary"
+                                            title="Phone"
+                                        />
+                                        <field
+                                            name="phone"
+                                            widget="phone"
+                                            class="w-100"
+                                            placeholder="Phone"
+                                        />
+                                    </div>
+                                </div>
+                                <field name="parent_id" invisible="True" />
+                            </sheet>
+                        </form>
                     </field>
                 </page>
             </xpath>


### PR DESCRIPTION
Switch the Members tab to kanban mode aligned with the Contacts tab. Add inline form dialogs to Members and Departments tabs so the partner type is pre-set via context when creating records. Change the child_ids department exclusion domain by a constraint: partners cannot have a department as parent_id.