### PR TITLE
[19.0][FIX] partner_firstname: always keep explicit name

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -71,7 +71,11 @@ class ResPartner(models.Model):
                         self._get_whitespace_cleaned_name(name), is_company
                     )
                     for key, value in inverted.items():
-                        if not vals.get(key) or partner_context.get("copy"):
+                        if (
+                            "name" in vals
+                            or not vals.get(key)
+                            or partner_context.get("copy")
+                        ):
                             vals[key] = value
 
                     # Remove the combined fields

--- a/partner_firstname/tests/test_partner_form.py
+++ b/partner_firstname/tests/test_partner_form.py
@@ -24,6 +24,20 @@ class PartnerCompanyCase(TransactionCase):
         self.assertEqual(partner_form.firstname, False)
         self.assertEqual(partner_form.lastname, name)
 
+    def test_create_from_form_keeps_name_over_default_name(self):
+        """If the name is updated in the create dialog, it must be saved instead of the
+        search term
+        """
+        with Form(
+            self.env["res.partner"].with_context(default_name="Test")
+        ) as partner_form:
+            partner_form.company_type = "company"
+            partner_form.name = "Full Test"
+
+        self.assertEqual(partner_form.name, "Full Test")
+        self.assertEqual(partner_form.firstname, False)
+        self.assertEqual(partner_form.lastname, "Full Test")
+
     def test_empty_name(self):
         """If we empty the name and save the form, EmptyNamesError must
         be raised (firstname and lastname are reset...)


### PR DESCRIPTION
When a partner is created from a m2o field, the search term is passed as ``default_name`` in the context and inverted into ``lastname`` by ``default_get``. Finishing the name in the create dialog does not refresh ``lastname`` so the search term ends up being saved instead.

With this change, an explicit ``name`` in ``vals`` overrides the inverted parts.