### PR TITLE
[16.0][FIX] partner_archive_propagate: actually do not archive deleted lines from wizard

### DIFF
--- a/partner_archive_propagate/tests/test_archive.py
+++ b/partner_archive_propagate/tests/test_archive.py
@@ -215,3 +215,29 @@ class TestPartnerArchivePropagate(TransactionCase):
         self.assertIn("Skipped contacts linked to active users", params["message"])
         # for partner B
         self.assertIn(self.B.name, params["message"])
+
+    def test_wizard_deleted_line_not_archived(self):
+        self.B.write({"type": "contact", "active": True, "propagated_from_id": False})
+        self.E.write({"type": "contact", "active": True, "propagated_from_id": False})
+        self.A.write({"active": True})
+        # Simulate user removing B from the list: only E remains in line_ids.
+        Wiz = (
+            self.env["res.partner.archive.propagate.wizard"]
+            .sudo()
+            .create(
+                {
+                    "partner_id": self.A.id,
+                    "line_ids": [(0, 0, {"partner_id": self.E.id})],
+                }
+            )
+        )
+        result = Wiz.action_confirm()
+        self.assertEqual(result, {"type": "ir.actions.act_window_close"})
+        # Organisation must be archived
+        self.assertFalse(self.A.active)
+        # E was in the list and must be archived
+        self.assertFalse(self.E.active)
+        self.assertEqual(self.E.propagated_from_id, self.A)
+        # B was removed from the list and must remain as it was
+        self.assertTrue(self.B.active)
+        self.assertFalse(bool(self.B.propagated_from_id))

--- a/partner_archive_propagate/wizard/archive_propagate_wizard_views.xml
+++ b/partner_archive_propagate/wizard/archive_propagate_wizard_views.xml
@@ -16,7 +16,7 @@
                         Remove any you want to keep active.
                     </div>
                     <field name="line_ids" nolabel="1" colspan="2">
-                        <tree editable="bottom">
+                        <tree create="0">
                             <field name="partner_id" />
                             <field name="name" readonly="1" />
                             <field name="email" readonly="1" />


### PR DESCRIPTION
Bug: Removing a contact from the wizard list before confirming had no effect; the contact was archived regardless

Fix: Replace editable="bottom" with create="0" in archive_propagate_wizard_views.xml. Row deletions are then posted to the server immediately, and create="0" also drops the "Add a line" footer while keeping the trash icon