### PR TITLE
[19.0][FIX] res_partner: skip company default when install_mode is active

### DIFF
--- a/partner_company_default/models/res_partner.py
+++ b/partner_company_default/models/res_partner.py
@@ -16,6 +16,7 @@ class ResPartner(models.Model):
         context = self.env.context
         if (
             context.get("creating_from_company")
+            or context.get("install_mode")
             or config["test_enable"]
             and not context.get("test_partner_company_default")
         ):


### PR DESCRIPTION
Cherry-pick of #2353, merged in 18.0 and never brought to 19.0: the migration (#2158) landed before that fix. Same commit, same author (@jqbeltran2).

The 19.0 branch still hits it: `-i partner_company_default,l10n_ca --with-demo` on a plain install logs

```
ERROR odoo.addons.account.models.chart_template: Error while loading accounting demo data
...
odoo.exceptions.ValidationError: The bank account of a bank journal must belong to the same company (CA Company).
```

and leaves the partner of `CA Company` owned by the main company. With this commit the demo data loads clean and that partner has no company.

`account` catches the exception, so the installation does not fail and only the log shows it. It never shows up in a CI either, since `test_enable` already makes this default step aside; only a plain install with demo data hits it.