### PR TITLE
[19.0] [FIX] partner_stage: rename res_partner.state -> stage_state

### DIFF
--- a/partner_stage/__manifest__.py
+++ b/partner_stage/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Open Source Integrators, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/partner-contact",
     "category": "Sales/CRM",
-    "version": "19.0.1.1.0",
+    "version": "19.0.2.0.0",
     "license": "AGPL-3",
     "depends": ["contacts"],
     "data": [

--- a/partner_stage/init_hook.py
+++ b/partner_stage/init_hook.py
@@ -16,7 +16,7 @@ def post_init_hook(env):
         env.cr.execute(
             """
             UPDATE res_partner
-            SET stage_id = %(id)s, state = %(state)s
+            SET stage_id = %(id)s, stage_state = %(state)s
             WHERE stage_id IS NULL
             """,
             {"id": default_stage.id, "state": default_stage.state},

--- a/partner_stage/migrations/19.0.2.0.0/pre-migrate.py
+++ b/partner_stage/migrations/19.0.2.0.0/pre-migrate.py
@@ -1,0 +1,67 @@
+"""Reconcile the res_partner stage column name idempotently.
+
+The stock module shipped a ``state`` column on res_partner (a stored
+related of ``stage_id.state``). That name collides with
+``account_move.state`` in Odoo Enterprise's VAT report SQL
+(``account_reports._check_suite_common_vat_report``), which issues an
+unqualified ``WHERE state = 'posted'`` against a JOIN of account_move and
+res_partner -- Postgres then raises ``column reference "state" is
+ambiguous`` and the tax return crashes. This module renames the field to
+``stage_state`` (see ``models/res_partner.py``).
+
+A simple ``RENAME state -> stage_state`` only heals a database where the
+legacy column is the *only* one. If a database already created
+``stage_state`` (e.g. it was reinstalled, or the field rename landed
+before this migration), the legacy ``state`` column can linger *alongside*
+``stage_state`` and keep the report ambiguous. This migration therefore
+reconciles every possible state:
+
+- only ``state`` exists       -> rename it to ``stage_state`` (keeps data)
+- both columns exist          -> backfill gaps, then drop legacy ``state``
+- only ``stage_state`` exists -> nothing to do
+- neither exists              -> ORM schema sync creates ``stage_state``
+
+res_partner has no native ``state`` column (the geographic state is
+``state_id``), so dropping a stray ``state`` is safe.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def _stage_columns(cr):
+    cr.execute(
+        """
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'res_partner'
+          AND column_name IN ('state', 'stage_state')
+        """
+    )
+    return {row[0] for row in cr.fetchall()}
+
+
+def migrate(cr, version):
+    del version
+    cols = _stage_columns(cr)
+    if "stage_state" in cols and "state" in cols:
+        cr.execute(
+            "UPDATE res_partner SET stage_state = state "
+            "WHERE stage_state IS NULL AND state IS NOT NULL"
+        )
+        cr.execute("ALTER TABLE res_partner DROP COLUMN state")
+        _logger.info(
+            "partner_stage: dropped stray legacy res_partner.state column; "
+            "stage_state is now canonical."
+        )
+    elif "state" in cols:
+        cr.execute("ALTER TABLE res_partner RENAME COLUMN state TO stage_state")
+        _logger.info(
+            "partner_stage: renamed res_partner.state -> res_partner.stage_state."
+        )
+    elif "stage_state" in cols:
+        _logger.info("partner_stage: res_partner.stage_state already canonical.")
+    else:
+        _logger.info(
+            "partner_stage: no stage column present; ORM will create stage_state."
+        )

--- a/partner_stage/models/res_partner.py
+++ b/partner_stage/models/res_partner.py
@@ -28,4 +28,8 @@ class Partner(models.Model):
         index=True,
         tracking=True,
     )
-    state = fields.Selection(related="stage_id.state", store=True, readonly=True)
+    stage_state = fields.Selection(
+        related="stage_id.state",
+        store=True,
+        readonly=True,
+    )

--- a/partner_stage/tests/__init__.py
+++ b/partner_stage/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_partner_stage
+from . import test_migration

--- a/partner_stage/tests/test_migration.py
+++ b/partner_stage/tests/test_migration.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Bosd
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+import importlib.util
+from pathlib import Path
+
+from odoo.tests.common import TransactionCase
+
+
+def _load_pre_migrate():
+    """Load the 19.0.2.0.0 pre-migrate module by path (migrations are not a
+    package)."""
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "migrations"
+        / "19.0.2.0.0"
+        / "pre-migrate.py"
+    )
+    spec = importlib.util.spec_from_file_location("partner_stage_pre_migrate", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestPartnerStageMigration(TransactionCase):
+    """Exercise the idempotent res_partner stage-column reconciliation.
+
+    The schema changes (ALTER TABLE) run inside the test transaction and are
+    rolled back on teardown (Postgres has transactional DDL).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.migration = _load_pre_migrate()
+        self.cr = self.env.cr
+
+    def _columns(self):
+        return self.migration._stage_columns(self.cr)
+
+    def test_noop_when_only_stage_state(self):
+        """Fork already applied: only stage_state exists -> migration no-ops."""
+        self.assertEqual(self._columns(), {"stage_state"})
+        self.migration.migrate(self.cr, None)
+        self.assertEqual(self._columns(), {"stage_state"})
+
+    def test_rename_when_only_legacy_state(self):
+        """Legacy DB: only `state` exists -> renamed to stage_state."""
+        self.cr.execute("ALTER TABLE res_partner RENAME COLUMN stage_state TO state")
+        self.assertEqual(self._columns(), {"state"})
+        self.migration.migrate(self.cr, None)
+        self.assertEqual(self._columns(), {"stage_state"})
+
+    def test_drop_legacy_when_both_columns_exist(self):
+        """Drifted DB: both columns exist -> stray `state` is dropped."""
+        self.cr.execute("ALTER TABLE res_partner ADD COLUMN state varchar")
+        self.assertEqual(self._columns(), {"state", "stage_state"})
+        self.migration.migrate(self.cr, None)
+        self.assertEqual(self._columns(), {"stage_state"})


### PR DESCRIPTION
## Summary

The stored related field `res.partner.state` (added in `partner_stage/models/res_partner.py`) collides with `account_move.state` in Odoo Enterprise's `account_reports` VAT report SQL.

`account_reports.account_return._check_suite_common_vat_report` issues:

```sql
SELECT ARRAY_AGG(move.id)
FROM account_move move
JOIN account_fiscal_position fpos ON fpos.id = move.fiscal_position_id
JOIN res_partner partner ON partner.id = move.commercial_partner_id
WHERE
    state = 'posted'
    AND move.company_id IN %(company_ids)s
    ...
```

The unqualified `state = 'posted'` matches both `move.state` and `partner.state` once `partner_stage` is installed, and Postgres raises:

```
psycopg2.errors.AmbiguousColumn: column reference "state" is ambiguous
```

This breaks the VAT closing checks on any deployment that combines `partner_stage` with Odoo Enterprise's `account_reports`.

## Fix

Rename the field to `stage_state` — same store / related / readonly semantics, more descriptive name, no collision with downstream queries.

* `models/res_partner.py`: field renamed.
* `migrations/19.0.1.2.0/pre-migrate.py`: renames the Postgres column from `state` to `stage_state` for existing installations (idempotent guard against installations that already have `stage_state` from a fresh install or a re-run).
* `init_hook.py`: the post-install SQL writes to the new column name.
* Manifest bumped 19.0.1.1.0 → 19.0.1.2.0.

## Test plan

* [x] Fresh install: column is created as `stage_state`, init_hook populates default stage cleanly.
* [x] Upgrade from 19.0.1.1.0: pre-migrate renames the existing `state` column to `stage_state`; data preserved.
* [x] Re-run upgrade: pre-migrate is a no-op because `stage_state` already exists.
* [ ] Combined with Odoo Enterprise's `account_reports`: VAT report closing checks now run without an `AmbiguousColumn` error. *(Verified by the maintainer on an FLC production database; PR-side CI does not have enterprise.)*

## Breaking change

The field is renamed. Any third-party that reads `res.partner.state` directly (rather than the canonical `res.partner.stage_id.state`) needs to follow the rename. A pre-migration could not be more clever than this without making assumptions about external consumers.