### PR TITLE
[FIX] partner_multi_relation: clear the menu left naming the action 19.0 removed

### DIFF
--- a/partner_multi_relation/__manifest__.py
+++ b/partner_multi_relation/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Partner Relations",
-    "version": "19.0.1.1.1",
+    "version": "19.0.1.1.2",
     "author": "Therp BV,Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/partner-contact",
     "complexity": "normal",

--- a/partner_multi_relation/migrations/19.0.1.1.2/post-migration.py
+++ b/partner_multi_relation/migrations/19.0.1.1.2/post-migration.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Vauxoo <https://www.vauxoo.com>.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+import logging
+
+from openupgradelib import openupgrade
+
+logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Clear this module's menus that still name an action 19.0 removed.
+
+    ``menu_res_partner_relation`` has been a plain container since 18.0, but
+    databases coming from older versions still carry the action it used to have,
+    ``action_res_partner_relation_all``. A ``<menuitem>`` without an ``action``
+    attribute emits no such field, and ``_load_records`` only writes the fields it
+    is given, so that value is never rewritten: it sits there, valid but claimed by
+    no data file, until something deletes what it points at.
+
+    19.0 is what deletes it. The action targets ``res.partner.relation.all``, the
+    SQL view ``migrations/19.0.1.0.0/pre-migration.py`` drops, so the record goes
+    with the model. And ``ir_ui_menu.action`` is a reference column holding
+    ``'<model>,<id>'`` as plain text, with no foreign key to cascade, so the menu
+    keeps naming a record that no longer exists.
+
+    The cost is out of proportion to the cause: ``/web/webclient/load_menus`` raises
+    ``Record does not exist or has been deleted`` and answers 404, the webclient
+    gets HTML where it expects JSON, and the backend renders blank for every user.
+
+    Cleared rather than repointed, because guessing which action the menu meant is
+    wrong exactly when it matters -- one that silently opens the wrong action is
+    worse than one that opens nothing. The XML agrees: this menu is a container and
+    its two children carry the actions.
+
+    This runs post- and not pre-migration on purpose. The records are removed while
+    this module's own data reloads, so a pre-migration would still find the action
+    alive and nothing to clean.
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_ui_menu AS menu
+           SET action = NULL
+          FROM ir_model_data AS data
+         WHERE data.model = 'ir.ui.menu'
+           AND data.res_id = menu.id
+           AND data.module = 'partner_multi_relation'
+           AND menu.action LIKE 'ir.actions.act_window,%%'
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM ir_act_window AS action
+                WHERE action.id = split_part(menu.action, ',', 2)::integer
+           )
+        """,
+    )

--- a/partner_multi_relation/tests/__init__.py
+++ b/partner_multi_relation/tests/__init__.py
@@ -2,5 +2,6 @@
 from . import test_partner_relation_common
 from . import test_partner_relation
 from . import test_partner_relation_action
+from . import test_menu_action
 from . import test_partner_relation_type
 from . import test_partner_search

--- a/partner_multi_relation/tests/test_menu_action.py
+++ b/partner_multi_relation/tests/test_menu_action.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Vauxoo <https://www.vauxoo.com>.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import TransactionCase
+
+
+class TestMenuAction(TransactionCase):
+    def test_menu_actions_resolve(self):
+        """Every menu this module owns must name an action that exists.
+
+        ``ir_ui_menu.action`` is a reference column holding ``'<model>,<id>'`` as
+        plain text, so nothing in the database stops a menu from outliving the action
+        it names. One that does is enough to make ``load_menus`` answer 404 and leave
+        the whole backend blank, so a stale reference has to fail here, not in a
+        browser.
+        """
+        self.env.cr.execute(
+            """
+            SELECT data.module || '.' || data.name, menu.action
+              FROM ir_ui_menu AS menu
+              JOIN ir_model_data AS data
+                ON data.model = 'ir.ui.menu' AND data.res_id = menu.id
+             WHERE data.module = 'partner_multi_relation'
+               AND menu.action IS NOT NULL
+               AND menu.action <> ''
+            """
+        )
+        dangling = []
+        for xmlid, reference in self.env.cr.fetchall():
+            model, _, res_id = reference.partition(",")
+            if not self.env[model].browse(int(res_id)).exists():
+                dangling.append(f"{xmlid} -> {reference}")
+        self.assertFalse(
+            dangling,
+            f"Menu(s) naming an action that does not exist: {', '.join(dangling)}",
+        )


### PR DESCRIPTION
Upgrading a database that predates 18.0 leaves the backend blank for every user. No apps, no menus, and in the browser a SyntaxError about HTML where JSON was expected, because /web/webclient/load_menus answers 404:

    Record does not exist or has been deleted. (Record: ir.actions.act_window(803,))

The menu is menu_res_partner_relation and the action is action_res_partner_relation_all.

Three things have to line up for this, and each one is reasonable on its own.

The menu has been a plain container since 18.0. It is declared with a name and a parent, no action, and the two menus that do carry actions hang underneath it:

https://github.com/OCA/partner-contact/blob/7e3e10eca258adf40a1f245b539401d77d644798/partner_multi_relation/views/menu.xml#L3-L14

But a <menuitem> without an action attribute emits no such field, and _load_records only writes the fields it is given, so the value an older version stored is never rewritten:

https://github.com/odoo/odoo/blob/27391b2f112039e52198ddf590548e7baa5968dc/odoo/tools/convert.py#L339-L353

It sits in the column, valid, claimed by no data file.

19.0 is what makes it dangle. In 18.0 the action lived in views/res_partner_relation_all.xml and targeted res.partner.relation.all:

https://github.com/OCA/partner-contact/blob/7e3e10eca258adf40a1f245b539401d77d644798/partner_multi_relation/views/res_partner_relation_all.xml#L71-L78

That whole file is gone in 19.0, and the model with it: migrations/19.0.1.0.0/pre-migration.py drops the SQL view the action was there to show.

https://github.com/OCA/partner-contact/blob/bce3eb448e580ad58eeb43c714d0dfa87710cb08/partner_multi_relation/migrations/19.0.1.0.0/pre-migration.py#L13

The replacement is a different record over a different model, action_res_partner_relation on res.partner.relation, so the old one is deleted rather than renamed:

https://github.com/OCA/partner-contact/blob/bce3eb448e580ad58eeb43c714d0dfa87710cb08/partner_multi_relation/views/ir_actions_act_window.xml#L8-L11

That deletion is correct and this patch does not touch it. The action cannot be kept or renamed; its model is gone.

And nothing connects the two. ir_ui_menu.action is a reference column holding '<model>,<id>' as plain text, with no foreign key, so no cascade fires and no constraint complains. The menu keeps naming a record that no longer exists, and one such menu is enough to take the whole backend down.

Measured on a production database upgraded from 18.0: the action exists before the upgrade and after the Odoo Upgrade Service, with no dangling menu on either side; it is gone after the module updates, with menu_res_partner_relation left pointing at it while its two siblings resolve.

The action is cleared, not repointed. Guessing which action the menu meant, by matching it against whichever one the module declares now, is wrong exactly when it matters: a menu that silently opens the wrong action is worse than one that opens nothing. The XML already says what this menu is -- a container.

The sweep is scoped to this module's own menus. A missing reference here is a class of damage rather than one bad row, and any renamed action can produce another, so it looks for what does not resolve instead of the known id; but cleaning menus another module owns would be reaching outside what this migration can reason about.

It runs post-migration and not pre-migration. The records are deleted while this module's data reloads, so a pre-migration would find the action still alive and nothing to clean.

The test walks every menu this module owns and resolves its action, since one stale reference is all it takes.