### PR TITLE
[19.0][FIX] partner_shipping_policy: Update dependencies for picking policy computation

### DIFF
--- a/partner_shipping_policy/models/sale_order.py
+++ b/partner_shipping_policy/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrder(models.Model):
         compute="_compute_picking_policy", store=True, readonly=False
     )
 
-    @api.depends("partner_id")
+    @api.depends("partner_shipping_id", "partner_id")
     def _compute_picking_policy(self):
         for this in self:
             picking_policy = (


### PR DESCRIPTION
Using only `partner_id` on the dependency is OK but the compute isn't called when updating ONLY `partner_shipping_id` and this one is the first used on the method.