### PR TITLE
[19.0][FIX] partner_contact_address_default: invalidate parent cache on archive

### DIFF
--- a/partner_contact_address_default/__manifest__.py
+++ b/partner_contact_address_default/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Partner Contact address default",
     "summary": "Set a default delivery address, "
     "invoice address and contact for contacts",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "development_status": "Beta",
     "category": "Generic Modules/Base",
     "website": "https://github.com/OCA/partner-contact",

--- a/partner_contact_address_default/models/res_partner.py
+++ b/partner_contact_address_default/models/res_partner.py
@@ -69,13 +69,20 @@ class ResPartner(models.Model):
     def write(self, vals):
         """We want to prevent archived contacts as default addresses"""
         if vals.get("active") is False:
-            self.search([("partner_delivery_id", "in", self.ids)]).write(
-                {"partner_delivery_id": False}
-            )
-            self.search([("partner_invoice_id", "in", self.ids)]).write(
-                {"partner_invoice_id": False}
-            )
-            self.search([("partner_contact_id", "in", self.ids)]).write(
-                {"partner_contact_id": False}
+            parents_delivery = self.search([("partner_delivery_id", "in", self.ids)])
+            parents_invoice = self.search([("partner_invoice_id", "in", self.ids)])
+            parents_contact = self.search([("partner_contact_id", "in", self.ids)])
+            parents_delivery.write({"partner_delivery_id": False})
+            parents_invoice.write({"partner_invoice_id": False})
+            parents_contact.write({"partner_contact_id": False})
+            # Invalidate cache on parent partners so that stale values
+            # are not returned by address_get in multi-module contexts
+            all_parents = parents_delivery | parents_invoice | parents_contact
+            all_parents.invalidate_recordset(
+                fnames=[
+                    "partner_delivery_id",
+                    "partner_invoice_id",
+                    "partner_contact_id",
+                ]
             )
         return super().write(vals)

--- a/partner_contact_address_default/tests/test_partner_contact_address_default.py
+++ b/partner_contact_address_default/tests/test_partner_contact_address_default.py
@@ -66,6 +66,15 @@ class TestPartnerContactAddressDefault(common.TransactionCase):
         self.assertEqual(res["invoice"], self.partner.id)
         self.assertEqual(res["contact"], self.partner.id)
 
+    def test_contact_address_archived_cache(self):
+        self.partner.partner_delivery_id = self.partner_child_delivery2
+        # Prime the cache by reading the field before archiving the child
+        _ = self.partner.partner_delivery_id.id
+        self.partner_child_delivery2.write({"active": False})
+        res = self.partner.address_get(["delivery"])
+        # Ensure no stale cached id from the archived child is returned
+        self.assertEqual(res["delivery"], self.partner_child_delivery1.id)
+
     def test_partner_domains(self):
         self.partner._compute_partner_domains()
         expected_base = [("id", "child_of", self.partner.commercial_partner_id.ids)]


### PR DESCRIPTION
Closes #2347

When a child contact is archived, the parent partner fields partner_delivery_id, partner_invoice_id and partner_contact_id are cleared.  Without explicit cache invalidation, stale values can persist in multi-module contexts and be returned by address_get.

Changes:
- Split parent search and cache invalidation into explicit steps
- Call invalidate_recordset on aggregated parent set for all three fields
- Add test to verify no stale cached id after archiving child

Run pre-commit locally: passed.