### PR TITLE
[FIX] partner_multi_relation: make this_partner_id/other_partner_id searchable

### DIFF
--- a/partner_multi_relation/models/res_partner_relation.py
+++ b/partner_multi_relation/models/res_partner_relation.py
@@ -70,11 +70,13 @@ class ResPartnerRelation(models.Model):
     this_partner_id = fields.Many2one(
         comodel_name="res.partner",
         compute="_compute_this_partner_id",
+        search="_search_this_partner_id",
         help="Partner shown left when no currently active partner",
     )
     other_partner_id = fields.Many2one(
         comodel_name="res.partner",
         compute="_compute_other_partner_id",
+        search="_search_other_partner_id",
         help="Partner shown right when no currently active partner"
         ", or connected partnes as seen from current partner.",
     )
@@ -276,7 +278,8 @@ class ResPartnerRelation(models.Model):
                 continue
             this.type_id_display = this.type_id.name
 
-    @api.depends_context("current_partner_id")
+    @api.depends("left_partner_id", "right_partner_id")
+    @api.depends_context("current_partner_id", "active_model", "active_id")
     def _compute_this_partner_id(self):
         """Show inverse type when coming from right partner."""
         current_partner = self._get_current_partner()
@@ -287,7 +290,8 @@ class ResPartnerRelation(models.Model):
                 else this.left_partner_id
             )
 
-    @api.depends_context("current_partner_id")
+    @api.depends("left_partner_id", "right_partner_id")
+    @api.depends_context("current_partner_id", "active_model", "active_id")
     def _compute_other_partner_id(self):
         """Show inverse type when coming from right partner."""
         current_partner = self._get_current_partner()
@@ -318,6 +322,46 @@ class ResPartnerRelation(models.Model):
         return [
             "|",
             ("left_partner_id", operator, value),
+            ("right_partner_id", operator, value),
+        ]
+
+    @api.model
+    def _search_this_partner_id(self, operator, value):
+        """Mirror _compute_this_partner_id for searches.
+
+        this_partner_id is right_partner_id when that side is the current
+        partner, left_partner_id otherwise.
+        """
+        current_partner = self._get_current_partner()
+        if not current_partner:
+            return [("left_partner_id", operator, value)]
+        return [
+            "|",
+            "&",
+            ("right_partner_id", "=", current_partner.id),
+            ("right_partner_id", operator, value),
+            "&",
+            ("right_partner_id", "!=", current_partner.id),
+            ("left_partner_id", operator, value),
+        ]
+
+    @api.model
+    def _search_other_partner_id(self, operator, value):
+        """Mirror _compute_other_partner_id for searches.
+
+        other_partner_id is left_partner_id when the right side is the
+        current partner, right_partner_id otherwise.
+        """
+        current_partner = self._get_current_partner()
+        if not current_partner:
+            return [("right_partner_id", operator, value)]
+        return [
+            "|",
+            "&",
+            ("right_partner_id", "=", current_partner.id),
+            ("left_partner_id", operator, value),
+            "&",
+            ("right_partner_id", "!=", current_partner.id),
             ("right_partner_id", operator, value),
         ]
 

--- a/partner_multi_relation/tests/test_partner_search.py
+++ b/partner_multi_relation/tests/test_partner_search.py
@@ -151,3 +151,53 @@ class TestPartnerSearch(TestPartnerRelationCommon):
             ]
         )
         self.assertTrue(self.partner_03_ngo in partners)
+
+    def test_search_this_other_partner_matches_compute(self):
+        """this/other_partner_id searches must return exactly the records
+        whose computed value matches, in every current_partner_id context."""
+        company = self.partner_02_company
+        person = self.partner_01_person
+        relation = self.company2person_relation
+
+        for context, label in (
+            ({}, "no context"),
+            ({"current_partner_id": company.id}, "current=left"),
+            ({"current_partner_id": person.id}, "current=right"),
+            ({"active_model": "res.partner", "active_id": person.id}, "active_id"),
+        ):
+            relations = self.Relation.with_context(**context)
+            for field in ("this_partner_id", "other_partner_id"):
+                for partner in (company, person):
+                    found = relations.search(
+                        [(field, "=", partner.id), ("id", "=", relation.id)]
+                    )
+                    computed = relations.browse(relation.id)[field]
+                    if computed == partner:
+                        self.assertEqual(
+                            found,
+                            relation,
+                            f"{label}: {field} computes to {partner.name}"
+                            " but searching for it misses the relation",
+                        )
+                    else:
+                        self.assertFalse(
+                            found,
+                            f"{label}: {field} computes to {computed.name}"
+                            f" but searching {partner.name} still matches",
+                        )
+
+    def test_search_this_other_partner_by_name(self):
+        """Non-equality operators go through the same side-aware domain."""
+        relation = self.company2person_relation
+        relations = self.Relation.with_context(
+            current_partner_id=self.partner_01_person.id
+        )
+        # current is the right side: this=right (person), other=left (company)
+        found = relations.search(
+            [("this_partner_id", "ilike", "User"), ("id", "=", relation.id)]
+        )
+        self.assertEqual(found, relation)
+        found = relations.search(
+            [("other_partner_id", "ilike", "User"), ("id", "=", relation.id)]
+        )
+        self.assertFalse(found)


### PR DESCRIPTION
## Problem

Odoo 19 warns when a computed field's `@depends` chain crosses a non-stored
field that has no search method, because it cannot determine which records to
recompute when the dependency changes (`odoo/orm/fields.py`, `resolve_depends`):

```
Field <field> in dependency of <field> should be searchable. This is necessary
to determine which records to recompute when <field> is modified. You should
either make the field searchable, or simplify the field dependency.
```

`this_partner_id` and `other_partner_id` are computed, non-stored and declare
no `search=`. Any module defining a field `related="this_partner_id.<x>"` (or
on `other_partner_id`) raises that warning on every registry setup — and, more
importantly, the related field is left without a reliable recompute trigger
when the underlying partner value changes.

## Why not simplify the dependency

Both fields resolve to whichever of `left_partner_id` / `right_partner_id`
matches the `current_partner_id` context
(`_compute_this_partner_id` / `_compute_other_partner_id`), so there is no
context-free column to search recompute candidates against. They genuinely need
a search method.

## Fix

Each field gets its own search method mirroring its compute, side by side:

```python
def _search_this_partner_id(self, operator, value):
    current_partner = self._get_current_partner()
    if not current_partner:
        return [("left_partner_id", operator, value)]
    return [
        "|",
        "&", ("right_partner_id", "=", current_partner.id),
             ("right_partner_id", operator, value),
        "&", ("right_partner_id", "!=", current_partner.id),
             ("left_partner_id", operator, value),
    ]
```

and the inverse pairing for `_search_other_partner_id`. Without a current
partner the domain collapses to the single side the compute falls back to.

The first version of this PR reused `_search_any_partner_id` for both fields.
[Review](https://github.com/OCA/partner-contact/pull/2425#discussion_r3867165937)
correctly pointed out that it does not match the computes: it matches a partner
on **either** side, while each compute resolves to exactly **one** side.
Searching `this_partner_id = X` returned relations whose computed
`this_partner_id` is a different partner, and with `current_partner_id` in
context every result could be a false positive.

## A cache bug the tests exposed

`_get_current_partner()` falls back to `active_model` / `active_id`, but the
computes only declared `@api.depends_context("current_partner_id")`: a value
computed without context was reused verbatim in an `active_id` context, so the
compute disagreed with itself depending on which context filled the cache
first. The computes now declare the two extra context keys, plus the
`@api.depends("left_partner_id", "right_partner_id")` that was missing for
writes to invalidate the cached aliases.

## Tests

`test_search_this_other_partner_matches_compute` asserts search and compute
agree record by record for both fields across the four context shapes: no
context, current partner on the left, current partner on the right, and
`active_model`/`active_id`. `test_search_this_other_partner_by_name` covers a
non-equality operator (`ilike`) through the same side-aware domain.

Full module suite on a clean 19.0 database: 0 failures.

## Reproducing the original warning

Declare on any model a field `related="this_partner_id.<something>"` over
`res.partner.relation` and start the server: the warning is emitted once per
registry setup.
