### PR TITLE
[19.0][FIX] partner_shipping_policy: Update dependencies for picking policy computation

### DIFF
--- a/partner_shipping_policy/README.rst
+++ b/partner_shipping_policy/README.rst
@@ -73,10 +73,12 @@ Authors
 Contributors
 ------------
 
-- Marina Alapont <marina.alapont@forgeflow.com>
-- `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
+-  Marina Alapont <marina.alapont@forgeflow.com>
+-  `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
 
-  - Bhavesh Heliconia
+   -  Bhavesh Heliconia
+
+-  Italo Lopes <italo.lopes@camptocamp.com>
 
 Maintainers
 -----------

--- a/partner_shipping_policy/models/sale_order.py
+++ b/partner_shipping_policy/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrder(models.Model):
         compute="_compute_picking_policy", store=True, readonly=False
     )
 
-    @api.depends("partner_id")
+    @api.depends("partner_shipping_id", "partner_id")
     def _compute_picking_policy(self):
         for this in self:
             picking_policy = (

--- a/partner_shipping_policy/readme/CONTRIBUTORS.md
+++ b/partner_shipping_policy/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 - Marina Alapont \<<marina.alapont@forgeflow.com>\>
 - [Heliconia Solutions Pvt. Ltd.](https://www.heliconia.io)
   - Bhavesh Heliconia
+- Italo Lopes \<<italo.lopes@camptocamp.com>\>

--- a/partner_shipping_policy/static/description/index.html
+++ b/partner_shipping_policy/static/description/index.html
@@ -425,6 +425,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Bhavesh Heliconia</li>
 </ul>
 </li>
+<li>Italo Lopes &lt;<a class="reference external" href="mailto:italo.lopes&#64;camptocamp.com">italo.lopes&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Using only partner_id on the dependency is OK but the compute isn't called when updating ONLY partner_shipping_id and this one is the first used on the method.