### PR TITLE
[19.0][FIX] properly display phone2 in partner views

### DIFF
--- a/partner_phone_secondary/README.rst
+++ b/partner_phone_secondary/README.rst
@@ -60,7 +60,8 @@ Authors
 Contributors
 ------------
 
-- Iván Todorovich <ivan.todorovich@gmail.com>
+-  Iván Todorovich <ivan.todorovich@gmail.com>
+-  Nils Coenen <nils.coenen@nico-solutions.de>
 
 Maintainers
 -----------

--- a/partner_phone_secondary/readme/CONTRIBUTORS.md
+++ b/partner_phone_secondary/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Iván Todorovich \<<ivan.todorovich@gmail.com>\>
+- Nils Coenen \<<nils.coenen@nico-solutions.de>\>

--- a/partner_phone_secondary/static/description/index.html
+++ b/partner_phone_secondary/static/description/index.html
@@ -408,6 +408,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-4">Contributors</a></h3>
 <ul class="simple">
 <li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;gmail.com">ivan.todorovich&#64;gmail.com</a>&gt;</li>
+<li>Nils Coenen &lt;<a class="reference external" href="mailto:nils.coenen&#64;nico-solutions.de">nils.coenen&#64;nico-solutions.de</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/partner_phone_secondary/views/res_partner.xml
+++ b/partner_phone_secondary/views/res_partner.xml
@@ -8,8 +8,9 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
         <field name="name">res.partner.simplified.form</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_simple_form" />
+        <field name="priority" eval="20" />
         <field name="arch" type="xml">
-            <field name="function" position="after">
+            <field name="phone" position="after">
                 <field name="phone2" widget="phone" />
             </field>
         </field>
@@ -18,17 +19,65 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
         <field name="name">res.partner.form</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
-        <field name="priority" eval="1" />
+        <field name="priority" eval="20" />
         <field name="arch" type="xml">
-            <field name="phone" position="after">
-                <field name="phone2" widget="phone" />
-            </field>
+            <xpath expr="/form/sheet//field[@name='phone']/.." position="after">
+                <div class="d-flex align-items-baseline w-md-50">
+                    <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone2" />
+                    <field
+                        name="phone2"
+                        class="w-100"
+                        widget="phone"
+                        placeholder="Phone2"
+                    />
+                </div>
+            </xpath>
             <xpath
-                expr="//field[@name='child_ids']/form//field[@name='phone']"
+                expr="//field[@name='child_ids']/kanban/templates//div[@t-if='record.phone.raw_value']"
                 position="after"
             >
-                <field name="phone2" widget="phone" />
+                <div t-if="record.phone2.raw_value">
+                    <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone2" />
+                    <field name="phone2" />
+                </div>
             </xpath>
+            <xpath
+                expr="//field[@name='child_ids']/form/sheet//field[@name='phone']/.."
+                position="after"
+            >
+                <div class="d-flex align-items-baseline" name="phone2">
+                    <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone2" />
+                    <field
+                        name="phone2"
+                        widget="phone"
+                        class="w-100"
+                        placeholder="Phone2"
+                    />
+                </div>
+            </xpath>
+        </field>
+    </record>
+    <record id="res_partner_kanban_view" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.res_partner_kanban_view" />
+        <field name="priority" eval="20" />
+        <field name="arch" type="xml">
+            <div t-if="record.phone.raw_value" position="after">
+                <div t-if="record.phone2.raw_value">
+                    <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone2" />
+                    <field name="phone2" />
+                </div>
+            </div>
+        </field>
+    </record>
+    <record id="view_partner_tree" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree" />
+        <field name="priority" eval="20" />
+        <field name="arch" type="xml">
+            <field name="phone" position="after">
+                <field name="phone2" optional="hide" class="o_force_ltr" />
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Before:
<img width="3348" height="1140" alt="before_list" src="https://github.com/user-attachments/assets/0007c0a5-b416-49ce-a5e7-5451e188f672" />
<img width="3254" height="880" alt="before_kanban" src="https://github.com/user-attachments/assets/5f96f4fc-feb6-4f3b-8510-3b58c8b4886e" />
<img width="2234" height="1570" alt="before_form" src="https://github.com/user-attachments/assets/d476515e-3be0-44c9-8384-e0e0adb7d22c" />
<img width="2042" height="960" alt="before_simple_form" src="https://github.com/user-attachments/assets/cc8385aa-99b2-41c5-b8a4-da5663651763" />

After:
<img width="3320" height="1272" alt="after_list" src="https://github.com/user-attachments/assets/0f772962-830c-4ac5-b3e9-cb1b778d086b" />
<img width="3336" height="1230" alt="after_kanban" src="https://github.com/user-attachments/assets/75358d39-b025-4acb-8a5e-3e0530e27a4d" />
<img width="2222" height="1696" alt="after_form" src="https://github.com/user-attachments/assets/ad390a15-1b0e-45ee-9f9c-3be8b04de8fd" />
<img width="2026" height="1004" alt="after_simple_form" src="https://github.com/user-attachments/assets/0a88b686-394b-45f6-8c67-885349a1b6a3" />

Here, the mobile number extension is activated as well, so please don’t get irritated by it.