### PR TITLE
[19.0][FIX] partner_department: filter departments out of the Contacts tab

### DIFF
--- a/partner_department/models/res_partner.py
+++ b/partner_department/models/res_partner.py
@@ -42,6 +42,16 @@ class ResPartner(models.Model):
         string="Departments",
     )
 
+    child_non_department_ids = fields.One2many(
+        "res.partner",
+        "parent_id",
+        domain=[("active", "=", True), ("type", "!=", "department")],
+        context={"active_test": False},
+        string="Contacts",
+        help="Children of this partner, excluding the department-type ones,"
+        " which are shown in their own tab.",
+    )
+
     @api.depends("department_member_ids")
     def _compute_department_all_member_ids(self):
         for dept in self:

--- a/partner_department/tests/test_partner_department.py
+++ b/partner_department/tests/test_partner_department.py
@@ -111,6 +111,29 @@ class TestPartnerDepartment(common.TransactionCase):
         self.assertIn(self.department, self.company.department_ids)
         self.assertNotIn(self.contact1, self.company.department_ids)
 
+    def test_child_non_department_ids_excludes_departments(self):
+        """child_non_department_ids has the children but not the departments"""
+        self.assertIn(self.contact1, self.company.child_non_department_ids)
+        self.assertIn(self.contact2, self.company.child_non_department_ids)
+        self.assertNotIn(self.department, self.company.child_non_department_ids)
+        self.assertIn(self.department, self.company.child_ids)
+
+    def test_child_non_department_ids_excludes_archived(self):
+        """Archived children are not shown, just like in child_ids"""
+        self.contact1.action_archive()
+        self.assertNotIn(self.contact1, self.company.child_non_department_ids)
+
+    def test_child_non_department_ids_is_writable(self):
+        """A contact created through the field becomes a child of the partner"""
+        self.company.write(
+            {"child_non_department_ids": [(0, 0, {"name": "New Contact"})]}
+        )
+        contact = self.company.child_non_department_ids.filtered(
+            lambda p: p.name == "New Contact"
+        )
+        self.assertEqual(contact.parent_id, self.company)
+        self.assertIn(contact, self.company.child_ids)
+
     def test_non_department_cannot_have_department_parent(self):
         """A non-department partner cannot have a department as its parent_id"""
         with self.assertRaises(ValidationError):

--- a/partner_department/views/res_partner_view.xml
+++ b/partner_department/views/res_partner_view.xml
@@ -31,24 +31,251 @@
                     options='{"no_open": False}'
                 />
             </xpath>
-            <!-- department_id inside the Contacts child_ids form -->
-            <xpath
-                expr="//field[@name='child_ids']/form//field[@name='function']"
-                position="after"
-            >
-                <field name="is_company" invisible="True" />
-                <field
-                    name="department_id"
-                    invisible="type != 'contact'"
-                    options='{"no_open": False}'
-                />
-            </xpath>
-            <!-- Exclude department-type partners from the Contacts tab -->
+            <!-- The `domain` attribute of an x2many is only used by the "Add"
+                 record selector, so it cannot filter out the department-type
+                 children from the Contacts tab. Hide `child_ids` and show
+                 `child_non_department_ids` instead, which is filtered by the
+                 domain of the field itself. -->
             <xpath
                 expr="//page[@name='contact_addresses']//field[@name='child_ids']"
                 position="attributes"
             >
-                <attribute name="domain">[('type', '!=', 'department')]</attribute>
+                <attribute name="invisible">True</attribute>
+            </xpath>
+            <xpath
+                expr="//page[@name='contact_addresses']//field[@name='child_ids']"
+                position="after"
+            >
+                <field
+                    name="child_non_department_ids"
+                    mode="kanban"
+                    context="{'default_parent_id': id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_lang': lang, 'default_user_id': user_id, 'default_type': is_company and 'contact' or 'other'}"
+                >
+                    <kanban color="color">
+                        <field name="color" />
+                        <field name="type" />
+                        <field name="is_company" />
+                        <templates>
+                            <t t-name="card" class="flex-row">
+                                <aside class="o_kanban_aside_full">
+                                    <field
+                                        name="avatar_128"
+                                        class="o_kanban_image_fill w-100"
+                                        widget="image"
+                                        options="{'img_class': 'object-fit-cover'}"
+                                        alt="Contact image"
+                                        invisible="type != 'contact'"
+                                    />
+                                    <field
+                                        name="avatar_128"
+                                        class="o_kanban_image_fill w-100"
+                                        widget="image"
+                                        options="{'img_class': 'object-fit-contain p-2'}"
+                                        alt="Contact image"
+                                        invisible="type == 'contact'"
+                                    />
+                                </aside>
+                                <main class="ps-2 ps-md-0">
+                                    <field
+                                        name="name"
+                                        invisible="not name"
+                                        class="fw-bold"
+                                    />
+                                    <field
+                                        name="type"
+                                        invisible="name"
+                                        class="fw-bold"
+                                    />
+                                    <div
+                                        t-if="record.email.raw_value"
+                                        class="text-truncate"
+                                    >
+                                        <i
+                                            class="fa fa-fw me-1 fa-envelope text-primary"
+                                            title="Email"
+                                        />
+                                        <field name="email" />
+                                    </div>
+                                    <div t-if="record.phone.raw_value">
+                                        <i
+                                            class="fa fa-fw me-1 fa-phone text-primary"
+                                            title="Phone"
+                                        />
+                                        <field name="phone" />
+                                    </div>
+                                    <div invisible="not function or is_company">
+                                        <i
+                                            class="fa fa-fw me-1 fa-suitcase text-primary"
+                                            title="Position"
+                                        />
+                                        <field name="function" />
+                                    </div>
+                                    <div
+                                        t-if="record.type.raw_value != 'contact' and (record.city.raw_value or record.country_id.raw_value)"
+                                    >
+                                        <i
+                                            class="fa fa-fw me-1 fa-map-marker text-primary"
+                                            title="Location"
+                                        />
+                                        <field name="city" />
+                                        <span
+                                            t-if="record.city.raw_value and record.country_id.raw_value"
+                                        >, </span>
+                                        <field name="country_id" />
+                                    </div>
+                                </main>
+                            </t>
+                        </templates>
+                    </kanban>
+                    <form string="Contact / Address">
+                        <sheet>
+                            <field
+                                name="type"
+                                required="1"
+                                widget="radio"
+                                options="{'horizontal': true}"
+                            />
+                            <field name="is_company" invisible="True" />
+                            <div class="d-flex align-items-center gap-3">
+                                <field
+                                    name="image_1920"
+                                    widget="contact_image"
+                                    nolabel="1"
+                                    options="{'preview_image': 'avatar_128', 'size': [100,100], 'img_class': 'rounded border'}"
+                                />
+                                <div class="flex-grow-1">
+                                    <h3>
+                                        <field
+                                            name="name"
+                                            class="d-block"
+                                            string="Name"
+                                            default_focus="1"
+                                            required="type == 'contact'"
+                                            placeholder="e.g. Brandon Freeman"
+                                        />
+                                    </h3>
+                                    <div class="row flex-row">
+                                        <div class="d-flex align-items-baseline">
+                                            <i
+                                                class="fa fa-fw me-1 fa-envelope text-primary"
+                                                title="Email"
+                                            />
+                                            <field
+                                                name="email"
+                                                widget="email"
+                                                class="w-100"
+                                                context="{'gravatar_image': True}"
+                                                required="user_ids"
+                                                placeholder="Email"
+                                            />
+                                        </div>
+                                        <div class="d-flex align-items-baseline">
+                                            <i
+                                                class="fa fa-fw me-1 fa-phone text-primary"
+                                                title="Phone"
+                                            />
+                                            <field
+                                                name="phone"
+                                                widget="phone"
+                                                class="w-100"
+                                                placeholder="Phone"
+                                            />
+                                        </div>
+                                        <div
+                                            invisible="is_company or type != 'contact'"
+                                            class="d-flex align-items-baseline"
+                                        >
+                                            <i
+                                                class="fa fa-fw me-1 fa-suitcase text-primary"
+                                                title="Position"
+                                            />
+                                            <field
+                                                name="function"
+                                                placeholder="Job title"
+                                            />
+                                        </div>
+                                        <div
+                                            invisible="type != 'contact'"
+                                            class="d-flex align-items-baseline"
+                                        >
+                                            <i
+                                                class="fa fa-fw me-1 fa-sitemap text-primary"
+                                                title="Department"
+                                            />
+                                            <field
+                                                name="department_id"
+                                                class="w-100"
+                                                options='{"no_open": False}'
+                                                placeholder="Department"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <group invisible="type == 'contact'" name="other_info">
+                                <group>
+                                    <span
+                                        class="o_form_label o_td_label o_address_type"
+                                    >
+                                        <field
+                                            name="type_address_label"
+                                            readonly="1"
+                                            class="fw-bold"
+                                        />
+                                    </span>
+                                    <div class="o_address_format" name="div_address">
+                                        <field
+                                            name="street"
+                                            placeholder="Street..."
+                                            class="o_address_street"
+                                        />
+                                        <field
+                                            name="street2"
+                                            placeholder="Street 2..."
+                                            class="o_address_street"
+                                        />
+                                        <field
+                                            name="city"
+                                            placeholder="City"
+                                            class="o_address_city"
+                                        />
+                                        <field
+                                            name="state_id"
+                                            class="o_address_state"
+                                            placeholder="State"
+                                            options="{'no_open': True, 'no_quick_create': True}"
+                                            context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"
+                                        />
+                                        <field
+                                            name="zip"
+                                            placeholder="ZIP"
+                                            class="o_address_zip"
+                                        />
+                                        <field
+                                            name="country_id"
+                                            placeholder="Country"
+                                            class="o_address_country"
+                                            options='{"no_open": True, "no_create": True}'
+                                        />
+                                    </div>
+                                </group>
+                            </group>
+                            <group>
+                                <!-- Need to save value from parented record, cf onchange -->
+                                <field name="company_id" invisible="1" />
+                                <label for="comment" />
+                                <field
+                                    name="comment"
+                                    options="{'height': 100}"
+                                    placeholder="Internal notes..."
+                                    nolabel="1"
+                                />
+                            </group>
+                            <!-- Need to add lang to save default value from parented record -->
+                            <field name="lang" invisible="True" />
+                        </sheet>
+                    </form>
+                </field>
             </xpath>
             <!-- Members and Departments tabs, right after the Contacts tab -->
             <xpath expr="//page[@name='contact_addresses']" position="after">


### PR DESCRIPTION
The `domain` attribute of an x2many is only used by the "Add" record selector, so it never filtered the department-type children out of the Contacts tab.

Add a `child_non_department_ids` one2many whose own domain excludes them, hide `child_ids` in that page and show the new field instead, keeping the `department_id` field in its inline form.