### PR TITLE
[19.0][IMP] partner_supplier_ref: show supplier_ref in partner list view

### DIFF
--- a/partner_supplier_ref/views/res_partner_view.xml
+++ b/partner_supplier_ref/views/res_partner_view.xml
@@ -13,4 +13,14 @@
             </group>
         </field>
     </record>
+    <record id="view_partner_tree" model="ir.ui.view">
+        <field name="name">res.partner.list - supplier.reference</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree" />
+        <field name="arch" type="xml">
+            <field name="complete_name" position="before">
+                <field name="supplier_ref" optional="hide" />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Add the supplier_ref field to the res.partner list view as an optional column hidden by default, placed before the name column.