### PR TITLE
[19.0] [IMP] partner_identification(_*): standarized _check_duplicate method

### DIFF
--- a/partner_identification/models/res_partner_id_category.py
+++ b/partner_identification/models/res_partner_id_category.py
@@ -59,12 +59,22 @@ class ResPartnerIdCategory(models.Model):
 
     def _validation_eval_context(self, id_number):
         self.ensure_one()
-        return {"self": self, "id_number": id_number}
+        return {
+            "self": self,
+            "id_number": id_number,
+            "UserError": UserError,
+            "ValidationError": ValidationError,
+        }
 
     def validate_id_number(self, id_number):
         """Validate the given ID number
+
         The method raises an odoo.exceptions.ValidationError if the eval of
-        python validation code fails
+        python validation code fails.
+
+        The validation code may also raise an odoo.exceptions.UserError (or a
+        subclass such as ValidationError) itself, to explain the failure with a
+        more precise message than the generic one raised here.
         """
         self.ensure_one()
         if self.env.context.get("id_no_validate") or not self.validation_code:
@@ -72,6 +82,11 @@ class ResPartnerIdCategory(models.Model):
         eval_context = self._validation_eval_context(id_number)
         try:
             safe_eval(self.validation_code, eval_context, mode="exec")
+        except UserError:
+            # The validation code is allowed to raise its own user-facing error
+            # when it can explain the failure better than the generic message
+            # raised below.
+            raise
         except Exception as e:
             raise UserError(
                 self.env._(

--- a/partner_identification/models/res_partner_id_category.py
+++ b/partner_identification/models/res_partner_id_category.py
@@ -57,6 +57,25 @@ class ResPartnerIdCategory(models.Model):
             domain.append(("partner_id.active", "=", True))
         return self.env["res.partner.id_number"].search(domain)
 
+    @api.model
+    def _check_duplicate(self, category_id, id_number, force_active=False):
+        """Raise if the given category and number are already used elsewhere.
+
+        Meant to be called from a validation code, so that all ID types report
+        duplicates with the same message.
+        """
+        duplicate = self._search_duplicate(category_id, id_number, force_active)
+        if not duplicate:
+            return
+        raise ValidationError(
+            self.env._(
+                "%(cat_name)s %(id_name)s is already used by %(partner_names)s",
+                cat_name=self.browse(category_id).name,
+                id_name=id_number.name,
+                partner_names=", ".join(duplicate.partner_id.mapped("display_name")),
+            )
+        )
+
     def _validation_eval_context(self, id_number):
         self.ensure_one()
         return {

--- a/partner_identification/readme/CONFIGURE.md
+++ b/partner_identification/readme/CONFIGURE.md
@@ -9,9 +9,13 @@ Code, abbreviation or acronym of this ID type. For example,
 'driver_license'
 
 Python validation code:  
-Optional python code called to validate ID numbers of this ID type. This
-functionality can be overridden by setting `id_no_validate` to `True` in
-the context, such as:
+Optional python code called to validate ID numbers of this ID type. Set
+`failed` to `True` to reject the ID number with a generic error message.
+When the reason deserves a better explanation, raise a `ValidationError`
+instead.
+
+This functionality can be overridden by setting `id_no_validate` to `True`
+in the context, such as:
 
 ``` python
 partner.with_context(id_no_validate=True).write({

--- a/partner_identification/tests/test_partner_identification.py
+++ b/partner_identification/tests/test_partner_identification.py
@@ -121,6 +121,38 @@ if id_number.name != '1235':
         with self.assertRaises(ValidationError), self.cr.savepoint():
             partner.id_numbers.write({"category_id": partner_id_category2.id})
 
+    def test_validation_code_raising_its_own_error(self):
+        """Validation code can raise to explain why the ID number is refused."""
+        partner_id_category = self.env["res.partner.id_category"].create(
+            {
+                "code": "id_code",
+                "name": "id_name",
+                "validation_code": """
+if id_number.name != '1234':
+    raise ValidationError("%s is not '1234'" % id_number.name)
+""",
+            }
+        )
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Apik test",
+                "email": "apik@test.example.com",
+                "phone": "+33 601 020 304",
+                "street": "Rue de la mairie",
+                "city": "New York",
+                "zip": "97648",
+                "website": "https://test.exemple.com",
+            }
+        )
+        with self.assertRaisesRegex(ValidationError, "01234 is not '1234'"):
+            partner.write(
+                {
+                    "id_numbers": [
+                        (0, 0, {"name": "01234", "category_id": partner_id_category.id})
+                    ]
+                }
+            )
+
     def test_bad_validation_code(self):
         partner_id_category = self.env["res.partner.id_category"].create(
             {

--- a/partner_identification/tests/test_partner_identification.py
+++ b/partner_identification/tests/test_partner_identification.py
@@ -153,6 +153,26 @@ if id_number.name != '1234':
                 }
             )
 
+    def test_check_duplicate(self):
+        """_check_duplicate names the partner already using the ID number."""
+        partner_id_category = self.env["res.partner.id_category"].create(
+            {
+                "code": "id_code",
+                "name": "id_name",
+                "validation_code": """
+self._check_duplicate(id_number.category_id.id, id_number)
+""",
+            }
+        )
+        partner = self.env["res.partner"].create({"name": "Partner 1"})
+        partner2 = self.env["res.partner"].create({"name": "Partner 2"})
+        vals = {"name": "1234", "category_id": partner_id_category.id}
+        partner.write({"id_numbers": [(0, 0, vals)]})
+        with self.assertRaisesRegex(
+            ValidationError, "id_name 1234 is already used by Partner 1"
+        ):
+            partner2.write({"id_numbers": [(0, 0, vals)]})
+
     def test_bad_validation_code(self):
         partner_id_category = self.env["res.partner.id_category"].create(
             {

--- a/partner_identification_eori/models/res_partner_id_category.py
+++ b/partner_identification_eori/models/res_partner_id_category.py
@@ -22,9 +22,6 @@ class ResPartnerIdCategory(models.Model):
         cat = self.env.ref(
             "partner_identification_eori.partner_identification_eori_number_category"
         ).id
-        duplicate_eori = self._search_duplicate(cat, id_number, True)
-
-        if duplicate_eori:
-            return True
+        self._check_duplicate(cat, id_number, True)
 
         return False

--- a/partner_identification_eori/tests/test_eori.py
+++ b/partner_identification_eori/tests/test_eori.py
@@ -40,7 +40,10 @@ class TestEORI(BaseCommon):
         # Duplicate EORI
         vals = {"name": "GB941785887000", "category_id": self.partner_id_category.id}
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError,
+            "EORI Identification Number GB941785887000 is already used by TestEORI",
+        ):
             self.partner2.write({"id_numbers": [Command.create(vals)]})
 
         # Wrong EORI

--- a/partner_identification_gln/models/res_partner_id_category.py
+++ b/partner_identification_gln/models/res_partner_id_category.py
@@ -22,10 +22,7 @@ class ResPartnerIdCategory(models.Model):
         cat = self.env.ref(
             "partner_identification_gln.partner_identification_gln_number_category"
         ).id
-        duplicate_gln = self._search_duplicate(cat, id_number, True)
-
-        if duplicate_gln:
-            return True
+        self._check_duplicate(cat, id_number, True)
 
         return False
 
@@ -40,9 +37,6 @@ class ResPartnerIdCategory(models.Model):
         cat = self.env.ref(
             "partner_identification_gln.partner_identification_gcp_number_category"
         ).id
-        duplicate_gln = self._search_duplicate(cat, id_number)
-
-        if duplicate_gln:
-            return True
+        self._check_duplicate(cat, id_number)
 
         return False

--- a/partner_identification_gln/tests/test_gln.py
+++ b/partner_identification_gln/tests/test_gln.py
@@ -35,7 +35,10 @@ class TestGLN(TransactionCase):
         # Duplicate GLN
         vals = {"name": "5450534005852", "category_id": self.partner_id_category.id}
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError,
+            "GLN Identification Number 5450534005852 is already used by TestGLN",
+        ):
             self.partner2.write({"id_numbers": [Command.create(vals)]})
 
         # Bad GLN
@@ -59,7 +62,10 @@ class TestGLN(TransactionCase):
         # Duplicate GLN
         vals = {"name": "545053", "category_id": self.partner_id_gcp_category.id}
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError,
+            "GCP Identification Number 545053 is already used by TestGLN",
+        ):
             self.partner2.write({"id_numbers": [Command.create(vals)]})
 
         # Bad GLN


### PR DESCRIPTION
In case of a failed validation due to duplicates, the previous error message was too vague mentioning only a validation error, misleading the user to think there was something wrong with the ID number itself -- and never actually checking if it was used elsewhere.

Now, a proper error message is displayed so the user is fully aware of the issue and how to solve it