### PR TITLE
[18.0][IMP] partner_email_check: Disable checks in test mode

### DIFF
--- a/partner_email_check/models/res_partner.py
+++ b/partner_email_check/models/res_partner.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import logging
+import threading
 
 from odoo import _, api, models
 from odoo.exceptions import UserError, ValidationError
@@ -80,14 +81,35 @@ class ResPartner(models.Model):
             ) from EmailUndeliverableError
         return result.normalized.lower()
 
+    def _partner_email_check_enabled(self):
+        """
+        Disabled by default while running under Odoo's test runner.
+        """
+        test_mode = (
+            getattr(threading.current_thread(), "testing", False)
+            or self.env.registry.in_test_mode()
+        )
+        if test_mode:
+            return bool(self.env.context.get("partner_email_check_force"))
+        return True
+
     def _should_check_syntax(self):
-        return self.env.company.partner_email_check_syntax
+        return (
+            self._partner_email_check_enabled()
+            and self.env.company.partner_email_check_syntax
+        )
 
     def _should_filter_duplicates(self):
-        return self.env.company.partner_email_check_filter_duplicates
+        return (
+            self._partner_email_check_enabled()
+            and self.env.company.partner_email_check_filter_duplicates
+        )
 
     def _should_check_deliverability(self):
-        return self.env.company.partner_email_check_check_deliverability
+        return (
+            self._partner_email_check_enabled()
+            and self.env.company.partner_email_check_check_deliverability
+        )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/partner_email_check/readme/CONFIGURE.md
+++ b/partner_email_check/readme/CONFIGURE.md
@@ -8,3 +8,7 @@ addresses"/`partner_email_check_filter_duplicates` setting.
 To validate that email addresses are deliverable (that the hostname
 exists), use the "Check deliverability of email
 addresses"/`partner_email_check_check_deliverability` setting.
+
+Checks are disabled by default when running under Odoo's test mode. To
+enable them anyway in a test, pass the `partner_email_check_force`
+context key (e.g. `partner.with_context(partner_email_check_force=True)`).

--- a/partner_email_check/tests/test_partner_email_check.py
+++ b/partner_email_check/tests/test_partner_email_check.py
@@ -12,7 +12,13 @@ class TestPartnerEmailCheck(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                partner_email_check_force=True,
+            )
+        )
         cls.test_partner = cls.env["res.partner"].create({"name": "test"})
         cls.env.company.partner_email_check_syntax = True
         cls.env.company.partner_email_check_filter_duplicates = False
@@ -142,3 +148,9 @@ class TestPartnerEmailCheck(TransactionCase):
         self.env.company.partner_email_check_syntax = False
         self.test_partner.email = "bad@email@domain..com"
         self.assertTrue(self.test_partner.email)
+
+    def test_disabled_by_default_in_test_mode(self):
+        """Without the force-context override, checks are off by default in test mode"""
+        partner = self.test_partner.with_context(partner_email_check_force=False)
+        partner.email = "bad@email@domain..com"
+        self.assertEqual(partner.email, "bad@email@domain..com")


### PR DESCRIPTION
Odoo test fixtures often use throwaway/fake email addresses.
Until now, any module installed alongside partner_email_check would have its own unrelated tests break the moment such a fixture got validated.