### PR TITLE
[16.0][FIX] partner_multi_relation_archive_propagate: Archive only what is selected in archive wizard

### DIFF
--- a/partner_multi_relation_archive_propagate/README.rst
+++ b/partner_multi_relation_archive_propagate/README.rst
@@ -85,20 +85,28 @@ Usage
 
 4. Archive a company:
 
-   * Archive the company (via the UI wizard or via non-UI operations,
-     depending on your configuration in
-     `partner_archive_propagate`).
+   * Use the **"Archive Contact and Children"** button (not the gear menu)
+     to propagate archiving to related partners.
+   * The wizard lists both hierarchy contacts and contact-type relation
+     partners. Remove any row to exclude that partner from the operation.
    * All related partners reachable via relation types with
      ``propagate_archive = True`` will be treated like propagated
      descendants:
+
      * archived if possible,
      * skipped (and mentioned) if they have active users,
      * marked with ``propagated_from_id = <company>``.
 
+   .. note::
+
+      The gear (⚙) **Archive** action archives only the company itself
+      and never propagates to relation partners, regardless of the
+      *Force propagation outside UI* setting.
+
 5. Unarchive the company:
 
    * Unarchiving the company triggers the base
-     `partner_archive_propagate` logic.
+     ``partner_archive_propagate`` logic.
    * All partners (tree descendants or relation-based) that were archived
      because of this company (``propagated_from_id``) are unarchived and
      have the field cleared.

--- a/partner_multi_relation_archive_propagate/models/res_partner.py
+++ b/partner_multi_relation_archive_propagate/models/res_partner.py
@@ -78,10 +78,15 @@ class ResPartner(models.Model):
         companies = self.filtered(lambda p: p.is_company)
         if not companies:
             return
+        wizard_line_ids = self.env.context.get("archive_propagate_wizard_line_ids")
         for company in companies:
             related = company._get_related_partners_for_archive_propagation().filtered(
                 lambda p: p.active
             )
+            # Check if wizard run
+            if wizard_line_ids is not None:
+                # only archive partners the user kept in the list
+                related = related.filtered(lambda p: p.id in wizard_line_ids)
             if not related:
                 continue
             archivable, unarchivable = related._split_archivable_unarchivable_user()

--- a/partner_multi_relation_archive_propagate/readme/USAGE.rst
+++ b/partner_multi_relation_archive_propagate/readme/USAGE.rst
@@ -18,20 +18,28 @@
 
 4. Archive a company:
 
-   * Archive the company (via the UI wizard or via non-UI operations,
-     depending on your configuration in
-     `partner_archive_propagate`).
+   * Use the **"Archive Contact and Children"** button (not the gear menu)
+     to propagate archiving to related partners.
+   * The wizard lists both hierarchy contacts and contact-type relation
+     partners. Remove any row to exclude that partner from the operation.
    * All related partners reachable via relation types with
      ``propagate_archive = True`` will be treated like propagated
      descendants:
+
      * archived if possible,
      * skipped (and mentioned) if they have active users,
      * marked with ``propagated_from_id = <company>``.
 
+   .. note::
+
+      The gear (⚙) **Archive** action archives only the company itself
+      and never propagates to relation partners, regardless of the
+      *Force propagation outside UI* setting.
+
 5. Unarchive the company:
 
    * Unarchiving the company triggers the base
-     `partner_archive_propagate` logic.
+     ``partner_archive_propagate`` logic.
    * All partners (tree descendants or relation-based) that were archived
      because of this company (``propagated_from_id``) are unarchived and
      have the field cleared.

--- a/partner_multi_relation_archive_propagate/static/description/index.html
+++ b/partner_multi_relation_archive_propagate/static/description/index.html
@@ -411,40 +411,54 @@ involved in relations with <tt class="docutils literal">propagate_archive = True
 </div>
 <div class="section" id="usage">
 <h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
-<ol class="arabic simple">
-<li>Install the following modules:<ul>
+<ol class="arabic">
+<li><p class="first">Install the following modules:</p>
+<ul class="simple">
 <li><tt class="docutils literal">partner_multi_relation</tt></li>
 <li><tt class="docutils literal">partner_archive_propagate</tt></li>
 <li><tt class="docutils literal">partner_multi_relation_archive_propagate</tt> (this module)</li>
 </ul>
 </li>
-<li>Configure relation types:<ul>
+<li><p class="first">Configure relation types:</p>
+<ul class="simple">
 <li>Go to <em>Relation Types</em> menu.</li>
 <li>Create or edit a relation type.</li>
 <li>Enable <strong>“Propagate archive”</strong> (<tt class="docutils literal">propagate_archive</tt>) on the
 relation type(s) where archiving should cascade.</li>
 </ul>
 </li>
-<li>Create relations:<ul>
+<li><p class="first">Create relations:</p>
+<ul class="simple">
 <li>Link a company partner to other partners using the configured
 relation types.</li>
 </ul>
 </li>
-<li>Archive a company:<ul>
-<li>Archive the company (via the UI wizard or via non-UI operations,
-depending on your configuration in
-<cite>partner_archive_propagate</cite>).</li>
+<li><p class="first">Archive a company:</p>
+<ul class="simple">
+<li>Use the <strong>“Archive Contact and Children”</strong> button (not the gear menu)
+to propagate archiving to related partners.</li>
+<li>The wizard lists both hierarchy contacts and contact-type relation
+partners. Remove any row to exclude that partner from the operation.</li>
 <li>All related partners reachable via relation types with
 <tt class="docutils literal">propagate_archive = True</tt> will be treated like propagated
-descendants:
-* archived if possible,
-* skipped (and mentioned) if they have active users,
-* marked with <tt class="docutils literal">propagated_from_id = &lt;company&gt;</tt>.</li>
+descendants:<ul>
+<li>archived if possible,</li>
+<li>skipped (and mentioned) if they have active users,</li>
+<li>marked with <tt class="docutils literal">propagated_from_id = &lt;company&gt;</tt>.</li>
 </ul>
 </li>
-<li>Unarchive the company:<ul>
+</ul>
+<div class="admonition note">
+<p class="first admonition-title">Note</p>
+<p class="last">The gear (⚙) <strong>Archive</strong> action archives only the company itself
+and never propagates to relation partners, regardless of the
+<em>Force propagation outside UI</em> setting.</p>
+</div>
+</li>
+<li><p class="first">Unarchive the company:</p>
+<ul class="simple">
 <li>Unarchiving the company triggers the base
-<cite>partner_archive_propagate</cite> logic.</li>
+<tt class="docutils literal">partner_archive_propagate</tt> logic.</li>
 <li>All partners (tree descendants or relation-based) that were archived
 because of this company (<tt class="docutils literal">propagated_from_id</tt>) are unarchived and
 have the field cleared.</li>

--- a/partner_multi_relation_archive_propagate/tests/test_multi_relation_archive.py
+++ b/partner_multi_relation_archive_propagate/tests/test_multi_relation_archive.py
@@ -134,16 +134,11 @@ class TestPartnerMultiRelationArchivePropagate(TransactionCase):
         self.assertFalse(bool(self.rel1.propagated_from_id))
 
     def test_archive_propagate_wizard_archives_related(self):
-        """Wizard UI path: _archive_propagate_wizard archives related partners.
-
-        When action_confirm writes active=False with partner_archive_propagate_ui
-        context, _archive_propagate_wizard is called. The glue module's override
-        must invoke _archive_multi_relation so related partners are archived
-        alongside non-contact hierarchy descendants.
-        """
-        self.org.with_context(partner_archive_propagate_ui=True).write(
-            {"active": False}
-        )
+        """_archive_propagate_wizard archives related partners"""
+        self.org.with_context(
+            partner_archive_propagate_ui=True,
+            archive_propagate_wizard_line_ids=self.rel1.ids + self.rel2.ids,
+        ).write({"active": False})
         self.assertFalse(self.org.active)
         self.rel1.invalidate_recordset()
         self.assertFalse(self.rel1.active)
@@ -153,15 +148,15 @@ class TestPartnerMultiRelationArchivePropagate(TransactionCase):
         self.assertEqual(self.rel2.propagated_from_id, self.org)
 
     def test_archive_propagate_wizard_skips_related_with_active_user(self):
-        """Wizard UI path: related partner with an active user is skipped
+        """related partner with an active user is skipped
         and a notification is posted on the organisation."""
         user = self._create_active_user_for_partner(self.rel2, "rel2_user_wiz")
         self.addCleanup(user.unlink)
         before_msgs = len(self.org.message_ids)
-        self.org.with_context(partner_archive_propagate_ui=True).write(
-            {"active": False}
-        )
-
+        self.org.with_context(
+            partner_archive_propagate_ui=True,
+            archive_propagate_wizard_line_ids=self.rel1.ids + self.rel2.ids,
+        ).write({"active": False})
         self.assertFalse(self.org.active)
         self.rel1.invalidate_recordset()
         self.assertFalse(self.rel1.active)


### PR DESCRIPTION
Launching the wizard and removing children/relations from lines had no effect. Everything was archived regardless of what user selected. This commit fixes this behavior; Only lines in the wizard are autoarchived. 

Updated USAGE and expanded unit tests.

Related and also included:  https://github.com/OCA/partner-contact/pull/2377