### PR TITLE
[19.0][IMP] partner_supplier_ref: search partners by supplier reference

### DIFF
--- a/partner_supplier_ref/models/res_partner.py
+++ b/partner_supplier_ref/models/res_partner.py
@@ -7,6 +7,10 @@ from odoo import api, fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
+    @property
+    def _rec_names_search(self):
+        return super()._rec_names_search + ["supplier_ref"]
+
     supplier_ref = fields.Char(
         string="Supplier Reference",
         help="Supplier reference given to this partner.",

--- a/partner_supplier_ref/tests/test_partner_supplier_ref.py
+++ b/partner_supplier_ref/tests/test_partner_supplier_ref.py
@@ -29,3 +29,7 @@ class TestResPartner(TransactionCase):
     def test_supplier_ref_not_copied(self):
         partner_copy = self.supplier.copy()
         self.assertFalse(partner_copy.supplier_ref)
+
+    def test_name_search_by_supplier_ref(self):
+        results = self.partner_model.name_search("1038")
+        self.assertIn(self.supplier.id, [res[0] for res in results])


### PR DESCRIPTION
Include supplier_ref in name_search so partners can be found by their supplier reference from any partner field.

@ForgeFlow