### PR TITLE
[17.0][FIX] partner_firstname: stabilize name inverse to avoid constraint errors

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -236,11 +236,20 @@ class ResPartner(models.Model):
         return {"lastname": parts[0], "firstname": parts[1]}
 
     def _inverse_name(self):
-        """Try to revert the effect of :meth:`._compute_name`."""
+        """
+        Try to revert the effect of :meth:`._compute_name`.
+
+        NOTE:
+        Field write order matters here. Each assignment triggers ``write()`` and
+        ``_check_name``. Writing falsy values first can cause transient
+        ``EmptyNamesError`` and previously made the ``mail`` module fail to install
+        unless it was installed before ``partner_firstname``.
+
+        We therefore use update() to prevent this issue.
+        """
         for record in self:
             parts = record._get_inverse_name(record.name, record.is_company)
-            record.lastname = parts["lastname"]
-            record.firstname = parts["firstname"]
+            record.update(parts)
 
     @api.constrains("firstname", "lastname")
     def _check_name(self):


### PR DESCRIPTION
## Fix inverse name computation

Backport of #2280 to 17.0.

Each field assignment in `_inverse_name()` triggered a separate `write()`
and constraint check. Writing falsy values first could temporarily put the
record in an invalid state and raise `EmptyNamesError`.