### PR TITLE
[19.0][IMP] partner_identification: Respect ID expiry in compute/inverse/search

### DIFF
--- a/partner_identification/models/res_partner.py
+++ b/partner_identification/models/res_partner.py
@@ -19,6 +19,14 @@ class ResPartner(models.Model):
         string="Identification Numbers",
     )
 
+    def _get_active_id_numbers(self, category_code):
+        """Return active (non-expired) ID numbers for the given category."""
+        return self.id_numbers.filtered(
+            lambda r: r.category_id.code == category_code
+            and r.active
+            and r.status != "close"
+        )
+
     @api.depends("id_numbers")
     def _compute_identification(self, field_name, category_code):
         """Compute a field that indicates a certain ID type.
@@ -50,9 +58,7 @@ class ResPartner(models.Model):
             category_code (str): Category code of the Identification type.
         """
         for record in self:
-            id_numbers = record.id_numbers.filtered(
-                lambda r: r.category_id.code == category_code
-            )
+            id_numbers = record._get_active_id_numbers(category_code)
             if not id_numbers:
                 # As this is used as a compute method
                 # we need to assign something
@@ -94,9 +100,7 @@ class ResPartner(models.Model):
             category_code (str): Category code of the Identification type.
         """
         for record in self:
-            id_number = record.id_numbers.filtered(
-                lambda r: r.category_id.code == category_code
-            )
+            id_number = record._get_active_id_numbers(category_code)
             record_len = len(id_number)
             # Record for category is not existent.
             if record_len == 0:
@@ -164,6 +168,11 @@ class ResPartner(models.Model):
             list: Domain to search with.
         """
         id_numbers = self.env["res.partner.id_number"].search(
-            [("name", operator, value), ("category_id.code", "=", category_code)]
+            [
+                ("name", operator, value),
+                ("category_id.code", "=", category_code),
+                ("active", "=", True),
+                ("status", "!=", "close"),
+            ]
         )
         return [("id_numbers.id", "in", id_numbers.ids)]

--- a/partner_identification/tests/test_res_partner.py
+++ b/partner_identification/tests/test_res_partner.py
@@ -84,3 +84,105 @@ class TestResPartner(common.TransactionCase):
         self.partner.social_security = "Test"
         partner = self.env["res.partner"].search([("social_security", "=", "Test")])
         self.assertEqual(partner, self.partner)
+
+    def test_compute_identification_skips_inactive(self):
+        """It should skip inactive/expired IDs when computing."""
+        category_ssn = self.env["res.partner.id_category"].create(
+            {"code": "SSN", "name": "SSN"}
+        )
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "Expired-SSN",
+                "category_id": category_ssn.id,
+                "partner_id": self.partner.id,
+                "active": False,
+                "status": "close",
+            }
+        )
+        active_id = self.env["res.partner.id_number"].create(
+            {
+                "name": "Active-SSN",
+                "category_id": category_ssn.id,
+                "partner_id": self.partner.id,
+            }
+        )
+        self.partner._compute_identification("social_security", "SSN")
+        self.assertEqual(self.partner.social_security, active_id.name)
+
+    def test_inverse_identification_creates_new_when_expired(self):
+        """It should create a new ID when the existing one is expired."""
+        category_ssn = self.env["res.partner.id_category"].create(
+            {"code": "SSN", "name": "SSN"}
+        )
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "Old-SSN",
+                "category_id": category_ssn.id,
+                "partner_id": self.partner.id,
+                "active": False,
+                "status": "close",
+            }
+        )
+        self.partner.social_security = "New-SSN"
+        active_ids = self.partner.id_numbers.filtered(
+            lambda r: r.category_id.code == "SSN" and r.active and r.status != "close"
+        )
+        self.assertEqual(len(active_ids), 1)
+        self.assertEqual(active_ids.name, "New-SSN")
+        old_ids = (
+            self.env["res.partner.id_number"]
+            .with_context(active_test=False)
+            .search(
+                [
+                    ("category_id.code", "=", "SSN"),
+                    ("partner_id", "=", self.partner.id),
+                    ("status", "=", "close"),
+                ]
+            )
+        )
+        self.assertEqual(len(old_ids), 1)
+        self.assertEqual(old_ids.name, "Old-SSN")
+
+    def test_inverse_identification_no_exception_when_one_active(self):
+        """It should not raise when multiple IDs exist but only one active."""
+        category_ssn = self.env["res.partner.id_category"].create(
+            {"code": "SSN", "name": "SSN"}
+        )
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "Expired-SSN-1",
+                "category_id": category_ssn.id,
+                "partner_id": self.partner.id,
+                "active": False,
+                "status": "close",
+            }
+        )
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "Active-SSN",
+                "category_id": category_ssn.id,
+                "partner_id": self.partner.id,
+            }
+        )
+        # Should not raise ValidationError
+        self.partner.social_security = "Updated-SSN"
+        self.assertEqual(self.partner.social_security, "Updated-SSN")
+
+    def test_search_identification_excludes_inactive(self):
+        """It should not return partners whose only matching ID is expired."""
+        category_ssn = self.env["res.partner.id_category"].create(
+            {"code": "SSN", "name": "SSN"}
+        )
+        self.env["res.partner.id_number"].create(
+            {
+                "name": "Unique-Expired",
+                "category_id": category_ssn.id,
+                "partner_id": self.partner.id,
+                "active": False,
+                "status": "close",
+            }
+        )
+        result = self.env["res.partner"].search(
+            [("social_security", "=", "Unique-Expired")]
+        )
+        self.assertFalse(result)


### PR DESCRIPTION
Forward-port of #2356 to 19.0.

When an identification has expired (active=False, status=close), the compute, inverse, and search methods should not consider it as the current active ID for the partner.

**Changes:**
- Add `_get_active_id_numbers()` helper filtering by `active=True` and `status != 'close'`
- `_compute_identification`: use helper to skip expired IDs
- `_inverse_identification`: use helper to allow creating new ID when existing ones are expired
- `_search_identification`: exclude inactive/closed IDs from search domain

Closes #2196

@NL66278