### PR TITLE
[19.0][FIX] partner_company_type: Fix UniqueViolation tests

### DIFF
--- a/partner_company_type/tests/test_res_partner_company_type.py
+++ b/partner_company_type/tests/test_res_partner_company_type.py
@@ -4,16 +4,17 @@
 from psycopg2 import IntegrityError
 
 from odoo import tools
-from odoo.tests.common import TransactionCase
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestResPartnerCompanyType(TransactionCase):
+class TestResPartnerCompanyType(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.company_type = cls.env["res.partner.company.type"].create(
             {
-                "name": "Anonymous Company",
+                "name": "Test Anonymous Company",
                 "shortcut": "AC",
             }
         )


### PR DESCRIPTION
Fix UniqueViolation tests

Prevent an error from occurring when running the tests if a record with that name already exists

```
ERROR: setUpClass (odoo.addons.partner_company_type.tests.test_res_partner_company_type.TestResPartnerCompanyType) Traceback (most recent call last):
  File "/opt/odoo/auto/addons/partner_company_type/tests/test_res_partner_company_type.py", line 14, in setUpClass
    cls.company_type = cls.env["res.partner.company.type"].create(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/custom/src/odoo/odoo/orm/decorators.py", line 369, in create
    return method(self, vals_list)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/custom/src/odoo/odoo/orm/models.py", line 4711, in create
    records = self._create(data_list)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/custom/src/odoo/odoo/orm/models.py", line 4887, in _create
    cr.execute(SQL(
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 440, in execute
    self._obj.execute(query, params)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "res_partner_company_type_name_uniq" DETAIL:  Key (name)=({"en_US": "Anonymous Company"}) already exists.
```

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa