### PR TITLE
[19.0][IMP] partner_email_check: allow bypassing the checks per operation

### DIFF
--- a/partner_email_check/__manifest__.py
+++ b/partner_email_check/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Email Format Checker",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "summary": "Validate email address field",
     "author": "Komit, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/partner-contact",

--- a/partner_email_check/models/res_partner.py
+++ b/partner_email_check/models/res_partner.py
@@ -61,12 +61,32 @@ class ResPartner(models.Model):
         return result.normalized.lower()
 
     def _should_check_syntax(self):
+        """Whether to validate the address, and so also normalize it.
+
+        ``partner_email_check_skip_syntax`` in the context turns this off for a
+        single operation, for the same reason as
+        ``_should_check_deliverability``. It skips normalization too, exactly as
+        disabling the company setting does.
+        """
+        if self.env.context.get("partner_email_check_skip_syntax"):
+            return False
         return self.env.company.partner_email_check_syntax
 
     def _should_filter_duplicates(self):
         return self.env.company.partner_email_check_filter_duplicates
 
     def _should_check_deliverability(self):
+        """Whether to require that the address' domain accepts mail.
+
+        ``partner_email_check_skip_deliverability`` in the context turns this
+        off for a single operation. Code that stores addresses it did not
+        collect from a user needs that: the incoming mail gateway creates a
+        partner for the sender of every message, and bulk senders routinely send
+        from a subdomain that publishes no MX record, so a hard check there
+        discards the message rather than improving anyone's data.
+        """
+        if self.env.context.get("partner_email_check_skip_deliverability"):
+            return False
         return self.env.company.partner_email_check_check_deliverability
 
     @api.model_create_multi

--- a/partner_email_check/readme/USAGE.md
+++ b/partner_email_check/readme/USAGE.md
@@ -1,1 +1,24 @@
 This module integrate automatically in all of the view `res.partner`
+
+## Bypassing the checks for a single operation
+
+The checks run on every `res.partner` create and write. That is what you want
+for an address a user typed, but not for one your code did not collect from a
+user: the incoming mail gateway creates a partner for the sender of every
+message it accepts, and bulk senders routinely send from a subdomain that
+publishes no MX record, so a deliverability failure there discards the message
+rather than improving anyone's data.
+
+Two context keys turn a check off for one operation:
+
+```python
+# Store the address even though its domain accepts no mail.
+partner.with_context(partner_email_check_skip_deliverability=True).write(vals)
+
+# Store it without validating or normalizing it at all.
+partner.with_context(partner_email_check_skip_syntax=True).write(vals)
+```
+
+`partner_email_check_skip_deliverability` keeps validation and normalization and
+skips only the DNS lookup. `partner_email_check_skip_syntax` skips both, exactly
+as disabling the company setting does.

--- a/partner_email_check/tests/test_partner_email_check.py
+++ b/partner_email_check/tests/test_partner_email_check.py
@@ -121,3 +121,39 @@ class TestPartnerEmailCheck(TransactionCase):
         self.env.company.partner_email_check_syntax = False
         self.test_partner.email = "bad@email@domain..com"
         self.assertTrue(self.test_partner.email)
+
+    def test_nondeliverable_addresses_allowed_by_context(self):
+        """The check is bypassable for one operation, and only that one.
+
+        Mixed case in, lowercase out: skipping deliverability must not also skip
+        validation, so callers keep the normalization they came for.
+        """
+        self.check_deliverability()
+        partner = self.test_partner.with_context(
+            partner_email_check_skip_deliverability=True
+        )
+        partner.email = "Cezrik@ACOA.nrdkt"
+        self.assertEqual(partner.email, "cezrik@acoa.nrdkt")
+
+    def test_syntax_still_checked_when_deliverability_skipped(self):
+        """Bypassing one check must not quietly bypass the other."""
+        self.check_deliverability()
+        with self.assertRaises(ValidationError):
+            self.test_partner.with_context(
+                partner_email_check_skip_deliverability=True
+            ).email = "bad@email@domain..com"
+
+    def test_deliverability_still_checked_outside_the_context(self):
+        """The bypass does not persist onto the record's own environment."""
+        self.check_deliverability()
+        self.test_partner.with_context(
+            partner_email_check_skip_deliverability=True
+        ).email = "cezrik@acoa.nrdkt"
+        with self.assertRaises(ValidationError):
+            self.test_partner.email = "othercezrik@acoa.nrdkt"
+
+    def test_invalid_email_addresses_allowed_by_context(self):
+        self.assertTrue(self.env.company.partner_email_check_syntax)
+        partner = self.test_partner.with_context(partner_email_check_skip_syntax=True)
+        partner.email = "bad@email@domain..com"
+        self.assertEqual(partner.email, "bad@email@domain..com")


### PR DESCRIPTION
## What

Two context keys that turn a check off for a single operation:

- `partner_email_check_skip_deliverability` — skips the DNS lookup, and keeps validation and normalization.
- `partner_email_check_skip_syntax` — skips both, exactly as disabling the company setting does.

The company settings are untouched and nothing changes for callers that do not opt out.

## Why

The checks run on every `res.partner` create and write. That is right for an address a user typed, and wrong for one the code did not collect from a user.

Odoo's incoming mail gateway creates a partner for the sender of every message it accepts, and bulk senders — HubSpot, Mailchimp, SendGrid — routinely send from a subdomain that publishes no MX record. With **Check email deliverability** enabled, storing that sender raises `ValidationError`. `mail.thread.message_route` reads any exception out of `message_new` as a misconfigured alias, so one such message produces:

- a discarded message,
- an alias flagged **Invalid**, which refuses every later message to it as well,
- and a bounce aimed at an address that by definition cannot receive it, retried until the relay gives up.

We hit that in production: a HubSpot campaign sent from `39698511m.em.knapheide.com` took a working inbound alias out of service until someone noticed and cleared the flag. Nobody's data was improved by refusing the address.

The only workaround available today is disabling the company setting, which gives up the check for exactly the addresses it was written for — the ones staff type in. A caller that knows it is storing a sender rather than user input can say so instead.

## Usage

```python
# Store the address even though its domain accepts no mail.
partner.with_context(partner_email_check_skip_deliverability=True).write(vals)

# Store it without validating or normalizing it at all.
partner.with_context(partner_email_check_skip_syntax=True).write(vals)
```

## Tests

Four added, covering that the deliverability bypass still normalizes (mixed case in, lowercase out), that it does not quietly take the syntax check with it, that it does not persist onto the record's own environment, and that the syntax key works while the company setting is on.

Documented in `readme/USAGE.md`.