### PR TITLE
[19.0][FIX] partner_company_default: don't stomp an explicit company assignment

### DIFF
--- a/partner_company_default/models/res_partner.py
+++ b/partner_company_default/models/res_partner.py
@@ -1,23 +1,37 @@
 # Copyright 2023 Quartile Limited
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import api, models
 from odoo.tools import config
 
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    company_id = fields.Many2one(default=lambda self: self._default_company_id())
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Deliberately a create() override rather than a default on
+        # ``company_id``: a field default is applied whenever the key is
+        # missing from the values, even when the company is being assigned
+        # some other way. With OCA's base_multi_company installed,
+        # ``company_id`` becomes a computed field whose inverse *replaces*
+        # the real ``company_ids``, so the default silently stomped any
+        # explicit ``company_ids`` passed to create() (and, under
+        # test_enable, wiped it entirely, as the guard's False still
+        # counted as an assigned value). Only fill the company when no
+        # company information was provided at all.
+        if self._apply_company_default():
+            for vals in vals_list:
+                if not vals.get("company_id") and not vals.get("company_ids"):
+                    vals["company_id"] = self.env.company.id
+        return super().create(vals_list)
 
     @api.model
-    def _default_company_id(self):
-        """Return False for other tests or if creating a company."""
+    def _apply_company_default(self):
+        """Skip when creating a company's own partner or for other tests."""
         context = self.env.context
-        if (
+        return not (
             context.get("creating_from_company")
             or config["test_enable"]
             and not context.get("test_partner_company_default")
-        ):
-            return False
-        return self.env.company
+        )

--- a/partner_company_default/tests/test_partner_company_default.py
+++ b/partner_company_default/tests/test_partner_company_default.py
@@ -44,3 +44,17 @@ class TestPartnerCompanyDefault(common.TransactionCase):
             .create({"name": "Test Partner 2"})
         )
         self.assertEqual(partner.company_id, company_fr)
+
+    def test_explicit_company_is_respected(self):
+        # An explicit company passed to create() must never be replaced by
+        # the default (the default only fills in when no company
+        # information is provided at all).
+        company_2 = self.env["res.company"].create({"name": "Other company"})
+        self.user.company_ids = [(4, company_2.id)]
+        partner = (
+            self.env["res.partner"]
+            .with_user(self.user.id)
+            .with_context(test_partner_company_default=True)
+            .create({"name": "Test Partner explicit", "company_id": company_2.id})
+        )
+        self.assertEqual(partner.company_id, company_2)


### PR DESCRIPTION
## Problem

The default on `company_id` is applied whenever the key is missing from the `create()` values, even when the company is being assigned some other way.

This composes badly with OCA's `base_multi_company` (multi-company repo), where `company_id` becomes a computed field whose inverse **replaces** the real `company_ids`:

- **Production**: `create({"name": "X", "company_ids": [(6, 0, [company_b.id])]})` silently ends up with `company_ids = [active company]` — the explicit assignment is stomped by the default's inverse. Easy to hit from imports or RPC.
- **Under `test_enable`**: the guard's `False` return still counts as an assigned value, fires the inverse, and wipes `company_ids` entirely — making several `partner_multi_company` tests fail whenever both modules are installed in the same test run.

Reproduction (production conditions, both modules installed):

```python
partner = env["res.partner"].create({"name": "P", "company_ids": [Command.set(co_a.ids)]})
partner.company_ids  # -> [active company], not [co_a]
```

## Fix

Replace the field default with a `create()` override that only fills the company in when no company information was provided at all (neither `company_id` nor `company_ids` in the values — a plain dict check, so no dependency on the multi-company modules).

Standalone behaviour is unchanged:
- partners created without a company still get the active company,
- a company's own partner stays global (`creating_from_company` guard),
- the test-mode guard keeps working.

An explicit company — either `company_id` or a multi-company `company_ids` — is now always respected.

## Testing

- Module's own tests green standalone on vanilla Odoo 19 (including a new regression test for an explicit `company_id`).
- Verified in combination with `base_multi_company`/`partner_multi_company`: explicit `company_ids` preserved, defaulting still applies when nothing is passed, and the previously failing combined test runs go green.
