### PR TITLE
[18.0][FIX] partner_firstname: honor is_company in create values

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -59,7 +59,9 @@ class ResPartner(models.Model):
         created_partners = self.browse()
         for vals in vals_list:
             partner_context = dict(self.env.context)
-            is_company = vals.get("company_type") == "company"
+            is_company = vals.get("company_type") == "company" or vals.get(
+                "is_company", False
+            )
             if not is_company and self.name_fields_in_vals(vals) and "name" in vals:
                 del vals["name"]
                 partner_context.pop("default_name", None)

--- a/partner_firstname/tests/test_create.py
+++ b/partner_firstname/tests/test_create.py
@@ -77,3 +77,26 @@ class UserCase(PersonCase, MailInstalled):
         else:
             # Run tests
             super().tearDown()
+
+
+class CompanyFromValsCase(TransactionCase):
+    """Company detection from the ``is_company`` key in the create values.
+
+    ``create()`` used to look only at ``company_type``, so a partner created
+    with ``is_company=True`` (and no ``company_type``) had its name split
+    into firstname/lastname as if it were a person.
+    """
+
+    def test_is_company_in_vals_keeps_name_unsplit(self):
+        partner = self.env["res.partner"].create(
+            {"name": "dummy company", "is_company": True}
+        )
+        self.assertEqual(partner.lastname, "dummy company")
+        self.assertFalse(partner.firstname)
+
+    def test_company_type_in_vals_still_works(self):
+        partner = self.env["res.partner"].create(
+            {"name": "other company", "company_type": "company"}
+        )
+        self.assertEqual(partner.lastname, "other company")
+        self.assertFalse(partner.firstname)


### PR DESCRIPTION
`create()` decides whether the partner being created is a company only from `vals.get("company_type")`. A create call that passes `is_company=True` together with a `name` — a perfectly valid combination, and what modules that don't know about `company_type` naturally send — has the name split into `firstname`/`lastname` as if the partner were a person:

```python
partner = env["res.partner"].create({"name": "dummy company", "is_company": True})
partner.firstname  # "dummy"
partner.lastname   # "company"
```

This was found while migrating the cooperator module family to 18.0: `get_partner_company_vals()` passes `is_company` and company partners came out with split names.

The fix makes `create()` also honor `is_company` in the values. Two regression tests included (one for `is_company` in vals, one confirming the existing `company_type` path still works).

Module test suite after the change: 51 tests, 0 failures.
