### PR TITLE
[FIX] partner_email_check: fix external dependency name for email-validator

### DIFF
--- a/partner_email_check/__manifest__.py
+++ b/partner_email_check/__manifest__.py
@@ -12,7 +12,7 @@
     "installable": True,
     "application": False,
     "license": "AGPL-3",
-    "external_dependencies": {"python": ["email-validator"]},
+    "external_dependencies": {"python": ["email_validator"]},
     "data": ["views/base_config_view.xml"],
     "demo": ["demo/res_company_demo.xml"],
 }


### PR DESCRIPTION
The external_dependencies key used "email-validator" (with hyphen),
which is not a valid Python import name. Odoo checks dependencies by
importing them, so the correct name is "email_validator" (with underscore).
