### PR TITLE
[18.0][FIX] partner_address_street3: copy street3 from parent on onchange

### DIFF
--- a/partner_address_street3/models/res_partner.py
+++ b/partner_address_street3/models/res_partner.py
@@ -18,6 +18,11 @@ class ResPartner(models.Model):
         res.append("street3")
         return res
 
+    @api.onchange("parent_id")
+    def _onchange_parent_id_street3(self):
+        if self.parent_id and self.type in ("contact", False):
+            self.street3 = self.parent_id.street3
+
     def _display_address(self, without_company=False):
         """Remove empty lines which can happen when street3 field is empty."""
         res = super()._display_address(without_company=without_company)

--- a/partner_address_street3/tests/test_street_3.py
+++ b/partner_address_street3/tests/test_street_3.py
@@ -41,6 +41,20 @@ class TestStreet3(TransactionCase):
         homer.write({"street3": "in OCA we trust"})
         self.assertEqual(bart.street3, "in OCA we trust")
 
+    def test_street3_copied_via_onchange_parent_id(self):
+        """street3 must be copied from parent when parent_id is set via onchange."""
+        company = self.env["res.partner"].create(
+            {
+                "name": "ACME Corp",
+                "is_company": True,
+                "street3": "Building C",
+            }
+        )
+        contact = self.env["res.partner"].new({"type": "contact"})
+        contact.parent_id = company
+        contact._onchange_parent_id_street3()
+        self.assertEqual(contact.street3, "Building C")
+
     def test_post_init_hook(self):
         from ..hooks import post_init_hook
 


### PR DESCRIPTION
## Problem

When creating a contact inside a company (via the Contacts tab or smart button on a company form), the form loads with `default_parent_id` in context and `onchange_parent_id` fires. Other address fields (street, street2, zip, city, state, country) are copied from the parent, but `street3` was not pre-filled in the form, even though `_address_fields()` correctly registers it.

Closes #2298

## Solution

Add an explicit `@api.onchange('parent_id')` method `_onchange_parent_id_street3` that copies `street3` from the parent company to the contact when `parent_id` is set and type is `contact`.

## Tests

Added `test_street3_copied_via_onchange_parent_id` using `env['res.partner'].new()` to simulate the form onchange path and assert `street3` is copied from parent.