### PR TITLE
[18.0][FIX] res_partner: skip company default when install_mode is active

### DIFF
--- a/partner_company_default/models/res_partner.py
+++ b/partner_company_default/models/res_partner.py
@@ -16,6 +16,7 @@ class ResPartner(models.Model):
         context = self.env.context
         if (
             context.get("creating_from_company")
+            or context.get("install_mode")
             or config["test_enable"]
             and not context.get("test_partner_company_default")
         ):


### PR DESCRIPTION
# [FIX] res_partner: skip company default when install_mode is active

During module installation, Odoo sets `install_mode=True` in the context when loading XML data. In this scenario,
`_default_company_id` was assigning `env.company` to every partner created without an explicit company_id, regardless of which company the record was intended for.

This causes a ValidationError when a localization module (e.g. l10n_ca) creates bank accounts for a demo company different from the one active at install time, as the partner ends up with the wrong company and fails the journal's bank account company check.

Skip the default when `install_mode` is present in context, since XML data loading could remain company-neutral.