### PR TITLE
[FIX] partner_firstname: skip the name check on module data

### DIFF
--- a/partner_firstname/models/firstname_mixin.py
+++ b/partner_firstname/models/firstname_mixin.py
@@ -159,7 +159,16 @@ class FirstNameMixin(models.AbstractModel):
     @api.constrains("name", "firstname", "lastname")
     def _check_firstname_lastname(self):
         """Ensure that name, firstname and lastname are correctly set
-        depending on the configuration and on the type of the record."""
+        depending on the configuration and on the type of the record.
+
+        Records loaded from the data files of a module are exempt: the module
+        declaring them cannot know about this one, so one that creates a partner
+        passing only ``name`` would abort the whole registry load. See the note
+        about ``mail`` in ``res_partner._inverse_name`` for an earlier instance
+        of the same clash.
+        """
+        if self.env.context.get("install_mode"):
+            return
         for record in self:
             if any(
                 [


### PR DESCRIPTION
[FIX] partner_firstname: skip the name check on module data

A module that creates a `res.partner` passing only `name` aborts the whole
registry load when this module is installed and both name parts are configured
as required.

Odoo Enterprise's `ai` module does exactly that: `ai.agent.create()` builds the
agent's partner with the agent name alone (the repository is private, so the
relevant lines are quoted here):

    # ai/models/ai_agent.py, ai.agent.create()
    partner = self.env['res.partner'].create({
        'name': vals.get('name'),
        'active': False,
    })

With

    ir.config_parameter: partner_firstname.required_fields = firstname_lastname

`_compute_firstname_lastname_required` marks both fields required regardless of
their content, so any partner reaching the constraint without them raises:

    odoo.tools.convert.ParseError: while parsing .../ai/data/ai_agent_data.xml:3
    Error(s) with partner <id>'s name.
    ...
      File "odoo/tools/convert.py", line 619, in _tag_root
    odoo.tools.convert.ParseError
    ERROR odoo.registry: Failed to load registry
    CRITICAL odoo.service.server: Failed to initialize database

Reproduced with `-i partner_firstname,ai` after setting that parameter. The
failure is not limited to `ai`: any module whose data creates a partner with a
single name string hits it.

This is not the first time the constraint clashes with a module install. The
module already documents one in `res_partner._inverse_name`:

    ``EmptyNamesError`` and previously made the ``mail`` module fail to install
    unless it was installed before ``partner_firstname``.

That one was worked around by writing the parts with `update()`. This commit
addresses the general case instead: records loaded from the data files of a
module are exempt from the policy, since the module declaring them cannot know
about this one.

`install_mode` is set by the core itself, in the very frame that raises here
(`odoo/tools/convert.py`, `xml_import._tag_record`), and the core already uses it
to relax behaviour on data load in `res_company.create`,
`res_partner_bank.write`, `discuss_channel.write` and
`account.chart_template._pre_reload_data`.

Records created by a user are unaffected: the existing tests, none of which run
under `install_mode`, keep asserting `EmptyNamesError`.
